### PR TITLE
Remove duplicate window exports

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1324,7 +1324,8 @@
     window.Select2 = {
         query: {
             ajax: ajax,
-            local: local
+            local: local,
+            tags: tags
         }, util: {
             debounce: debounce
         }, "class": {


### PR DESCRIPTION
I noticed the `window` exports are now duplicated.  Looks like they got left over when a cleaner (bottom of file) implementation was added.
