### PR TITLE
Define `undefined`

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -16,7 +16,7 @@
  specific language governing permissions and limitations
  under the License.
  */
-(function ($) {
+(function ($, undefined) {
     "use strict";
     /*global document, window, jQuery, console */
 


### PR DESCRIPTION
It's a good idea to define `undefined` in the wrapper for a few reasons. Note that `undefined` becomes defined by not being passed in to the function.
1. Minifies better, since `undefined` becomes a single letter in the resulting minified code.
2. Spares JS from searching the global namespace to find it, possibly adding a tiny bit of efficiency.
3. Ensures it's the correct value, just in case another script has assigned a value to `undefined`.

P.S. Thanks for making Select2! I was in need of exactly this (an autocomplete/multi-select like Chosen, with the ability to handle alternative data sources, progressive loading, caching, templating, and that works well with Bootstrap).
