### PR TITLE
Added support for [placeholder] attribute

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -756,9 +756,7 @@
         },
 
         getPlaceholder: function () {
-            var placeholder = this.opts.element.data("placeholder");
-            if (placeholder !== undefined) return placeholder;
-            return this.opts.placeholder;
+            return this.opts.element.attr("placeholder") || this.opts.element.data("placeholder") || this.opts.placeholder;
         },
 
         /**


### PR DESCRIPTION
Not that this fixes anything or that you have to pull. 

I just wanted to use placeholder attributes (for instance, on <input type="hidden"> it makes sense) for convenience sake.

I stripped out all my other commits since most of them were either reverted or mirrored in your version.

Merely a suggestion.
