### PR TITLE
Adding tab support for tags

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1122,6 +1122,7 @@
                         killEvent(e);
                         return;
                     case KEY.ENTER:
+                    case KEY.TAB:
                         this.selectHighlighted();
                         killEvent(e);
                         return;


### PR DESCRIPTION
When you select a tag currently the only way to insert it, is by using the enter key. This change allows the tab key to also insert it.
