### PR TITLE
Check for nonexistent data attribute in a way that works in jQuery 1.4.2

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -352,7 +352,8 @@
             this.id=opts.id;
 
             // destroy if called on an existing component
-            if (opts.element.data("select2") !== undefined) {
+            if (opts.element.data("select2") !== undefined &&
+                opts.element.data("select2") !== null) {
                 this.destroy();
             }
 


### PR DESCRIPTION
In an app running jQuery 1.4.2, initializing select2 for a select element was failing because of the check for a "select2" data attribute in init()

At least for that version of jQuery, calling .data() with a nonexistent key argument appears to return null.  For newer versions of jQuery, it returns undefined.

A simple fix that worked for me was to add a check for opts.element.data("select2") !== null
