### PR TITLE
Support not showing search input

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -144,6 +144,12 @@ Version: @@ver@@ Timestamp: @@timestamp@@
   padding-right: 4px;
 }
 
+.select2-container .select2-hide-search {
+  display: block;
+  position: absolute;
+  left: -10000px;
+}
+
 .select2-container .select2-search input {
     background: #fff url('select2.png') no-repeat 100% -22px;
     background: url('select2.png') no-repeat 100% -22px, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, white), color-stop(0.99, #eeeeee));

--- a/select2.js
+++ b/select2.js
@@ -730,6 +730,25 @@
                 var parts = [], // html parts
                     def; // default choice
 
+				// If we aren't showing the search input, do not filter items
+				// but do highlight an item matching current search
+				if(initial !== true && !this.showSearchInput){
+					if(data.results.length > 0){
+						var key = data.results[0].id,
+							self = this;
+						this.results.find("li").each(function(i, li){
+							if($(li).data("select2-data").id == key){
+								self.highlight(i);
+								return false;
+							}
+						});
+					} else {
+						// if the search doesn't match, reset so user can search again
+						search.val("");
+					}
+					return;
+				}
+
                 // create a default choice and prepend it to the list
                 if (this.opts.createSearchChoice && search.val() !== "") {
                     def = this.opts.createSearchChoice.call(null, search.val(), data.results);
@@ -1017,8 +1036,8 @@
             // hide the search box if this is the first we got the results and there are a few of them
 
             if (initial === true) {
-                showSearchInput = data.results.length >= this.opts.minimumResultsForSearch;
-                this.search.parent().toggle(showSearchInput);
+                showSearchInput = this.showSearchInput = data.results.length >= this.opts.minimumResultsForSearch;
+                this.search.parent()[showSearchInput ? "removeClass" : "addClass"]("select2-hide-search");
 
                 //add "select2-with-searchbox" to the container if search box is shown
                 this.container[showSearchInput ? "addClass" : "removeClass"]("select2-with-searchbox");


### PR DESCRIPTION
Thanks for this great plugin which we hope to use for all our custom selects. Sometimes we have very small selects with only a few options, and we really don't need the search input field. We just want to duplicate the browser select in a skinnable way.

This commit adds a `showSearch` option, which defaults to true but can be set to false, which allows for a single-select to display without a text entry field. When this option is set to false:
- the search field is displayed off-screen but on the dom
- when the select is open, typing does not filter the results list, but does highlight the first item to match the search
- when the search fails to match, reset it to empty so user can begin search again, as in browser selects

A few questions:
- is this option in line with your vision for the library?
- is there an easier way to find the dom element for a result item if we have the item's id? I'm doing a lot of data lookups, which are slower than necessary. If there isn't a better way currently, perhaps we can add an actual data-id attribute so we can find the item with one css query.

Thanks again for this great plugin. Hope we can give back some in return for using it.
