### PR TITLE
Added zindex options to dropdown

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -540,6 +540,7 @@
                 formatInputTooShort: function (input, min) { return "Please enter " + (min - input.length) + " more characters"; },
                 minimumResultsForSearch: 0,
                 minimumInputLength: 0,
+                zIndex: 2000,
                 id: function (e) { return e.id; },
                 matcher: function(term, text) {
                     return text.toUpperCase().indexOf(term.toUpperCase()) >= 0;
@@ -654,7 +655,8 @@
             this.dropdown.css({
                 top: offset.top + height,
                 left: offset.left,
-                width: width
+                width: width,
+                "z-index": this.opts.zIndex
             });
         },
 


### PR DESCRIPTION
On positionDropdown(), we assign zindex to the dropdown that can be specified in the options as zIndex.

By default this value is 2000 (Modal is usually in the 1000s)
