### PR TITLE
Minimum width

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -469,6 +469,7 @@
                 formatInputTooShort: function (input, min) { return "Please enter " + (min - input.length) + " more characters"; },
                 minimumResultsForSearch: 0,
                 minimumInputLength: 0,
+                minimumWidth: undefined,
                 id: function (e) { return e.id; },
                 matcher: function(term, text) {
                     return text.toUpperCase().indexOf(term.toUpperCase()) >= 0;
@@ -823,7 +824,7 @@
          * @returns The width string (with units) for the container.
          */
         getContainerWidth: function () {
-            var style, attrs, matches, i, l;
+            var style, attrs, matches, i, l, width=0, elWidth;
             if (this.opts.width !== undefined)
                 return this.opts.width;
 
@@ -837,7 +838,12 @@
                         return matches[1];
                 }
             }
-            return this.opts.element.width() + 'px';
+            if (this.opts.minimumWidth !== undefined) {
+                width = parseFloat(this.opts.minimumWidth);
+            }
+            elWidth = this.opts.element.width()
+
+            return (elWidth > width ? elWidth : width)+ 'px';
         }
     });
 


### PR DESCRIPTION
Add an option to set a minimum width for the container. 

Here's an example:

```
$("#select-input").select2({
minimumWidth: 200
})
```

This will assure that the container is atleast 200px wide. By default, this setting is set to undefined which means the width will be the result of getContainerWidth(), like it used to.
