### PR TITLE
Support for MongoDB style '_id' fields.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -602,7 +602,7 @@
                 formatLoadMore: function (pageNumber) { return "Loading more results..."; },
                 minimumResultsForSearch: 0,
                 minimumInputLength: 0,
-                id: function (e) { return e.id; },
+                id: function (e) { return e.id || e._id; },
                 matcher: function(term, text) {
                     return text.toUpperCase().indexOf(term.toUpperCase()) >= 0;
                 }
@@ -649,7 +649,7 @@
                     query.callback(data);
                 });
                 // this is needed because inside val() we construct choices from options and there id is hardcoded
-                opts.id=function(e) { return e.id; };
+                opts.id=function(e) { return e.id || e._id; };
             } else {
                 if (!("query" in opts)) {
                     if ("ajax" in opts) {


### PR DESCRIPTION
I'm using node.js with Mongoose and MongoDB to serve up JSON for select2 and I ran in to a problem today where the `value` field of the hidden input was not being updated. This was because my object had no `id` key.

However mongoDB uses `_id` instead which is then used all over my app to reference objects. So rather than hacking my code and confusing things I've made a small change to select2.js for my needs which seems to fix the problem.

Up to you if you want to include this :)
