### PR TITLE
Prevent dropdowns from opening if you press a 'meta' key 

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1126,7 +1126,7 @@
                 clickingInside = false;
             }));
             containers.delegate(selector, "keydown", this.bind(function (e) {
-                if (!this.enabled || e.which === KEY.TAB || KEY.isControl(e) || KEY.isFunctionKey(e) || e.which === KEY.ESC) {
+                if (!this.enabled || e.which === KEY.TAB || KEY.isControl(e) || KEY.isFunctionKey(e) || e.which === KEY.ESC || e.metaKey) {
                     return;
                 }
                 this.open();
@@ -1405,7 +1405,7 @@
                     }
                 }
 
-                if (e.which === KEY.TAB || KEY.isControl(e) || KEY.isFunctionKey(e) || e.which === KEY.BACKSPACE || e.which === KEY.ESC) {
+                if (e.which === KEY.TAB || KEY.isControl(e) || KEY.isFunctionKey(e) || e.which === KEY.BACKSPACE || e.which === KEY.ESC || e.metaKey) {
                     return;
                 }
 


### PR DESCRIPTION
Discovered this when a select2 dropdown unexpectedly opened while I was trying to CMD+TAB to a different application on a mac.

This is likely also an issue if you press windows key on windows (have not tested though), and probably similar on linux. Although it's less common for people to actually use the windows key on windows (irony?), this is still strange behaviour.
