### PR TITLE
Fix placeholders in jQuery 1.4

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -809,7 +809,10 @@
         },
 
         getPlaceholder: function () {
-            return this.opts.element.attr("placeholder") || this.opts.element.data("placeholder") || this.opts.placeholder;
+            return this.opts.element.attr("placeholder") ||
+                this.opts.element.attr("data-placeholder") || // jquery 1.4 compat
+                this.opts.element.data("placeholder") ||
+                this.opts.placeholder;
         },
 
         /**


### PR DESCRIPTION
Old jquery doesn't check data- attrs with .data()
