### PR TITLE
Use browser-native placeholder attribute for multi selects

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1117,7 +1117,8 @@
             var opts = this.parent.prepareOpts.apply(this, arguments);
 
             opts = $.extend({}, {
-                closeOnSelect: true
+                closeOnSelect: true,
+                nativePlaceholder: false,
             }, opts);
 
             // TODO validate placeholder is a string if specified
@@ -1212,6 +1213,8 @@
                 this.clearPlaceholder();
             }));
 
+            if (this.opts.nativePlaceholder) this.search.attr('placeholder', this.getPlaceholder());
+
             // set the placeholder if necessary
             this.clearSearch();
         },
@@ -1257,7 +1260,9 @@
                 && this.getVal().length === 0
                 && this.search.hasClass("select2-focused") === false) {
 
-                this.search.val(placeholder).addClass("select2-default");
+                // we're not using the placeholder attribute, just setting the field value directly:
+                if (!this.opts.nativePlaceholder) this.search.val(placeholder).addClass("select2-default");
+
                 // stretch the search box to full width of the container so as much of the placeholder is visible as possible
                 this.search.width(this.getContainerWidth());
             } else {


### PR DESCRIPTION
Especially for users with OS X (where native placeholders stay visible during focus), it's often easier just to set use the browser's built-in placeholder attribute. This adds the boolean `nativePlaceholder` option for multiple selects. (Looks like http://cl.ly/1H2L0T1i3V0Z2j2Y0U2O)
