### PR TITLE
Having paged requests, new results set mistakenly added to the last child

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -535,12 +535,7 @@
 
                     populate(results, 0);
 
-                    children=container.children();
-                    if (children.length===0) {
-                        container.html(markup.join(""));
-                    } else {
-                        $(children[children.length-1]).append(markup.join(""));
-                    }
+                    container.append(markup.join(""));                    
 
                     for (uid in uidToData) {
                         $("#select2-result-"+uid, container).data("select2-data", uidToData[uid]);


### PR DESCRIPTION
but it should be added to the results list instead.
