### PR TITLE
Default to width: auto instead of width: 0px when styling select2-container

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1033,7 +1033,7 @@
                         return matches[1];
                 }
             }
-            return this.opts.element.width() + 'px';
+            return (this.opts.element.width() === 0 ? 'auto' : this.opts.element.width() + 'px');
         }
     });
 


### PR DESCRIPTION
Allows container to scale with content when, at creation time of the container the content is hidden or unpopulated.
