### PR TITLE
Fixes syntax error in jQuery < 1.6 (":focus" selector is unavailable)

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -980,7 +980,8 @@
             this.close();
             this.container.removeClass("select2-container-active");
             this.dropdown.removeClass("select2-drop-active");
-            if (this.search.is(":focus")) { this.search.blur(); }
+            // synonymous to .is(':focus'), which is available in jquery >= 1.6
+            if (this.search[0] === document.activeElement) { this.search.blur(); }
             this.clearSearch();
             this.selection.find(".select2-search-choice-focus").removeClass("select2-search-choice-focus");
         },
@@ -1082,7 +1083,7 @@
 
         // single
         isFocused: function () {
-            return this.selection.is(":focus");
+            return this.selection[0] === document.activeElement;
         },
 
         // single


### PR DESCRIPTION
jQuery < 1.6 throws a syntax error on :focus selectors. This fix just uses the same check internal to jQuery's sizzle.
