### PR TITLE
improvement for the formatSelection function

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1630,18 +1630,20 @@
         // multi
         addSelectedChoice: function (data) {
             var choice,
-                id = this.id(data),
-                parts,
-                val = this.getVal();
-
+            id = this.id(data),
+            //span.formatSelection is only temporary
             parts = ["<li class='select2-search-choice'>",
-                this.opts.formatSelection(data),
+                "<span class='formatSelection'></span>",
                 "<a href='javascript:void(0)' class='select2-search-choice-close' tabindex='-1'></a>",
                 "</li>"
-            ];
+            ],
+            val = this.getVal();
 
             choice = $(parts.join(""));
-            choice.find("a")
+            // replace span.formatSelection with the returned value of this.opts.formatSelection(data)
+            // allows the possibility to return jQuery objects with formatSelection
+            choice.find('.formatSelection').replaceWith(this.opts.formatSelection(data));
+            choice.find(".select2-search-choice-close")
                 .bind("click dblclick", this.bind(function (e) {
                 if (!this.enabled) return;
 


### PR DESCRIPTION
The close event is now delegated to all elements inside the li which have the class "select2-search-choice-close"

It is now possible to return a jQuery object in the formatSelection function

Usecase:

I need this for an asynchronous behavior for custom tags.
I send in the function an ajax call to validate something from the backend and the anwser need access to the dom element. This is only possible if the element is a dom/jQuery Element.
