### PR TITLE
added autoWidth option + jQuery Position

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -56,6 +56,7 @@ Version: @@ver@@ Timestamp: @@timestamp@@
 
 .select2-container.select2-drop-above .select2-choice
 {
+    border-top: 0px;
     border-bottom-color: #aaa;
     -webkit-border-radius:0px 0px 4px 4px;
     -moz-border-radius:0px 0px 4px 4px;
@@ -116,6 +117,9 @@ Version: @@ver@@ Timestamp: @@timestamp@@
   -moz-border-radius: 0 0 4px 4px;
   border-radius: 0 0 4px 4px;
 }
+.select2-drop.autoWidth{
+	border-top:1px solid #aaa;
+}
 
 .select2-drop.select2-drop-above {
     -webkit-border-radius: 4px 4px 0px 0px;
@@ -130,7 +134,9 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     -o-box-shadow: 0 -4px 5px rgba(0, 0, 0, .15);
     box-shadow: 0 -4px 5px rgba(0, 0, 0, .15);
 }
-
+.select2-drop.select2-drop-above.autoWidth{
+	border-bottom:1px solid #aaa;
+}
 .select2-container .select2-choice div {
     -webkit-border-radius: 0 4px 4px 0;
     -moz-border-radius: 0 4px 4px 0;
@@ -171,6 +177,9 @@ Version: @@ver@@ Timestamp: @@timestamp@@
   margin: 0;
   padding-left: 4px;
   padding-right: 4px;
+}
+.autoWidth .select2-search{
+	padding-top: 4px;
 }
 
 .select2-search-hidden {

--- a/select2.js
+++ b/select2.js
@@ -598,6 +598,7 @@
                 formatInputTooShort: function (input, min) { return "Please enter " + (min - input.length) + " more characters"; },
                 formatLoadMore: function (pageNumber) { return "Loading more results..."; },
                 minimumResultsForSearch: 0,
+                autoWidth: false,
                 minimumInputLength: 0,
                 id: function (e) { return e.id; },
                 matcher: function(term, text) {
@@ -728,16 +729,14 @@
         positionDropdown: function() {
             var offset = this.container.offset(),
                 height = this.container.outerHeight(),
-                width = this.container.outerWidth(),
                 dropHeight = this.dropdown.outerHeight(),
                 viewportBottom = document.body.scrollTop + document.documentElement.clientHeight,
                 dropTop = offset.top + height,
                 enoughRoomBelow = dropTop + dropHeight <= viewportBottom,
                 enoughRoomAbove = (offset.top - dropHeight) >= document.body.scrollTop,
                 aboveNow = this.dropdown.hasClass("select2-drop-above"),
-                above,
-                css;
-
+                above;
+            
             // always prefer the current above/below alignment, unless there is not enough room
 
             if (aboveNow) {
@@ -757,14 +756,28 @@
                 this.container.removeClass("select2-drop-above");
                 this.dropdown.removeClass("select2-drop-above");
             }
-
-            css = {
-                top:dropTop,
-                left:offset.left,
-                width:width
-            };
-
-            this.dropdown.css(css);
+            
+            if (this.opts.autoWidth === true){
+            	//this.container.addClass("auto-container");
+            	this.dropdown.addClass("autoWidth")
+	            var width = "auto",
+	            	css;
+	            css = {
+	                width:width
+	            };
+	            this.dropdown.css(css);
+            
+            } else {
+            	//this.container.removeClass("auto-container");
+            	this.dropdown.removeClass("autoWidth")
+	            var width = this.container.outerWidth(),
+	            	css;
+	            css = {
+	                width:width,
+	            };
+	            this.dropdown.css(css);
+	            
+            }
         },
 
         // abstract
@@ -814,6 +827,17 @@
             this.dropdown.show();
             this.ensureHighlightVisible();
             this.focusSearch();
+            position();
+            
+            function position(using) {
+	            $(".select2-drop").position({
+	                my: "left top",
+	                at: "left bottom",
+	                of: $(".select2-dropdown-open"),
+	                using: using,
+	                collision: 'fit flip'
+	            });
+	    	}
 
             return true;
         },


### PR DESCRIPTION
autoWidth adds the option to adapt the dropdown width to its content.
The container still gets its width from the select style/class/inline
width.

jQuery Position is added to let the dropdown flip when browser borders
are detected. The 'old' code only gave option to flip when bottom
collision would occur, with autoWidth added it is also needed to watch
for right browser border detection.
