### PR TITLE
body element caching bug fix

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -429,7 +429,7 @@
 
             this.enabled=true;
             this.container = this.createContainer();
-			this.body = opts.element.closest("body"); // cache for future access
+            this.body = $("body"); // opts.element.closest("body"); // cache for future access
 
             if (opts.element.attr("class") !== undefined) {
                 this.container.addClass(opts.element.attr("class"));


### PR DESCRIPTION
In some scenarios we need to apply select2 function before attaching it to the document (like JavaScript templates, etc).
