### PR TITLE
Added text-color that contrasts with the selected background-color

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -100,6 +100,7 @@ Version: @@ver@@ Timestamp: @@timestamp@@
 
 .select2-drop {
     background: #fff;
+    color: #000;
     border: 1px solid #aaa;
     border-top: 0;
     position: absolute;


### PR DESCRIPTION
When the containing element have a text-color of white because it blends well with a dark blue background, the dropdown results become unreadable because that background is forced white.

Now, it also forces the text to be black :).
