### PR TITLE
Added opts to initSelection() parameters

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -659,9 +659,9 @@
                     } else if ("tags" in opts) {
                         opts.query = tags(opts.tags);
                         opts.createSearchChoice = function (term) { return {id: term, text: term}; };
-                        opts.initSelection = function (element, callback) {
+                        opts.initSelection = function (opts, callback) {
                             var data = [];
-                            $(splitVal(element.val(), opts.separator)).each(function () {
+                            $(splitVal(opts.element.val(), opts.separator)).each(function () {
                                 data.push({id: this, text: this});
                             });
 
@@ -1293,7 +1293,7 @@
                 this.setPlaceholder();
             } else {
                 var self = this;
-                this.opts.initSelection.call(null, this.opts.element, function(selected){
+                this.opts.initSelection.call(null, this.opts, function(selected){
                     if (selected !== undefined && selected !== null) {
                         self.updateSelection(selected);
                         self.close();
@@ -1309,8 +1309,8 @@
 
             if (opts.element.get(0).tagName.toLowerCase() === "select") {
                 // install the selection initializer
-                opts.initSelection = function (element, callback) {
-                    var selected = element.find(":selected");
+                opts.initSelection = function (opts, callback) {
+                    var selected = opts.element.find(":selected");
                     // a single select box always has a value, no need to null check 'selected'
                     if ($.isFunction(callback))
                         callback({id: selected.attr("value"), text: selected.text()});
@@ -1480,7 +1480,7 @@
 
             if (opts.element.get(0).tagName.toLowerCase() === "select") {
                 // install sthe selection initializer
-                opts.initSelection = function (element,callback) {
+                opts.initSelection = function (opts,callback) {
 
                     var data = [];
                     element.find(":selected").each2(function (i, elm) {
@@ -1607,7 +1607,7 @@
             }
             if (this.select || this.opts.element.val() !== "") {
                 var self = this;
-                this.opts.initSelection.call(null, this.opts.element, function(data){
+                this.opts.initSelection.call(null, this.opts, function(data){
                     if (data !== undefined && data !== null) {
                         self.updateSelection(data);
                         self.close();


### PR DESCRIPTION
I am not sure how useful this really is, so you're completely free to close this without merging as it was more of a convenience factor I had in a local version.

By passing `this.opts` to `initSelection()` it allows me to see things like if multiple is true, retrieve the ajax url, and reuse other formatter functions without having to explicitly call those variables or introspect the source element.

The problem is that the dev might modify this object and thereby make breaking changes, however I figured that edge-case was so obscure I'd rather just show a warning on the docs than bother cloning the options.

The new signature is: `initSelection(opts, callback)` where `opts` is the result of the passed options merged onto defaults with additional calculated options.
