### PR TITLE
Fixes #249: Relative widths set via CSS

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1119,16 +1119,16 @@
                 } else if (this.opts.width === "element"){
                     return this.opts.element.outerWidth() === 0 ? 'auto' : this.opts.element.outerWidth() + 'px';
                 } else if (this.opts.width === "copy" || this.opts.width === "resolve") {
-                    // check if there is inline style on the element that contains width
-                    style = this.opts.element.attr('style');
-                    if (style !== undefined) {
-                        attrs = style.split(';');
-                        for (i = 0, l = attrs.length; i < l; i = i + 1) {
-                            matches = attrs[i].replace(/\s/g, '')
-                                .match(/width:(([-+]?([0-9]*\.)?[0-9]+)(px|em|ex|%|in|cm|mm|pt|pc))/);
-                            if (matches !== null && matches.length >= 1)
-                                return matches[1];
+                    if (this.opts.width === "copy") {
+                       // get the width as computed by jQuery for the original element
+                        var newWidth = this.opts.element.outerWidth();
+                        // if the width of the element is bigger than its parent, get the width relative to the screen
+                        if(this.opts.element.outerWidth() > this.opts.element.parent().outerWidth()) {
+                            newWidth = (this.opts.element.outerWidth() / $(window).outerWidth()) * 100;
+                            return newWidth + "%";
                         }
+                        // return it in a pixel value so it is consistent across browsers
+                        return newWidth + "px";
                     }
 
                     if (this.opts.width === "resolve") {


### PR DESCRIPTION
This commit fixes #249 and allows for the width to be dynamic to allow for values that are percentages.

**Note:** The diff was _slightly_ messed up, the actual change is below at line 1122:

```
if (this.opts.width === "copy") {
    // get the width as computed by jQuery for the original element
    var newWidth = this.opts.element.outerWidth();
    // if the width of the element is bigger than its parent, get the width relative to the screen
    if(this.opts.element.outerWidth() > this.opts.element.parent().outerWidth()) {
        newWidth = (this.opts.element.outerWidth() / $(window).outerWidth()) * 100;
        return newWidth + "%";
    }
    // return it in a pixel value so it is consistent across browsers
    return newWidth + "px";
}
```
