### PR TITLE
Passing a string to select2('val') with initSelection causes it to be used

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1448,7 +1448,7 @@
                 this.updateSelection(data);
             } else {
                 // val is an object. !val is true for [undefined,null,'']
-                if (this.opts.initSelection) {
+                if (this.opts.initSelection && val) {
                     that = this;
                     this.opts.initSelection(this.opts.element.val(val), function(data){
                         self.opts.element.val(!data ? "" : self.id(data));
@@ -1915,7 +1915,7 @@
                 });
                 this.updateSelection(data);
             } else {
-                if (this.opts.initSelection) {
+                if (this.opts.initSelection && val !== null) {
                     this.opts.initSelection(this.opts.element.val(val), function(newVal){
                         $(newVal).each(function () { data.push(self.id(this)); });
                         self.setVal(data);


### PR DESCRIPTION
Fixes #224.

Unfortunately there is a bit of an inconsistency with how select2(val) and select2(data) is used. I think it would be better instead of having any flexibilty to instead make it explicit.

If you use 'data', you MUST pass an object (or array of objects). If you use 'val', you MUST pass a string, or a comma-deliminated string. Use of initSelection would of course depend on if it's defined, and setting the value to a false-ish value should work in either case.
