### PR TITLE
Possible fix for #259

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -707,12 +707,17 @@
          */
         // abstract
         triggerChange: function (details) {
-
             details = details || {};
-            details= $.extend({}, details, { type: "change", val: this.val() });
+
             // prevents recursive triggering
             this.opts.element.data("select2-change-triggered", true);
-            this.opts.element.trigger(details);
+			
+            var changeDetails = $.extend({}, details, { type: "change", val: this.val() });
+            this.opts.element.trigger(changeDetails);
+			
+            var clickDetails = $.extend({}, details, { type: "click", button: 0, which: 1 });
+            this.opts.element.trigger(clickDetails);
+			
             this.opts.element.data("select2-change-triggered", false);
         },
 


### PR DESCRIPTION
I've added code to spoof a `click()` event after the existing `change()` event. The event data doesn't contain any mouse position information, but it does indicate that the left mouse button was used while clicking.

My reason for adding the `button` and `which` attributes was to try and avoid problems with anti-right-click code. These attributes indicate that it was a left button click that caused the event, allowing it to pass both positive (is it the right button) and negative (is it anything except the left button) checks.

I haven't put in any position information because I couldn't be bothered. It appears that the mouse position data is hard to work with anyway, so it may as well be left blank.
