### PR TITLE
dropdownAttached option.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -742,6 +742,7 @@
 
         // abstract
         positionDropdown: function() {
+          if (!this.opts.dropdownAttached) {
             var offset = this.container.offset(),
                 height = this.container.outerHeight(),
                 width = this.container.outerWidth(),
@@ -784,6 +785,7 @@
             };
 
             this.dropdown.css(css);
+          }
         },
 
         // abstract
@@ -834,10 +836,12 @@
 
             this.updateResults(true);
 
-            if(this.dropdown[0] !== this.body().children().last()[0]) {
-                this.dropdown.detach().appendTo(this.body());
+            if (!this.opts.dropdownAttached) {
+              if(this.dropdown[0] !== this.body().children().last()[0]) {
+                  this.dropdown.detach().appendTo(this.body());
+              }
             }
-
+          
             this.dropdown.show();
             this.ensureHighlightVisible();
 
@@ -2113,6 +2117,7 @@
         dropdownCss: {},
         containerCssClass: "",
         dropdownCssClass: "",
+        dropdownAttached: false,
         formatResult: function(result, container, query) {
             var markup=[];
             markMatch(result.text, query.term, markup);


### PR DESCRIPTION
It would be great to get this brought into master, as I have been having trouble with the way the drop down is appended to the body and positioned alongside the link control.

---

Added dropdownAttached option (false by default) which can simplify integration by avoiding issues where the drop down can break away from the link control when used inside jQuery UI dialogs etc.

Note that this setting does NOT allow for the newly introduced feature where the drop down is positioned above if there is no space, since it essentially prevents positionDropDown from being called altogether.
