### PR TITLE
Fixes #59: Limited Selection

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -315,6 +315,11 @@ Version: @@ver@@ Timestamp: @@timestamp@@
   display: list-item;
 }
 
+.select2-results .select2-selection-limit {
+  background: #f4f4f4;
+  display: list-item;
+}
+
 /*
 disabled look for already selected choices in the results dropdown
 .select2-results .select2-disabled.select2-highlighted {

--- a/select2.js
+++ b/select2.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  Copyright 2012 Igor Vaynberg
 
  Version: @@ver@@ Timestamp: @@timestamp@@
@@ -1035,6 +1035,11 @@
                 results.html(escapeMarkup(html));
                 postRender();
             }
+            
+            if (opts.selectionLimit && ("getVal" in this) && this.getVal().length >= opts.selectionLimit) {
+            	render("<li class='select2-selection-limit'>" + opts.formatLimitReached(opts.selectionLimit) + "</li>");
+            	return;
+            }
 
             if (search.val().length < opts.minimumInputLength) {
                 render("<li class='select2-no-results'>" + opts.formatInputTooShort(search.val(), opts.minimumInputLength) + "</li>");
@@ -1983,7 +1988,7 @@
                 $(val).each(function () {
                     if (indexOf(this, unique) < 0) unique.push(this);
                 });
-                this.opts.element.val(unique.length === 0 ? "" : unique.join(","));
+                this.opts.element.val(unique.length === 0 ? "" : unique.join(this.opts.separator));
             }
         },
 
@@ -2138,9 +2143,11 @@
         },
         formatNoMatches: function () { return "No matches found"; },
         formatInputTooShort: function (input, min) { return "Please enter " + (min - input.length) + " more characters"; },
+        formatLimitReached: function (limit) { return "You can only select " + limit + " items"; },
         formatLoadMore: function (pageNumber) { return "Loading more results..."; },
         minimumResultsForSearch: 0,
         minimumInputLength: 0,
+        selectionLimit: 0,
         id: function (e) { return e.id; },
         matcher: function(term, text) {
             return text.toUpperCase().indexOf(term.toUpperCase()) >= 0;


### PR DESCRIPTION
This adds support for limiting the number of options that can be selected, as suggested in #59.  This _also_ fixes a small bug when joining the data for the parent element to set values where the separator set in the options was not used.

<hr />

This introduces two new settings, `selectionLimit` (int) and `formatLimitReached(limit)` (fn) that can be used to limit the number of options that can be selected in a multi-select element.  Once the limit is reached, a message is displayed using `formatLimitReached` instead of displaying the options.

The default for `selectionLimit` is **0**, which means that it will not check for a limit.
