### PR TITLE
data attribute support for simplifying ajax select boxes

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1430,6 +1430,14 @@
                     if ($.isFunction(callback))
                         callback({id: selected.attr("value"), text: selected.text()});
                 };
+            } else if (opts.element.get(0).tagName.toLowerCase() === "input"
+                       && opts.element.attr("hidden") == "hidden"
+                       && opts.initSelection == undefined
+                       && opts.element.data("text")) {
+                // install the selection initializer
+                opts.initSelection = function (element,callback) {
+                    return {id: element.val(), text: element.data("text")};
+                };
             }
 
             return opts;


### PR DESCRIPTION
I added some small enhancements to make using ajax easier. Now you can optionally specify the url, and text of the select box in data attributes directly on the input tag. 

```
<input data-ajax-url="/models.json" data-text="This appears in the select box" hidden="hidden" type="number" value="12" style="display: none; ">
```

I only added the data-text support to the single box implementation. I'd be happy to update the documentation, but it's not checked into the repo.

Excellent library, by the way!

Thanks,
James 
