### PR TITLE
Fixes #182: Disable Information Messages

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1039,13 +1039,21 @@
             if (opts.maximumSelectionSize >=1) {
                 data = this.data();
                 if ($.isArray(data) && data.length >= opts.maximumSelectionSize) {
-            	    render("<li class='select2-selection-limit'>" + opts.formatSelectionTooBig(opts.maximumSelectionSize) + "</li>");
-            	    return;
+                    if (typeof(opts.formatSelectionTooBig) === "function") {
+                        render("<li class='select2-selection-limit'>" + opts.formatSelectionTooBig(opts.maximumSelectionSize) + "</li>");
+                    } else {
+                        render("");
+                    }
+                    return;
                 }
             }
 
             if (search.val().length < opts.minimumInputLength) {
-                render("<li class='select2-no-results'>" + opts.formatInputTooShort(search.val(), opts.minimumInputLength) + "</li>");
+                if (typeof(opts.formatInputTooShort) === "function") {
+                    render("<li class='select2-no-results'>" + opts.formatInputTooShort(search.val(), opts.minimumInputLength) + "</li>");
+                } else {
+                    render("");
+                }
                 return;
             }
 
@@ -1075,7 +1083,11 @@
                 }
 
                 if (data.results.length === 0) {
-                    render("<li class='select2-no-results'>" + opts.formatNoMatches(search.val()) + "</li>");
+                    if (typeof(opts.formatNoMatches) === "function") {
+                        render("<li class='select2-no-results'>" + opts.formatNoMatches(search.val()) + "</li>");
+                    } else {
+                        render("");
+                    }
                     return;
                 }
 


### PR DESCRIPTION
Allows for formatNoMatches, formatSelectionTooBig, and formatInputTooShort to be set to false to not display any message.  This could have been done with a function returning nothing, but setting the option to false is quicker.  This also fixes any error that would have come if the user did not set the option to a function.
