### PR TITLE
Multiple selects can be open at the same time

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -40,7 +40,7 @@
         return;
     }
 
-    var KEY, AbstractSelect2, SingleSelect2, MultiSelect2, nextUid, sizer;
+    var KEY, AbstractSelect2, SingleSelect2, MultiSelect2, nextUid, sizer, currentSelect2;
 
     KEY = {
         TAB: 9,
@@ -858,6 +858,12 @@
          */
         // abstract
         opening: function() {
+            // We already have an open instance. Close that one!
+            if(currentSelect2) {
+                currentSelect2.close();
+            }
+            currentSelect2 = this;
+
             this.clearDropdownAlignmentPreference();
 
             if (this.search.val() === " ") { this.search.val(""); }
@@ -882,6 +888,9 @@
         // abstract
         close: function () {
             if (!this.opened()) return;
+
+            // Removing us as the currently open instance
+            currentSelect2 = null;
 
             this.clearDropdownAlignmentPreference();
 


### PR DESCRIPTION
Currently, opening a second select does not close the currently active.

To test, go to http://ivaynberg.github.com/select2/ and click on multiple selects without clicking on anything else.

As an alternative, pull the code and add the following html-file inside the directory:

``` html
<!doctype html>

<link href=select2.css rel=stylesheet>

<select>
    <option>a
    <option>b
    <option>c
</select>

<select>
    <option>a
    <option>b
    <option>c
</select>

<script src=http://code.jquery.com/jquery-1.7.1.min.js></script>
<script src=select2.js></script>
<script>
    $('select').select2()
</script>
```

This might be related to stopping events dead when clicking inside the dropdown.
