### PR TITLE
Round the css top and left values for the dropdown

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -826,8 +826,8 @@
             }
 
             css = {
-                top:dropTop,
-                left:offset.left,
+                top:Math.floor(dropTop),
+                left:Math.round(offset.left),
                 width:width
             };
 


### PR DESCRIPTION
In Chrome 21.0.1180.57, the dropdown appears one pixel too low or offset left/right from the container if the result of this.container.offset() produces offsets that are not whole numbers.
This fix rounds the css top attribute down to a whole number.
This fix also rounds the left attribute to the nearest whole number.
