### PR TITLE
Fix typing mistake

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -396,7 +396,7 @@
      */
     function checkFormatter(formatter, formatterName) {
         if ($.isFunction(formatter)) return true;
-        if (!formatter) return fasle;
+        if (!formatter) return false;
         throw new Error("formatterName must be a function or a falsy value");
     }
 


### PR DESCRIPTION
Fix return value of checkFormatter function. It was "fasle" instead of "false"
