### PR TITLE
Open search on key.enter on selection in single mode

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1472,7 +1472,7 @@
                 }
 
                 if (e.which === KEY.TAB || KEY.isControl(e) || KEY.isFunctionKey(e)
-                 || e.which === KEY.ESC || e.which == KEY.ENTER) {
+                 || e.which === KEY.ESC) {
                     return;
                 }
 


### PR DESCRIPTION
Currently after focusing control by TAB, pressing ENTER do nothing.
But when control is focused by SHIFT+TAB, pressing ENTER opens search.
Its because TAB go to < a > , and SHIFT+TAB goes to < input >.
Events 'keydown' on both elements are different in ENTER processing.
