### PR TITLE
ajax - support traditional param serialization in ajax calls

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -277,6 +277,7 @@
      * @param options.url url for the data
      * @param options.data a function(searchTerm, pageNumber, context) that should return an object containing query string parameters for the above url.
      * @param options.dataType request data type: ajax, jsonp, other datatatypes supported by jQuery's $.ajax function or the transport function if specified
+     * @param options.traditional a boolean flag that should be true if you wish to use the traditional style of param serialization for the ajax request
      * @param options.quietMillis (optional) milliseconds to wait before making the ajaxRequest, helps debounce the ajax function if invoked too often
      * @param options.results a function(remoteData, pageNumber) that converts data returned form the remote request to the format expected by Select2.
      *      The expected format is an object containing the following keys:
@@ -297,6 +298,7 @@
                 var requestNumber = requestSequence, // this request's sequence number
                     data = options.data, // ajax data function
                     transport = options.transport || $.ajax,
+                    traditional = options.traditional || false,
                     type = options.type || 'GET'; // set type of request (GET or POST)
 
                 data = data.call(this, query.term, query.page, query.context);
@@ -308,6 +310,7 @@
                     dataType: options.dataType,
                     data: data,
                     type: type,
+                    traditional: traditional,                    
                     success: function (data) {
                         if (requestNumber < requestSequence) {
                             return;


### PR DESCRIPTION
Added 'traditional' ajax parameter to ajax() function allowing for traditional style of parameter serialization.
