### PR TITLE
Bugfix: IE fires window.onbeforeunload event

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1333,7 +1333,7 @@
             var container = $("<div></div>", {
                 "class": "select2-container"
             }).html([
-                "    <a href='javascript:void(0)' class='select2-choice'>",
+                "    <a href='#' onclick='return false;' class='select2-choice'>",
                 "   <span></span><abbr class='select2-search-choice-close' style='display:none;'></abbr>",
                 "   <div><b></b></div>" ,
                 "</a>",


### PR DESCRIPTION
This change fixes a bug in Internet Explorer which fires the window.onbeforeunload event, when you click on a select2 input twice.

The bug is described under: http://stackoverflow.com/a/2508151/1286092

Greets from Austria,
Gerhard
