### PR TITLE
make escapeMarkup optional

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2059,7 +2059,6 @@
                 formatted;
 
             formatted=this.opts.formatSelection(data, choice);
-                    console.log(" 7 " + this.escapeMarkup);
             choice.find("div").replaceWith("<div>"+this.escapeMarkup(formatted)+"</div>");
             choice.find(".select2-search-choice-close")
                 .bind("mousedown", killEvent)


### PR DESCRIPTION
This is my pull request on refactoring the place where the `escapeMarkup` lives and making it optional with an `doEscapeMarkup` parameter. 
## Disclaimer

I'm no JS developer and I hope those changes makes sense.
## Reasoning

I'm using select2 with Django by supplying an `ajax` object and I'm generating the rich format of a selection items on server side (i.e. values from db wrapped by some nice tables and images). I want to display those items "as is" and I'm escaping all the user inputed data on server side (in json). So my json looks something like this:

```
{

"id": "2",
"value": "Pear",
"label": "\n <table class=\"selectable_table\">\n <tr>\n <td rowspan=\"2\" class=\"image\">\n <img src=\"/media/fruitimages/pear.jpg\" alt=\"\" width=\"50px\" height=\"50px\">\n </td>\n <td>Pear</td>\n </tr>\n <tr>\n <td class=\"small\">this is a pear! and it is  &lt;script&gt;alert(&#39;hacked&#39;);&lt;/script&gt;</td>\n </tr>\n </table>"

 },
```

and format funcs look like this:

```
        formatResult     :  function (state) {
          return state.label;
        },
        formatSelection  :  function (state) {
          return state.value;
        },
```

because i want to display:

```
this is a pear! and it is  <script>alert('hacked');</script>
```

In current implementation of select2 it seems that i can't do that because theres is no option to ignore the client side escaping.
