### PR TITLE
Added new clipboard style copy(…) and paste(…) functions

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>Select2 Clipboard API Demo</title>
+		<!-- CDN hosted jQuery 1.8 -->
+		<script type"text/javascript" src="http://code.jquery.com/jquery-1.8.0.min.js"></script>
+		
+		<!-- CDN hosted Bootstrap 2.1 -->
+		<link rel="stylesheet" type="text/css" href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.1.0/css/bootstrap-combined.min.css" />
+		
+		<!-- Tweaked Select2 with clipboard API -->
+		<link rel="stylesheet" type="text/css" href="../select2.css" />
+		<script type="text/javascript" src="../select2.js"></script>
+		
+		<style type="text/css">
+			html, body, select {
+				font-family: Helvetica;
+				margin: 15px;
+			}
+		</style>
+		
+		<script type="text/javascript">
+			$(document).ready(function() {
+				// Initialize Select2 widgets
+				$('select').select2();
+			});
+			
+			function selectCopy(btnEl) {
+				// Find the sibling select2 element and copy
+				$(btnEl).siblings('select.select2-enabled').select2('copy');
+			}
+			
+			function selectPaste(btnEl) {
+				// Find the sibling select2 element and paste
+				$(btnEl).siblings('select.select2-enabled').select2('paste');
+			}
+		</script>
+	</head>
+	
+	<body>	
+		<div class="hero-unit">
+			<h2>Select2 Clipboard API Demo</h2>
+			<p>
+				Try out the added copy and paste API added to the <a href="http://ivaynberg.github.com/select2/" target="_blank">excellent Select2 widget</a>. You can select values in both single and multi-select modes,
+				and copy (or paste) from widget to widget with one line of code.
+			</p>
+			<p>
+				Great for applications which use multiple Select2 widgets on a single page.
+			</p>
+		</div>
+		
+		<h3>Select2 Single Mode</h3>
+		<div>
+			<h5>1st Select Widget:</h5>	
+			<button type="button" class="btn btn-primary" onclick="selectCopy(this)">Copy</button>
+			<button type="button" class="btn btn-info" onclick="selectPaste(this)">Paste</button>
+			<select name="select2_1" class="select2-enabled" style="width:300px">
+	            <optgroup label="Alaskan/Hawaiian Time Zone">
+	                <option value="AK">Alaska</option>
+	                <option value="HI">Hawaii</option>
+	            </optgroup>
+	            <optgroup label="Pacific Time Zone">
+	                <option value="CA">California</option>
+	                <option value="NV">Nevada</option>
+	                <option value="OR">Oregon</option>
+	                <option value="WA">Washington</option>
+	            </optgroup>
+	            <optgroup label="Mountain Time Zone">
+	                <option value="AZ">Arizona</option>
+	                <option value="CO">Colorado</option>
+	                <option value="ID">Idaho</option>
+	                <option value="MT">Montana</option><option value="NE">Nebraska</option>
+	                <option value="NM">New Mexico</option>
+	                <option value="ND">North Dakota</option>
+	                <option value="UT">Utah</option>
+	                <option value="WY">Wyoming</option>
+	            </optgroup>
+	            <optgroup label="Central Time Zone">
+	                <option value="AL">Alabama</option>
+	                <option value="AR">Arkansas</option>
+	                <option value="IL">Illinois</option>
+	                <option value="IA">Iowa</option>
+	                <option value="KS">Kansas</option>
+	                <option value="KY">Kentucky</option>
+	                <option value="LA">Louisiana</option>
+	                <option value="MN">Minnesota</option>
+	                <option value="MS">Mississippi</option>
+	                <option value="MO">Missouri</option>
+	                <option value="OK">Oklahoma</option>
+	                <option value="SD">South Dakota</option>
+	                <option value="TX">Texas</option>
+	                <option value="TN">Tennessee</option>
+	                <option value="WI">Wisconsin</option>
+	            </optgroup>
+	            <optgroup label="Eastern Time Zone">
+	                <option value="CT">Connecticut</option>
+	                <option value="DE">Delaware</option>
+	                <option value="FL">Florida</option>
+	                <option value="GA">Georgia</option>
+	                <option value="IN">Indiana</option>
+	                <option value="ME">Maine</option>
+	                <option value="MD">Maryland</option>
+	                <option value="MA">Massachusetts</option>
+	                <option value="MI">Michigan</option>
+	                <option value="NH">New Hampshire</option><option value="NJ">New Jersey</option>
+	                <option value="NY">New York</option>
+	                <option value="NC">North Carolina</option>
+	                <option value="OH">Ohio</option>
+	                <option value="PA">Pennsylvania</option><option value="RI">Rhode Island</option><option value="SC">South Carolina</option>
+	                <option value="VT">Vermont</option><option value="VA">Virginia</option>
+	                <option value="WV">West Virginia</option>
+	            </optgroup>
+	        </select>
+		</div>
+		
+		<div>
+			<h5>2nd Select Widget:</h5>	
+			<button type="button" class="btn btn-primary" onclick="selectCopy(this)">Copy</button>
+			<button type="button" class="btn btn-info" onclick="selectPaste(this)">Paste</button>
+			<select name="select2_2" class="select2-enabled" style="width:300px">
+	            <optgroup label="Alaskan/Hawaiian Time Zone">
+	                <option value="AK">Alaska</option>
+	                <option value="HI">Hawaii</option>
+	            </optgroup>
+	            <optgroup label="Pacific Time Zone">
+	                <option value="CA">California</option>
+	                <option value="NV">Nevada</option>
+	                <option value="OR">Oregon</option>
+	                <option value="WA">Washington</option>
+	            </optgroup>
+	            <optgroup label="Mountain Time Zone">
+	                <option value="AZ">Arizona</option>
+	                <option value="CO">Colorado</option>
+	                <option value="ID">Idaho</option>
+	                <option value="MT">Montana</option><option value="NE">Nebraska</option>
+	                <option value="NM">New Mexico</option>
+	                <option value="ND">North Dakota</option>
+	                <option value="UT">Utah</option>
+	                <option value="WY">Wyoming</option>
+	            </optgroup>
+	            <optgroup label="Central Time Zone">
+	                <option value="AL">Alabama</option>
+	                <option value="AR">Arkansas</option>
+	                <option value="IL">Illinois</option>
+	                <option value="IA">Iowa</option>
+	                <option value="KS">Kansas</option>
+	                <option value="KY">Kentucky</option>
+	                <option value="LA">Louisiana</option>
+	                <option value="MN">Minnesota</option>
+	                <option value="MS">Mississippi</option>
+	                <option value="MO">Missouri</option>
+	                <option value="OK">Oklahoma</option>
+	                <option value="SD">South Dakota</option>
+	                <option value="TX">Texas</option>
+	                <option value="TN">Tennessee</option>
+	                <option value="WI">Wisconsin</option>
+	            </optgroup>
+	            <optgroup label="Eastern Time Zone">
+	                <option value="CT">Connecticut</option>
+	                <option value="DE">Delaware</option>
+	                <option value="FL">Florida</option>
+	                <option value="GA">Georgia</option>
+	                <option value="IN">Indiana</option>
+	                <option value="ME">Maine</option>
+	                <option value="MD">Maryland</option>
+	                <option value="MA">Massachusetts</option>
+	                <option value="MI">Michigan</option>
+	                <option value="NH">New Hampshire</option><option value="NJ">New Jersey</option>
+	                <option value="NY">New York</option>
+	                <option value="NC">North Carolina</option>
+	                <option value="OH">Ohio</option>
+	                <option value="PA">Pennsylvania</option><option value="RI">Rhode Island</option><option value="SC">South Carolina</option>
+	                <option value="VT">Vermont</option><option value="VA">Virginia</option>
+	                <option value="WV">West Virginia</option>
+	            </optgroup>
+	        </select>
+		</div>	
+		<br/><br/>
+		<h3>Select2 Multi-Select Mode</h3>
+		<div>
+			<h5>3rd Select Widget:</h5>	
+			<button type="button" class="btn btn-primary" onclick="selectCopy(this)">Copy</button>
+			<button type="button" class="btn btn-info" onclick="selectPaste(this)">Paste</button>
+			<select name="select2_3" class="select2-enabled" style="width:300px" multiple="">
+	            <optgroup label="Alaskan/Hawaiian Time Zone">
+	                <option value="AK">Alaska</option>
+	                <option value="HI">Hawaii</option>
+	            </optgroup>
+	            <optgroup label="Pacific Time Zone">
+	                <option value="CA">California</option>
+	                <option value="NV">Nevada</option>
+	                <option value="OR">Oregon</option>
+	                <option value="WA">Washington</option>
+	            </optgroup>
+	            <optgroup label="Mountain Time Zone">
+	                <option value="AZ">Arizona</option>
+	                <option value="CO">Colorado</option>
+	                <option value="ID">Idaho</option>
+	                <option value="MT">Montana</option><option value="NE">Nebraska</option>
+	                <option value="NM">New Mexico</option>
+	                <option value="ND">North Dakota</option>
+	                <option value="UT">Utah</option>
+	                <option value="WY">Wyoming</option>
+	            </optgroup>
+	            <optgroup label="Central Time Zone">
+	                <option value="AL">Alabama</option>
+	                <option value="AR">Arkansas</option>
+	                <option value="IL">Illinois</option>
+	                <option value="IA">Iowa</option>
+	                <option value="KS">Kansas</option>
+	                <option value="KY">Kentucky</option>
+	                <option value="LA">Louisiana</option>
+	                <option value="MN">Minnesota</option>
+	                <option value="MS">Mississippi</option>
+	                <option value="MO">Missouri</option>
+	                <option value="OK">Oklahoma</option>
+	                <option value="SD">South Dakota</option>
+	                <option value="TX">Texas</option>
+	                <option value="TN">Tennessee</option>
+	                <option value="WI">Wisconsin</option>
+	            </optgroup>
+	            <optgroup label="Eastern Time Zone">
+	                <option value="CT">Connecticut</option>
+	                <option value="DE">Delaware</option>
+	                <option value="FL">Florida</option>
+	                <option value="GA">Georgia</option>
+	                <option value="IN">Indiana</option>
+	                <option value="ME">Maine</option>
+	                <option value="MD">Maryland</option>
+	                <option value="MA">Massachusetts</option>
+	                <option value="MI">Michigan</option>
+	                <option value="NH">New Hampshire</option><option value="NJ">New Jersey</option>
+	                <option value="NY">New York</option>
+	                <option value="NC">North Carolina</option>
+	                <option value="OH">Ohio</option>
+	                <option value="PA">Pennsylvania</option><option value="RI">Rhode Island</option><option value="SC">South Carolina</option>
+	                <option value="VT">Vermont</option><option value="VA">Virginia</option>
+	                <option value="WV">West Virginia</option>
+	            </optgroup>
+	        </select>
+		</div>
+		
+		<div>
+			<h5>4th Select Widget:</h5>	
+			<button type="button" class="btn btn-primary" onclick="selectCopy(this)">Copy</button>
+			<button type="button" class="btn btn-info" onclick="selectPaste(this)">Paste</button>
+			<select name="select2_4" class="select2-enabled" style="width:300px" multiple="">
+	            <optgroup label="Alaskan/Hawaiian Time Zone">
+	                <option value="AK">Alaska</option>
+	                <option value="HI">Hawaii</option>
+	            </optgroup>
+	            <optgroup label="Pacific Time Zone">
+	                <option value="CA">California</option>
+	                <option value="NV">Nevada</option>
+	                <option value="OR">Oregon</option>
+	                <option value="WA">Washington</option>
+	            </optgroup>
+	            <optgroup label="Mountain Time Zone">
+	                <option value="AZ">Arizona</option>
+	                <option value="CO">Colorado</option>
+	                <option value="ID">Idaho</option>
+	                <option value="MT">Montana</option><option value="NE">Nebraska</option>
+	                <option value="NM">New Mexico</option>
+	                <option value="ND">North Dakota</option>
+	                <option value="UT">Utah</option>
+	                <option value="WY">Wyoming</option>
+	            </optgroup>
+	            <optgroup label="Central Time Zone">
+	                <option value="AL">Alabama</option>
+	                <option value="AR">Arkansas</option>
+	                <option value="IL">Illinois</option>
+	                <option value="IA">Iowa</option>
+	                <option value="KS">Kansas</option>
+	                <option value="KY">Kentucky</option>
+	                <option value="LA">Louisiana</option>
+	                <option value="MN">Minnesota</option>
+	                <option value="MS">Mississippi</option>
+	                <option value="MO">Missouri</option>
+	                <option value="OK">Oklahoma</option>
+	                <option value="SD">South Dakota</option>
+	                <option value="TX">Texas</option>
+	                <option value="TN">Tennessee</option>
+	                <option value="WI">Wisconsin</option>
+	            </optgroup>
+	            <optgroup label="Eastern Time Zone">
+	                <option value="CT">Connecticut</option>
+	                <option value="DE">Delaware</option>
+	                <option value="FL">Florida</option>
+	                <option value="GA">Georgia</option>
+	                <option value="IN">Indiana</option>
+	                <option value="ME">Maine</option>
+	                <option value="MD">Maryland</option>
+	                <option value="MA">Massachusetts</option>
+	                <option value="MI">Michigan</option>
+	                <option value="NH">New Hampshire</option><option value="NJ">New Jersey</option>
+	                <option value="NY">New York</option>
+	                <option value="NC">North Carolina</option>
+	                <option value="OH">Ohio</option>
+	                <option value="PA">Pennsylvania</option><option value="RI">Rhode Island</option><option value="SC">South Carolina</option>
+	                <option value="VT">Vermont</option><option value="VA">Virginia</option>
+	                <option value="WV">West Virginia</option>
+	            </optgroup>
+	        </select>
+		</div>	
+	</body>
+</html>

--- a/select2.js
+++ b/select2.js
@@ -1746,7 +1746,20 @@
                     this.updateSelection(value);
                 }
             }
-        }
+        },
+
+		copy: function() {
+			// Copy currently selected value to clipboard
+			var currentVal = this.val();
+			window.Select2.clipboard = currentVal;
+		},
+		
+		paste: function() {
+			// If a clipboard value exists, then apply it to this select
+			if(window.Select2.clipboard) {
+				this.val(window.Select2.clipboard);
+			}
+		}
     });
 
     MultiSelect2 = clazz(AbstractSelect2, {
@@ -2278,7 +2291,20 @@
                 this.updateSelection(values);
                 this.clearSearch();
             }
-        }
+        },
+
+		copy: function() {
+			// Copy currently selected value to clipboard
+			var currentVal = this.val();
+			window.Select2.clipboard = currentVal;
+		},
+		
+		paste: function() {
+			// If a clipboard value exists, then apply it to this select
+			if(window.Select2.clipboard) {
+				this.val(window.Select2.clipboard);
+			}
+		}
     });
 
     $.fn.select2 = function () {
@@ -2286,7 +2312,7 @@
         var args = Array.prototype.slice.call(arguments, 0),
             opts,
             select2,
-            value, multiple, allowedMethods = ["val", "destroy", "opened", "open", "close", "focus", "isFocused", "container", "onSortStart", "onSortEnd", "enable", "disable", "positionDropdown", "data"];
+            value, multiple, allowedMethods = ["val", "destroy", "opened", "open", "close", "focus", "isFocused", "container", "onSortStart", "onSortEnd", "enable", "disable", "positionDropdown", "data", "copy", "paste"];
 
         this.each(function () {
             if (args.length === 0 || typeof(args[0]) === "object") {
@@ -2378,7 +2404,8 @@
             "abstract": AbstractSelect2,
             "single": SingleSelect2,
             "multi": MultiSelect2
-        }
+        },
+		clipboard: null
     };
 
 }(jQuery));


### PR DESCRIPTION
I am going to be implementing Select2 in a business web application wherein it will be instanced multiple times on a single page. Users will be selecting names of other persons for multiple line items in a leave request.

In a prototype created several months ago, I added a rudimentary copy/paste function using only jQuery and HTML select elements. It turned out to be extremely well received during project meetings. For the production version of my app, I am using Select2 to make the UX even nicer, and along the way it made the most sense to incorporate the copy/paste functionality directly into Select2 as a callable API.

Please consider this small addition for your next version of Select2. A demo page is packaged with the changes so you can quickly sample how it works.
