### PR TITLE
Fix for ValidationEngine & hiding errors on change.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -568,7 +568,7 @@
             this.body = thunk(function() { return opts.element.closest("body"); });
 
             if (opts.element.attr("class") !== undefined) {
-                this.container.addClass(opts.element.attr("class"));
+                this.container.addClass(opts.element.attr("class").replace(/validate\[[\S ]+] ?/, ''));
             }
 
             this.container.css(evaluate(opts.containerCss));
@@ -833,6 +833,11 @@
             // some validation frameworks ignore the change event and listen instead to keyup, click for selects
             // so here we trigger the click event manually
             this.opts.element.click();
+
+            // ValidationEngine ignorea the change event and listens instead to blur
+            // so here we trigger the blur event manually if so desired
+            if (this.opts.blurOnChange)
+                this.opts.element.blur();
         },
 
 
@@ -2366,7 +2371,8 @@
                 return markup.replace(/&/g, "&amp;");
             }
             return markup;
-        }
+        },
+        blurOnChange: false
     };
 
     // exports


### PR DESCRIPTION
Copying class attribute to container causes and issue with the JQuery ValidationEngine. In order to prevent double validation, a simple regex replace call to copy all but the actual validation[] class.

Also, added a blurOnChange default setting, to allow people to trigger and blur() event in case of using JQuery ValidationEngine in order to immediately hide the validation error message when selecting an option.
