### PR TITLE
formatResult and formatSelection should escape

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -706,7 +706,7 @@
 
                             formatted=opts.formatResult(result, label, query);
                             if (formatted!==undefined) {
-                                label.html(self.opts.escapeMarkup(formatted));
+                                label.html(formatted);
                             }
 
                             node.append(label);
@@ -1682,7 +1682,7 @@
             container.empty();
             formatted=this.opts.formatSelection(data, container);
             if (formatted !== undefined) {
-                container.append(this.opts.escapeMarkup(formatted));
+                container.append(formatted);
             }
 
             this.selection.removeClass("select2-default");
@@ -2339,11 +2339,11 @@
         dropdownCssClass: "",
         formatResult: function(result, container, query) {
             var markup=[];
-            markMatch(result.text, query.term, markup);
+            markMatch(this.escapeMarkup(result.text), this.escapeMarkup(query.term), markup);
             return markup.join("");
         },
         formatSelection: function (data, container) {
-            return data.text;
+            return this.escapeMarkup(data.text);
         },
         formatResultCssClass: function(data) {return undefined;},
         formatNoMatches: function () { return "No matches found"; },
@@ -2363,7 +2363,16 @@
         tokenizer: defaultTokenizer,
         escapeMarkup: function (markup) {
             if (markup && typeof(markup) === "string") {
-                return markup.replace(/&/g, "&amp;");
+                return markup.replace(/&|'|"|<|>/g, function(chr) {
+                     switch(chr) {
+                     	case '&': return '&amp;';
+                     	case "'": return '&apos;';
+                     	case '"': return '&quot;';
+                     	case '<': return '&lt;';
+                     	case '>': return '&gt;';
+                     }
+                     return '&#' + chr.charCodeAt(0) + ';';
+                });
             }
             return markup;
         }


### PR DESCRIPTION
I have followed a number of issues revolving around escapeMarkup that seem to recur, and I
believe the solutions you are choosing are good, but don't get at the root cause of the problem.
I believe the root of the problem is that it is used in the wrong place.

If formatSelection and formatResult are expected to return HTML, then you should not be calling
any escaping function on their output. Instead, you should expect that the job of "formatting" is to convert text into HTML, which includes escaping.

This means that your impl of formatSelection and formatResult should call escapeMarkup, and that escapeMarkup needs to be robust enough to sanitize any string (it shouldn't expect pre-escaped text).

NOTE: This is not yet tested. Might not even run. I'll take a look in a bit, but unless you're expecting to do a new release really soon, my priority is to fix up the version I have now (3.1).
