### PR TITLE
Tabbing out doesn't put placeholder back on input tags with multiple=true and no value selected

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1865,7 +1865,7 @@
 
             this.search.bind("keyup", this.bind(this.resizeSearch));
 
-            this.search.bind("blur", this.bind(function() {
+            this.search.bind("blur", this.bind(function(e) {
                 this.container.removeClass("select2-container-active");
                 this.search.removeClass("select2-focused");
                 this.clearSearch();


### PR DESCRIPTION
Tabbing out of input tags with multiple set as true and no value
selected will result in the default placeholder not being shown.
This patch fixes the issue by calling clearSearch() on blur of
MultiSelect2 and preventing the bubbling of the blur event to the
abstract class.

Test case with version 3.2: http://jsfiddle.net/pmirshad/PqP2L/1/

Clicking anywhere on the page resets the placeholders.
