### PR TITLE
Pluralize 'items' in formatSelectionTooBig

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2348,7 +2348,7 @@
         formatResultCssClass: function(data) {return undefined;},
         formatNoMatches: function () { return "No matches found"; },
         formatInputTooShort: function (input, min) { return "Please enter " + (min - input.length) + " more characters"; },
-        formatSelectionTooBig: function (limit) { return "You can only select " + limit + " items"; },
+        formatSelectionTooBig: function (limit) { return "You can only select " + limit + " item" + (limit == 1 ? "" : "s"); },
         formatLoadMore: function (pageNumber) { return "Loading more results..."; },
         formatSearching: function () { return "Searching..."; },
         minimumResultsForSearch: 0,


### PR DESCRIPTION
`formatSelectionTooBig` returns the text 'You can only select 1 items'. This patch fixes that by correctly pluralizing items based on the limit.
