### PR TITLE
Prevent formatSelection for erroring when accessing an empty select input.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -926,7 +926,7 @@
 
             if (this.opened()) return false;
 
-            event = jQuery.Event("open");
+            event = $.Event("open");
             this.opts.element.trigger(event);
             return !event.isDefaultPrevented();
         },
@@ -1020,7 +1020,7 @@
             this.results.empty();
             this.clearSearch();
 
-            this.opts.element.trigger(jQuery.Event("close"));
+            this.opts.element.trigger($.Event("close"));
         },
 
         // abstract


### PR DESCRIPTION
When a Select2 input is initialized without any values, programmatically attempting to access a value (e.g `$("#no-value-select").select2("val", 1)`) will throw an error when using the default `formatSelection` function.

Added a condition to check if `data` exists first before trying to return `data.text`.
