### PR TITLE
Fix perfs issues

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -165,7 +165,7 @@
         });
     }
 
-    $document.delegate("body", "mousemove", function (e) {
+    $document.bind("mousemove", function (e) {
         lastMousePosition = {x: e.pageX, y: e.pageY};
     });
 
@@ -497,7 +497,7 @@
      * also takes care of clicks on label tags that point to the source element
      */
     $document.ready(function () {
-        $document.delegate("body", "mousedown touchend", function (e) {
+        $document.bind("mousedown touchend", function (e) {
             var target = $(e.target).closest("div.select2-container").get(0), attr;
             if (target) {
                 $document.find("div.select2-container-active").each(function () {


### PR DESCRIPTION
Hi, There is 3 performance related changes.

The most important is that `jQuery.data` is a very costly call, especially in Firefox. And listening for `mousemove` events on body, generate a lot of calls. So I've replaced the `data` access by a simpler and lighter closure variable. http://jsperf.com/data-vs-variable

Also there was 2 useless event delegation handler. In that case regular are suffisant.

Regards.
