### PR TITLE
Remove inline onclick handlers

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1389,7 +1389,7 @@
             var container = $("<div></div>", {
                 "class": "select2-container"
             }).html([
-                "    <a href='#' onclick='return false;' class='select2-choice'>",
+                "    <a href='#' class='select2-choice'>",
                 "   <span></span><abbr class='select2-search-choice-close' style='display:none;'></abbr>",
                 "   <div><b></b></div>" ,
                 "</a>",
@@ -1488,7 +1488,7 @@
                     }
                 }
             }));
-
+            this.selection.bind("click", killEvent)
             this.search.bind("focus", this.bind(function() {
                 this.selection.attr("tabIndex", "-1");
             }));
@@ -2052,7 +2052,7 @@
             var choice=$(
                     "<li class='select2-search-choice'>" +
                     "    <div></div>" +
-                    "    <a href='#' onclick='return false;' class='select2-search-choice-close' tabindex='-1'></a>" +
+                    "    <a href='#' class='select2-search-choice-close' tabindex='-1'></a>" +
                     "</li>"),
                 id = this.id(data),
                 val = this.getVal(),


### PR DESCRIPTION
Using your plugin in a chrome extension, and chrome forbids inline onclick handlers:

> Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src 'self' chrome-extension-resource:".

See http://developer.chrome.com/extensions/contentSecurityPolicy.html

I've removed the two instances on onclick from select2. The first instance I swapped out to use your `killEvent` helper and the second one was superfluous since `killEvent` was being called in the handler anyway.
