### PR TITLE
Fix for z-index of search text box on single select

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -165,8 +165,9 @@ Version: @@ver@@ Timestamp: @@timestamp@@
 
 .select2-search {
   display: inline-block;
-    white-space: nowrap;
-    z-index: 10000;
+  white-space: nowrap;
+  z-index: 10000;
+  position: relative;
   min-height: 26px;
   width: 100%;
   margin: 0;


### PR DESCRIPTION
Using the select2 control in a jquery dialog works fine except for you cannot click on the input box when doing a single select select box. The containing div was given a z-index, but not a position attribute, so the z-index was ignored.
