### PR TITLE
formatSearching can be disabled

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1226,7 +1226,7 @@
                 }
                 return;
             }
-            else {
+            else if (opts.formatSearching() != null) {
                 render("<li class='select2-searching'>" + opts.formatSearching() + "</li>");
             }
 


### PR DESCRIPTION
formatSearching can be disabled by returning null from the function which allows the searching message to be disabled.

We need this for our use case as we want a first option in the dropdown of 'search everything' available like so ![](http://f.cl.ly/items/2Y1l0X101k2y262B3Y2e/Screen%20Shot%202012-09-21%20at%204.16.35%20PM.png)

Otherwise the dropdown will flicker to 'Searching...' as each character is pressed.

It can be used in the select2 options like so:

``` coffee
formatSearching: ->
    return
```

or javascript

``` javascript
formatSearching: function() {},
```
