### PR TITLE
Fixes 424: Improved Placeholder Detection

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1587,7 +1587,7 @@
         // single
         initSelection: function () {
             var selected;
-            if (this.opts.element.val() === "") {
+            if (this.opts.element.val() === "" && this.opts.element.text() === "") {
                 this.close();
                 this.setPlaceholder();
             } else {
@@ -1921,7 +1921,7 @@
         // multi
         initSelection: function () {
             var data;
-            if (this.opts.element.val() === "") {
+            if (this.opts.element.val() === "" && this.opts.element.text() === "") {
                 this.updateSelection([]);
                 this.close();
                 // set the placeholder if necessary


### PR DESCRIPTION
This fixes the issue in #424 where the value was blank, but it had text for the option.  This will automatically be selected as the default, as that is what the browser would normally do and is the default option without it.

A blank value with text in the tag is commonly used in frameworks such as Django.  It previously showed no text, instead of showing the provided text, and did not generate or any errors.
