### PR TITLE
Prepare for easier test automation: Make Select2 search field accessible by script

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1502,7 +1502,15 @@
             }));
             this.search.bind("blur", this.bind(function() {
                 if (!this.opened()) this.container.removeClass("select2-container-active");
-                window.setTimeout(this.bind(function() { this.selection.attr("tabIndex", this.opts.element.attr("tabIndex")); }), 10);
+                window.setTimeout(this.bind(function() {
+                    // restore original tab index
+                    var ti=this.opts.element.attr("tabIndex");
+                    if (ti) {
+                        this.selection.attr("tabIndex", ti);
+                    } else {
+                        this.selection.removeAttr("tabIndex");
+                    }
+                }), 10);
             }));
 
             selection.delegate("abbr", "mousedown", this.bind(function (e) {


### PR DESCRIPTION
...tically

Example:
$(obj).select2("search")  => reference to the input field, select2 shows as input element. This is very
                             convenient for automatic testing purposes
