### PR TITLE
Fixes #482: Mobile Safari issues

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1403,7 +1403,7 @@ the specific language governing permissions and limitations under the Apache Lic
             var container = $("<div></div>", {
                 "class": "select2-container"
             }).html([
-                "    <a href='#' onclick='return false;' class='select2-choice'>",
+                "    <a href='javascript:void(0)' onclick='return false;' class='select2-choice'>",
                 "   <span></span><abbr class='select2-search-choice-close' style='display:none;'></abbr>",
                 "   <div><b></b></div>" ,
                 "</a>",
@@ -2074,7 +2074,7 @@ the specific language governing permissions and limitations under the Apache Lic
             var choice=$(
                     "<li class='select2-search-choice'>" +
                     "    <div></div>" +
-                    "    <a href='#' onclick='return false;' class='select2-search-choice-close' tabindex='-1'></a>" +
+                    "    <a href='javascript:void(0)' onclick='return false;' class='select2-search-choice-close' tabindex='-1'></a>" +
                     "</li>"),
                 id = this.id(data),
                 val = this.getVal(),


### PR DESCRIPTION
This is a change to the code to fix the scrolling issues associated with Mobile Safari on iOS in #482.

Previously it would force the page to jump to the top, which would make it so you could not use Select2 on Mobile Safari.  This change prevents the jump and keeps it consistent across all of the browsers.
