### PR TITLE
Ajax loading of multi select2 choices defect

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -705,6 +705,10 @@ the specific language governing permissions and limitations under the Apache Lic
                         for (i = 0, l = results.length; i < l; i = i + 1) {
 
                             result=results[i];
+                            // if the element is already selectec, skip the following code
+                            try {
+                              if($.inArray(""+id(result), self.getVal()) != -1) continue;
+                            } catch(e) {}
                             selectable=id(result) !== undefined;
                             compound=result.children && result.children.length > 0;
 


### PR DESCRIPTION
Hi,

when loading choices for the multi select2 box, the choices list which is displayed shows already selected choices. Through this fix, already selected choices in the input field are filtered and therefore not displayed in the resulting choice list.

This is implemented through a simple check if it is already selected and an continue statement.

Cheers,
Johannes
