### PR TITLE
Pull request related to Issue #412

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -636,7 +636,7 @@ the specific language governing permissions and limitations under the Apache Lic
             search.bind("focus", function () { search.addClass("select2-focused"); if (search.val() === " ") search.val(""); });
             search.bind("blur", function () { search.removeClass("select2-focused");});
 
-            this.dropdown.delegate(resultsSelector, "mouseup", this.bind(function (e) {
+            this.dropdown.delegate(resultsSelector, "click", this.bind(function (e) {
                 if ($(e.target).closest(".select2-result-selectable:not(.select2-disabled)").length > 0) {
                     this.highlightUnderEvent(e);
                     this.selectHighlighted(e);


### PR DESCRIPTION
When the view area is shortest than the dropdown height, clicking on the select2 causes the scroll position of the page to change (because the search input is focused), this position change causes the cursor (still on mousedown) to go over an option and than the mouseup event selects this option and closes the select2. So you open and close it in a fraction of second selecting an option that you don't want. This keeps happening all the time.
