### PR TITLE
Feature: Allow placeholders with nonempty values

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1868,13 +1868,6 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // single
         getPlaceholder: function() {
-            // if a placeholder is specified on a single select without the first empty option ignore it
-            if (this.select) {
-                if (this.select.find("option").first().text() !== "") {
-                    return undefined;
-                }
-            }
-
             return this.parent.getPlaceholder.apply(this, arguments);
         },
 


### PR DESCRIPTION
The application I develop for has as standard of using a value of "-1" to indicate an "all" option, in order to distinguish it from something that was simply not specified (a "none" option). The existing structure in select2 only allows placeholders to be used with an option with a blank value and blank text, which means we have to do some fiddling to get the results to submit properly. I think this may be a common desire, as it seems very limiting to only allow an empty string as the placeholder value.

I modified the source to allow for two new options:

*placeholderValue: to be used in conjunction with the placeholder option. When specified, the placeholder is the option with that value, instead of the option with an empty string as the value. In this case, however, the text of the option must still be blank, and the placeholder text is defined by the placeholder option.
*placeholderIndex: to be used separately form placeholderValue and placeholder. When using a DOM select, setting the placeholderIndex will cause the option at that index to be used as the placeholder, regardless of its value or text. The placeholder text is taken directly from the option.

While minor, the inability to have nonempty placeholders is a serious barrier to using this otherwise great plugin in our application.
