### PR TITLE
Trivial change: pluralize default inputTooShort function

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2379,7 +2379,7 @@ the specific language governing permissions and limitations under the Apache Lic
         },
         formatResultCssClass: function(data) {return undefined;},
         formatNoMatches: function () { return "No matches found"; },
-        formatInputTooShort: function (input, min) { return "Please enter " + (min - input.length) + " more characters"; },
+        formatInputTooShort: function (input, min) { var n = min - input.length; return "Please enter " + n + " more character" + (n == 1? "" : "s"); },
         formatSelectionTooBig: function (limit) { return "You can only select " + limit + " item" + (limit == 1 ? "" : "s"); },
         formatLoadMore: function (pageNumber) { return "Loading more results..."; },
         formatSearching: function () { return "Searching..."; },


### PR DESCRIPTION
I have my minimumInputLength set at one so the "Please enter 1 more characters" message was bugging me. I tested the change on chrome, ff, and ie9.
