### PR TITLE
Fixed bug with closeOnSelecet is false

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2166,7 +2166,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             });
 
-            if (this.opts.closeOnSelect){
+            if (this.highlight() == -1){
                 choices.each2(function (i, choice) {
                     if (!choice.hasClass("select2-disabled") && choice.hasClass("select2-result-selectable")) {
                         self.highlight(0);


### PR DESCRIPTION
When closeOnSelecet is false, with a multi select, each time you select an item the dropdown scrolls all the way back up to the top which makes quickly selecting a bunch of adjacent items slower.
