### PR TITLE
Add documentation for 'close' event, fix #542

### DIFF
--- a/index.html
+++ b/index.html
@@ -1382,6 +1382,12 @@ Example: <pre class="prettyprint">alert("Selected value is: "+$("#e8").select2("
         </p>
     </div>
 </div>
+<div class="row">
+  <div class="span12">
+    <h3>close</h3>
+    <p>Fired when the dropdown is closed (whether by selection or cancellation).</p>
+  </div>
+</div>
 
 </section>
 


### PR DESCRIPTION
Added a simple mention of the `close` event. 
Not sure there's anything special to write about it.
