### PR TITLE
Fix of issue 550 Select2 and CSS Transforms: dropdown menu is off position

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -882,7 +882,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         positionDropdown: function() {
-            var offset = this.container.offset(),
+            var offset = { top: this.container[0].offsetTop, left: this.container[0].offsetLeft },
                 height = this.container.outerHeight(false),
                 width = this.container.outerWidth(false),
                 dropHeight = this.dropdown.outerHeight(false),


### PR DESCRIPTION
Fix of issue 550 Select2 and CSS Transforms: dropdown menu is off position:
https://github.com/ivaynberg/select2/issues/550

jquery offset() returns incorrect value when ancestor container has css transform applied to it, causing dropdown to appear in incorrect position.

Using { top: variable.offsetTop, left: variable.offsetLeft } instead of variable.offset() fixes this issue
