### PR TITLE
Multiple multiselect blur fails to close dropdown

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1759,7 +1759,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 this.select
                     .val(val)
                     .find(":selected").each2(function (i, elm) {
-                        data = {id: elm.attr("value"), text: elm.text()};
+                        data = {id: elm.attr("value"), text: elm.text(), locked: elm.data("locked")};
                         return false;
                     });
                 this.updateSelection(data);
@@ -2294,7 +2294,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             if (this.select) {
                 this.select.find(":selected").each(function () {
-                    data.push({id: $(this).attr("value"), text: $(this).text()});
+                    data.push({id: $(this).attr("value"), text: $(this).text(), locked: $(this).data("locked")});
                 });
                 this.updateSelection(data);
                 this.triggerChange();


### PR DESCRIPTION
Tested with select2 3.2 and the latest from master.

Moving between multiple multi-selects on the same page does not close the dropdown on the initially-focused multi-select. Example jsfiddle here:
http://jsfiddle.net/timbonicus/KZbah/2/

Clicking on the first multiselect and then the single select, the dropdown closes properly on blur. Clicking the first multiselect and then the second multiselect, both remain open.
