### PR TITLE
Allow method 'clear' to be called

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2333,7 +2333,7 @@ the specific language governing permissions and limitations under the Apache Lic
         var args = Array.prototype.slice.call(arguments, 0),
             opts,
             select2,
-            value, multiple, allowedMethods = ["val", "destroy", "opened", "open", "close", "focus", "isFocused", "container", "onSortStart", "onSortEnd", "enable", "disable", "positionDropdown", "data"];
+            value, multiple, allowedMethods = ["val", "destroy", "opened", "open", "close", "focus", "isFocused", "container", "onSortStart", "onSortEnd", "enable", "disable", "positionDropdown", "data", "clear"];
 
         this.each(function () {
             if (args.length === 0 || typeof(args[0]) === "object") {


### PR DESCRIPTION
Allows the method 'clear' to be called using $('#select2').select2("clear").
