### PR TITLE
Update context from callback data on `query` call

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1189,6 +1189,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     }
                     self.positionDropdown();
                     self.resultsPage = page;
+                    self.context = data.context;
                 })});
             }
         },


### PR DESCRIPTION
My test case is:

``` javascript
$('#my_select').select2({
    minimumInputLength: 1,
    query: function(options) {
        var context = (options.context || 0) + 1;
        var data = {
            results: [{id: 1, text: ""+context}],
            context: context,
            more: context < 20
        };
        options.callback(data);
    }
})
```

I expected a paged select list of [1,2,3,4,5...20].

Instead I got a list of [1,2,2,2,2,......2].

This commit updates the context on a query callback which I believe is the correct thing to do.
