### PR TITLE
Add option for selectOnExternalMouseDown

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -520,8 +520,7 @@ the specific language governing permissions and limitations under the Apache Lic
                         var el = $(this).data("select2");
                         if (el.opts.selectOnExternalMouseDown)
                             el.selectHighlighted();
-                        else
-                            el.blur();
+                        el.blur();
                     }
                 });
             }


### PR DESCRIPTION
Add ability to have the value be selected, when the user clicks outside of the select2 control.  Added selectOnExternalMouseDown to the options, to make it optional. 
