### PR TITLE
Firefox Tab and Enter keys issue.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1584,6 +1584,9 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             }));
             selection.bind("keypress", this.bind(function(e) {
+		if (e.which == KEY.DELETE || e.which == KEY.BACKSPACE || e.which == KEY.TAB || e.which == KEY.ENTER || e.which == 0) {
+			return
+		}
                 var key = String.fromCharCode(e.which);
                 this.search.val(key);
                 this.open();


### PR DESCRIPTION
<b>Problems:</b>
1. When item is selected by enter, the list is reopened.
2. Also pressing tab on focused element with drop list cause immediate reopening with empty search result list.
<b>Condition: </b>
This issue occurs only on master. 
<b>Reason:</b>
This problem occurred because Firefox catches the Tab and Enter keys in the keypress event. And e.which return zero when Tab key is pressed. 
<b>Note: </b>
It was described here #461 and here #570 (with examples).
Probably it was broken in commit 4b1204c, because right before this commit (on version 908c358) it works fine.

I tested it on IE7, IE8, IE9, FireFox 16.0.2 (MacOs), Chrome 23.0.1271.91(MacOs) and Safari 6.0.1(MacOs). 
