### PR TITLE
Fix for #607: Handle case when blank option is last and marked as selected

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1654,7 +1654,6 @@ the specific language governing permissions and limitations under the Apache Lic
                 first = this.select.find('option:first');
                 selected = this.select.find('option:selected');
 
-
                 if ((selected.length && selected.text() !== "") || 
                     (!selected.length && first.text() !== "")) return;
 
@@ -1725,6 +1724,10 @@ the specific language governing permissions and limitations under the Apache Lic
             if (this.opts.allowClear && this.getPlaceholder() !== undefined) {
                 this.selection.find("abbr").show();
             }
+
+            // Reapply the placeholder. This handles the case when user
+            // reselects a blank option that happens to be the last one.
+            this.setPlaceholder();
         },
 
         // single


### PR DESCRIPTION
This fix adds a check for blank OPTION tag that has `selected` attribute in addition to check for blank first option, and also retriggers `setPlaceholder` in `updateSelection` so that placeholder is reapplied when user reselects the blank option. Tested other use cases, and it doesn't seem this patch breaks them.
