### PR TITLE
Option to set clear value when clicking "x"

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1601,9 +1601,7 @@ the specific language governing permissions and limitations under the Apache Lic
             if (this.select) {
                 this.opts
                     .element
-                    .find(":selected").each2(function () {
-                        this.removeAttribute("selected");
-                    });
+                    .val($("option:first").val());
             } else {
                 this.opts.element.val("");
             }


### PR DESCRIPTION
This allows you to override the default of clearing to a value of `""`, for example you could set `clearValue: "0"` to make the x created by `allowClear` reset to `option[value="0"]`.

I added this because I have legacy code where sometimes the default value is `0`, thought it might be useful to give this option to others, it will work with any string.

Default is set to `""` like before.
