### PR TITLE
Fix for more than one multi-select being open at the same time

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -509,16 +509,19 @@ the specific language governing permissions and limitations under the Apache Lic
     $document.ready(function () {
         $document.bind("mousedown touchend", function (e) {
             var target = $(e.target).closest("div.select2-container").get(0), attr;
+            var targetDropdown = null;
             if (target) {
                 $document.find("div.select2-container-active").each(function () {
                     if (this !== target) $(this).data("select2").blur();
                 });
-            } else {
-                target = $(e.target).closest("div.select2-drop").get(0);
-                $document.find("div.select2-drop-active").each(function () {
-                    if (this !== target) $(this).data("select2").blur();
-                });
+                targetDropdown = $(target).data('select2').dropdown.get(0);
             }
+
+            // close any other active dropdowns
+            target = targetDropdown || $(e.target).closest("div.select2-drop").get(0);
+            $document.find("div.select2-drop-active").each(function () {
+                if (this !== target) $(this).data("select2").blur();
+            });
 
             target=$(e.target);
             attr = target.attr("for");


### PR DESCRIPTION
On Chrome, FF, and Safari the dropdowns for multi-selects don't blur properly when another multi-select is clicked (IE seems to work fine).  I found that this would trip up my selenium tests as they couldn't figure out which dropdown to manipulate. 

Before the fix, the mousedown/touchend event would only close the other active dropdowns if the target of the event wasn't a select2 element.  With the fix, if the target is a select2 element then we find out which dropdown it spawned and blur the other active dropdowns.

Here's the original behavior: http://jsfiddle.net/FPNTa/
and with the fix: http://jsfiddle.net/FPNTa/1/
