### PR TITLE
Update select2.js

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1522,7 +1522,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 if (!this.opened()) this.container.removeClass("select2-container-active");
                 window.setTimeout(this.bind(function() {
                     // restore original tab index
-                    var ti=this.opts.element.attr("tabIndex");
+                    var ti=this.opts.element.attr("tabIndex") || 0;
                     if (ti) {
                         this.selection.attr("tabIndex", ti);
                     } else {
@@ -1565,7 +1565,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 if (!this.opened()) {
                     this.container.removeClass("select2-container-active");
                 }
-                window.setTimeout(this.bind(function() { this.search.attr("tabIndex", this.opts.element.attr("tabIndex")); }), 10);
+                window.setTimeout(this.bind(function() { this.search.attr("tabIndex", this.opts.element.attr("tabIndex") || 0); }), 10);
             }));
 
             selection.bind("keydown", this.bind(function(e) {


### PR DESCRIPTION
`jQuery("input#someId").attr("tabIndex")` don't work well in new jQuery 1.8+.
When you try this on field  that don't have tabIndex attr you get undefined 
(but `document.getElementById("someId").tabIndex returns '0'`).
This is why Select2 element onBlur stay whit attr `tabindex='-1'` 
and you can't navigate form with 'tab' key.
This simple `|| 0` fix this bug.
