### PR TITLE
Ability to specify a containing element for the dropdown (minimal and easier way)

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -582,7 +582,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.container.attr("id", this.containerId);
 
             // cache the body so future lookups are cheap
-            this.body = thunk(function() { return opts.element.closest("body"); });
+            this.body = thunk(function() { return opts.dropdownContainer || opts.element.closest("body"); });
 
             if (opts.element.attr("class") !== undefined) {
                 this.container.addClass(opts.element.attr("class").replace(/validate\[[\S ]+] ?/, ''));


### PR DESCRIPTION
Fix : #556
Fix : #600

This patch fixes #556 as @zacharynicoll started with a cleaner solution. It brings a total isolation of select2 component.

This patch fixes #600 as well since developper this way : 

``` javascript
$("#select").select2({
  dropdownContainer  : $("#select").closest(".modal")
});
```

Tested on FF, IE8, IE9, IE10
