### PR TITLE
Update select2.js fixing formatSelection on plugin init.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1831,7 +1831,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
                     var data = [];
                     element.find(":selected").each2(function (i, elm) {
-                        data.push({id: elm.attr("value"), text: elm.text(), element: elm});
+                        data.push({id: elm.attr("value"), text: elm.text(), element: $(this)});
                     });
 
                     if ($.isFunction(callback))


### PR DESCRIPTION
Multi select, on items that are selected="selected". On select2 init, the element is undefined. Can also wrap $(elm) as well instead of $(this).

I realized my formatSelection was missing the element property thus causing it to not work correctly.
