### PR TITLE
Allow to pass a callback as ajax.url configuration parameter

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -316,7 +316,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 if( null !== handler) { handler.abort(); }
 
                 handler = transport.call(null, {
-                    url: options.url,
+                    url: ((typeof options.url === 'function')?options.url():options.url),
                     dataType: options.dataType,
                     data: data,
                     type: type,


### PR DESCRIPTION
In some cases, it can be useful to have a callback denoting the url used for the ajax call made by select2.

My use case : 2 "hierarchical" select menus, let's say country and zipcode. When I select the country, I want to filter the zipcodes retrieved by select2 given a URL where I provide the selected country

=> zipcodes' ajax url should be dependent on current selected country.

I would then be able to write something like this : 

```
$("#zipcodes").select2({ ajax: { url: function(){ return "http://my.zipcodes.service/country/"+$("#countries").val()+"/zipcodes"; } });
```

For the moment, the only way to solve this problem is :
- re-create a new select2() wrapper after each country selection, which seems a perf killer
- provide the country as GET query param ... but If I can't modify accessed url, it is a no-op
- implement my own query impl ... just to be able to have a url callback

I tried to update the documentation too, but I don't know if this is possible to make a pull request on 2 different branches at the same time (update on documentation is minimalistic, just saying url parameter can be a function returning the ajax url).
