### PR TITLE
Added contentType to ajax helper options

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -321,6 +321,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     data: data,
                     type: type,
                     traditional: traditional,
+                    contentType: options.contentType,
                     success: function (data) {
                         if (requestNumber < requestSequence) {
                             return;


### PR DESCRIPTION
If the contentType is specified in the ajax helper options, then it is used when making the ajax request.

In response to #492.
