### PR TITLE
Add missing parantheses and allow empty ajax.data

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -311,7 +311,11 @@ the specific language governing permissions and limitations under the Apache Lic
                     traditional = options.traditional || false,
                     type = options.type || 'GET'; // set type of request (GET or POST)
 
-                data = data.call(this, query.term, query.page, query.context);
+
+                if(data)
+                    data = data.call(this, query.term, query.page, query.context);
+                else
+                    data = null;
 
                 if( null !== handler) { handler.abort(); }
 
@@ -1432,12 +1436,11 @@ the specific language governing permissions and limitations under the Apache Lic
         // single
 
 		createContainer: function () {
-            var container = $(document.createElement("div").attr({
+            var container = $(document.createElement("div")).attr({
                 "class": "select2-container"
-            }).html([
-                "    <a href='javascript:void(0)' onclick='return false;' class='select2-choice'>",
+            }).html(["    <a href='javascript:void(0)' onclick='return false;' class='select2-choice'>",
                 "   <span></span><abbr class='select2-search-choice-close' style='display:none;'></abbr>",
-                "   <div><b></b></div>" ,
+                "   <div><b></b></div>",
                 "</a>",
                 "    <div class='select2-drop select2-offscreen'>" ,
                 "   <div class='select2-search'>" ,
@@ -1830,7 +1833,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // multi
         createContainer: function () {
-            var container = $(document.createElement("div").attr({
+            var container = $(document.createElement("div")).attr({
                 "class": "select2-container select2-container-multi"
             }).html([
                 "    <ul class='select2-choices'>",


### PR DESCRIPTION
I use select2's ajax function to get a list for autocompletion. However I'm not sending json to the server, the query is only in the url, hence I don't need data in 

`ajax:{ url:...., data: function(){...}, ....}`

when I emit data, I get an error because select2 goes `data.call(...` somewhere on line 315 or so.

My change allows data to be empty, which is set to null in the script if data is undefined.

I think it's a common use-case to not send json when doing simple queries, so having data empty should be allowed...

Please :)
