### PR TITLE
Avoid error when label has no matching element

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -529,7 +529,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 attr = attr.replace(/([\[\].])/g,'\\$1'); /* escapes [, ], and . so properly selects the id */
                 target = $("#"+attr);
                 target = target.data("select2");
-                if (target !== undefined) { target.focus(); e.preventDefault();}
+                if (target !== undefined && target !== null) { target.focus(); e.preventDefault();}
             }
         });
     });


### PR DESCRIPTION
$('#no_such_element').data("select2") returns null rather than
undefined (jQuery 1.9.0).

http://jsfiddle.net/gnv3W/
