### PR TITLE
add clearEnable option to enable selection

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1524,7 +1524,14 @@ the specific language governing permissions and limitations under the Apache Lic
             }));
 
             selection.delegate("abbr", "mousedown", this.bind(function (e) {
-                if (!this.enabled) return;
+                if (!this.enabled) {
+                   if (this.opts.clearEnable) {
+                       this.enable();
+                       this.open();
+                   } else {
+                       return;
+                   }
+                }
                 this.clear();
                 killEventImmediately(e);
                 this.close();


### PR DESCRIPTION
If this option is set to true and allowClear is set to true as well and the
select is disabled, this patch allows the user to click on the clear button
to enable the select.

This is patch to feature request #749
