### PR TITLE
Ajax `url` option (when function) now called with same arguments and context as `data` option

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -286,16 +286,18 @@ the specific language governing permissions and limitations under the Apache Lic
                 requestSequence += 1; // increment the sequence
                 var requestNumber = requestSequence, // this request's sequence number
                     data = options.data, // ajax data function
+                    url = options.url, // ajax url string or function
                     transport = options.transport || $.ajax,
                     traditional = options.traditional || false,
                     type = options.type || 'GET'; // set type of request (GET or POST)
 
                 data = data ? data.call(this, query.term, query.page, query.context) : null;
+                url = (typeof url === 'function') ? url.call(this, query.term, query.page, query.context) : url;
 
                 if( null !== handler) { handler.abort(); }
 
                 handler = transport.call(null, {
-                    url: ((typeof options.url === 'function')?options.url():options.url),
+                    url: url,
                     dataType: options.dataType,
                     data: data,
                     type: type,


### PR DESCRIPTION
Builds on #692.  The constructed URL may need to incorporate the information about the current query, for example if the URL includes the search terms directly in the path.
