### PR TITLE
Highlighting broken with multiple: true and closeOnSelect: false

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1126,7 +1126,7 @@ the specific language governing permissions and limitations under the Apache Lic
         highlightUnderEvent: function (event) {
             var el = $(event.target).closest(".select2-result-selectable");
             if (el.length > 0 && !el.is(".select2-highlighted")) {
-                var choices = this.results.find('.select2-result').not(".select2-selected");
+                var choices = this.results.find('.select2-result:visible');
                 this.highlight(choices.index(el));
             } else if (el.length == 0) {
                 // if we are over an unselectable item remove al highlights


### PR DESCRIPTION
The index of the current choice being moused-over was being passed into highlight.  However, in `highlightUnderEvent`, the index was being calculated against all .select2-result choices, which included selected options.  In `highlight`, the index was being calculated against only visible elements.  

An alternate fix might be:
`var choices = this.results.find('.select2-result:visible');` 
since this seems to duplicate the logic in `highlight`.  

The symptoms for this seemed similar to #348, but that fix is still on master; I think the implementation of `highlight` has evolved since that fix, which may have caused the issue to resurface.
