### PR TITLE
Issue #529: Fire highlight event when an element is highlighted in the select2 list.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1101,7 +1101,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         highlight: function (index) {
-            var choices = this.results.find(".select2-result:visible");
+            var data, choices = this.results.find(".select2-result:visible");
 
             if (arguments.length === 0) {
                 return indexOf(choices.filter(".select2-highlighted")[0], choices.get());
@@ -1115,6 +1115,10 @@ the specific language governing permissions and limitations under the Apache Lic
             $(choices[index]).addClass("select2-highlighted");
             this.ensureHighlightVisible();
 
+            data = $(choices[index]).data("select2-data");
+            if (data) {
+              this.opts.element.trigger({ type: "highlight", val: this.id(data) });
+            }
         },
 
         // abstract


### PR DESCRIPTION
Fix issue #529 by firing off a "highlight" event when an element is highlighted in the select2 dropdown. The event has a val property which is the id of the currently highlighted option (which is consistent with the change event).
