### PR TITLE
Adding defensive check during the document mousedown/touchend event handler.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -482,7 +482,7 @@ the specific language governing permissions and limitations under the Apache Lic
         $document.bind("mousedown touchend", function (e) {
             var target = $(e.target).closest("div.select2-container").get(0), attr;
             var targetDropdown = null;
-            if (target) {
+            if (target && $(target).data("select2") ) {
                 $document.find("div.select2-container-active").each(function () {
                     if (this !== target) $(this).data("select2").blur();
                 });


### PR DESCRIPTION
There is currently a global listener (not bound to the lifecycle of any particular select2 control).  This handler was throwing an error if the select2 control did not exist by the time processing occurred - for example, if select2("destroy") was called first.  

Feels like this event handler should perhaps not be global and instead be bound to each individual select2 instance, and automatically removed on calls to select2.destroy, but wasn't sure from code inspection what side effect this might have.

Solution to avoid throwing the error was to add a defensive check in the event handler to first ensure that the target.data("select2") was not empty before proceeding.
