### PR TITLE
Fix issue introduced by 20950e0.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1126,7 +1126,7 @@ the specific language governing permissions and limitations under the Apache Lic
         highlightUnderEvent: function (event) {
             var el = $(event.target).closest(".select2-result-selectable");
             if (el.length > 0 && !el.is(".select2-highlighted")) {
-        		var choices = this.results.find('.select2-result');
+        		var choices = this.results.find('.select2-result:visible');
                 this.highlight(choices.index(el));
             } else if (el.length == 0) {
                 // if we are over an unselectable item remove al highlights


### PR DESCRIPTION
Selected items and other invisible items were not ignored by highlightUnderEvent when calculating index.
This caused highlighting of incorrect items when the list contained hidden items.
