### PR TITLE
#619 : val takes an optional argument to avoid triggering 'change'

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1736,13 +1736,17 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // single
         val: function () {
-            var val, data = null, self = this;
+            var val, triggerChange = true, data = null, self = this;
 
             if (arguments.length === 0) {
                 return this.opts.element.val();
             }
 
             val = arguments[0];
+
+            if (arguments.length > 1) {
+                triggerChange = arguments[1];
+            }
 
             if (this.select) {
                 this.select
@@ -1753,7 +1757,9 @@ the specific language governing permissions and limitations under the Apache Lic
                     });
                 this.updateSelection(data);
                 this.setPlaceholder();
-                this.triggerChange();
+                if (triggerChange) {
+                    this.triggerChange();
+                }
             } else {
                 if (this.opts.initSelection === undefined) {
                     throw new Error("cannot call val() if initSelection() is not defined");
@@ -1761,7 +1767,9 @@ the specific language governing permissions and limitations under the Apache Lic
                 // val is an id. !val is true for [undefined,null,'']
                 if (!val) {
                     this.clear();
-                    this.triggerChange();
+                    if (triggerChange) {
+                        this.triggerChange();
+                    }
                     return;
                 }
                 this.opts.element.val(val);
@@ -2278,7 +2286,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // multi
         val: function () {
-            var val, data = [], self=this;
+            var val, triggerChange = true, data = [], self=this;
 
             if (arguments.length === 0) {
                 return this.getVal();
@@ -2286,11 +2294,17 @@ the specific language governing permissions and limitations under the Apache Lic
 
             val = arguments[0];
 
+            if (arguments.length > 1) {
+                triggerChange = arguments[1];
+            }
+
             if (!val) {
                 this.opts.element.val("");
                 this.updateSelection([]);
                 this.clearSearch();
-                this.triggerChange();
+                if (triggerChange) {
+                    this.triggerChange();
+                }
                 return;
             }
 
@@ -2302,7 +2316,9 @@ the specific language governing permissions and limitations under the Apache Lic
                     data.push({id: $(this).attr("value"), text: $(this).text()});
                 });
                 this.updateSelection(data);
-                this.triggerChange();
+                if (triggerChange) {
+                    this.triggerChange();
+                }
             } else {
                 if (this.opts.initSelection === undefined) {
                     throw new Error("val() cannot be called if initSelection() is not defined")
@@ -2313,7 +2329,9 @@ the specific language governing permissions and limitations under the Apache Lic
                     self.setVal(ids);
                     self.updateSelection(data);
                     self.clearSearch();
-                    self.triggerChange();
+                    if (triggerChange) {
+                        self.triggerChange();
+                    }
                 });
             }
             this.clearSearch();

--- a/test-619.html
+++ b/test-619.html
@@ -1,0 +1,28 @@
+<html>
+  <head>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+    <link href="select2.css" rel="stylesheet"/>
+    <script type="text/javascript" src="select2.js"></script>
+ </head>
+ <body>
+   <select id="s1">
+     <option value="A"></option>
+     <option value="B"></option>
+   </select>
+
+    <script type="text/javascript">
+      $(document).ready(function () {
+      $("#s1").select2({}).on("change", function () {
+         alert("Changed caused by val()");
+      }).select2("val", "A");
+
+      // This should not trigger a change
+      $("#s1").select2("val", "B", false);
+      });
+
+    </script>
+
+
+ </body>
+
+</html>


### PR DESCRIPTION
This is a suggested fix for this issue #619 

I simply added an optional 'triggerChange' argument to the two "val" functions, and used it to avoid triggering (as demonstrated by the test-619.html file). 

Although, I'm not sure where to document it, nor if the setVal function should also be changed. 

Hoping this helps. 

Thanks
PH
