### PR TITLE
Added ability to specify tags within the HTML-tag

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2387,6 +2387,11 @@ the specific language governing permissions and limitations under the Apache Lic
                     multiple = opts.element.attr("multiple");
                 } else {
                     multiple = opts.multiple || false;
+                    
+                    if ($.isArray(opts.element.data("select2Tags")) && opts.element.data("select2Tags").length > 0) {
+                        opts.tags = opts.element.data('select2Tags');
+                    }
+                    
                     if ("tags" in opts) {opts.multiple = multiple = true;}
                 }
 


### PR DESCRIPTION
It's now possible to specify tags using a JSON-encoded array using the attribute 'data-select2-tags'.
