### PR TITLE
Added support to display optgroup name as prefix for value in multiple instances

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -759,7 +759,13 @@ the specific language governing permissions and limitations under the Apache Lic
                         var group;
                         if (element.is("option")) {
                             if (query.matcher(term, element.text(), element)) {
-                                collection.push({id:element.attr("value"), text:element.text(), element: element.get(), css: element.attr("class"), disabled: equal(element.attr("disabled"), "disabled") });
+                            	// if groupPrefix is set and a 
+                            	if(opts.groupPrefix && (element.val().length > 0 && element.parent().is('optgroup'))){
+                            	    collection.push({id:element.attr("value"), text:element.parent().attr('label')+": "+element.text(), element: element.get(), css: element.attr("class"), disabled: equal(element.attr("disabled"), "disabled") });
+                            	}
+                            	else{
+                            	    collection.push({id:element.attr("value"), text:element.text(), element: element.get(), css: element.attr("class"), disabled: equal(element.attr("disabled"), "disabled") });
+                            	}
                             }
                         } else if (element.is("optgroup")) {
                             group={text:element.attr("label"), children:[], element: element.get(), css: element.attr("class")};
@@ -2442,6 +2448,7 @@ the specific language governing permissions and limitations under the Apache Lic
         formatSelectionTooBig: function (limit) { return "You can only select " + limit + " item" + (limit == 1 ? "" : "s"); },
         formatLoadMore: function (pageNumber) { return "Loading more results..."; },
         formatSearching: function () { return "Searching..."; },
+        groupPrefix: false,
         minimumResultsForSearch: 0,
         minimumInputLength: 0,
         maximumInputLength: null,


### PR DESCRIPTION
Added optgroup labels to options to help with clarity when select has multiple enabled.

Example:

```
<select class="prefix" multiple="multiple">
    <optgroup label="Group1">
        <option>itemA</option>
        <option>itemC</option>
    </optgroup>
    <optgroup label="Group2">
        <option>itemA</option>
        <option>itemB</option>
        <option>itemD</option>
    </optgroup>
</select>
$('.prefix').select2({groupPrefix: true });
```

Displayed selected items will now look like:

<kbd>Group1: itemA</kbd> <kbd>Group2: itemA</kbd> <kbd>Group2: itemB</kbd>
