### PR TITLE
Add 'selected' and 'removed' events

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1835,6 +1835,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.opts.element.val(this.id(data));
             this.updateSelection(data);
+            this.opts.element.trigger({ type: "select", val: this.id(data), choice: data });
             this.close();
 
             if (!options || !options.noFocus)


### PR DESCRIPTION
I have a use case where I need to grab the value from a Select2 instance when a value is highlighted, but then restore the value if nothing was actually selected. I can grab the value in the new `highlight` event, but having trouble cleaning up (reverting to the previous value if nothing was selected).  

The `change` event doesn't quite work here because it only fires if the value changes, and it fires after the `close` event. So I've added a really simple `select` event to fire when an item is selected, so I can do something like this:

``` javascript
var $selected = false,
     $fontSize = null,
     $oldFontSize = null; 

elem.select()
    .on('open', function() { $selected = false; $oldFontSize = $fontSize; })
    .on('highlight', function(e) { $fontSize = e.val; })
    .on('select', function(e) { $selected = true; })
    .on('close', function(e) { if (!$selected) { $fontSize = $oldFontSize; } });
```

The code above will update the $fontSize variable 'live' with mouse/keyboard interaction, and revert the value if nothing was actually selected.
