### PR TITLE
Better imitate native experience on iOS

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -309,6 +309,7 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     position: relative;
     overflow-x: hidden;
     overflow-y: auto;
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
 .select2-results ul.select2-result-sub {

--- a/select2.js
+++ b/select2.js
@@ -648,7 +648,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.initContainerWidth();
 
             installFilteredMouseMove(this.results);
-            this.dropdown.delegate(resultsSelector, "mousemove-filtered", this.bind(this.highlightUnderEvent));
+            this.dropdown.delegate(resultsSelector, "mousemove-filtered touchstart touchmove touchend", this.bind(this.highlightUnderEvent));
 
             installDebouncedScroll(80, this.results);
             this.dropdown.delegate(resultsSelector, "scroll-debounced", this.bind(this.loadMoreIfNeeded));


### PR DESCRIPTION
This removes the grey box that shows up when you select an option on iOS.  This prevented users from being able to preview their selection, which was a major issue I found.  This also highlights the selected option in a more reliable fashion than before, by using the touch events.

I did not add the touch event handlers to the `mousemove-filtered` events because it was not passing along the events with enough consistency.
