### PR TITLE
Add blur/focus event triggerings (#798)

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1737,7 +1737,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     this.container.removeClass("select2-container-active");
                 }
                 if (!this.container.hasClass("select2-container-active")) {
-                    this.opts.element.trigger('select2:blur');
+                    this.opts.element.trigger('blur');
                 }
             }));
             this.search.bind("focus", this.bind(function(){
@@ -1748,7 +1748,7 @@ the specific language governing permissions and limitations under the Apache Lic
             }));
             this.search.bind("blur", this.bind(function(){
                 if (!this.container.hasClass("select2-container-active")) {
-                    this.opts.element.trigger('select2:blur');
+                    this.opts.element.trigger('blur');
                 }
             }));
 


### PR DESCRIPTION
An attempt to add blur/focus events.  Related to issue #798

I ran in to problems using the real 'blur' and 'focus' events, so I simplified the problem by using 'select2:blur' and 'select2:focus.'

Also, when switching between the `container` and `search`, a blur and focus event are emitted.  I'd like to avoid that, if possible, but I'm not sure how to, and it's late.
