### PR TITLE
fix to allow distinct data-ajax-url attributes on individual select2 widgets

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -340,7 +340,8 @@ the specific language governing permissions and limitations under the Apache Lic
         var timeout, // current scheduled but not yet executed request
             requestSequence = 0, // sequence used to drop out-of-order responses
             handler = null,
-            quietMillis = options.quietMillis || 100;
+            quietMillis = options.quietMillis || 100,
+            ajaxUrl = options.url;
 
         return function (query) {
             window.clearTimeout(timeout);
@@ -348,7 +349,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 requestSequence += 1; // increment the sequence
                 var requestNumber = requestSequence, // this request's sequence number
                     data = options.data, // ajax data function
-                    url = options.url, // ajax url string or function
+                    url = ajaxUrl, // ajax url string or function
                     transport = options.transport || $.ajax,
                     type = options.type || 'GET', // set type of request (GET or POST)
                     params = {};


### PR DESCRIPTION
Because a shared options object is passed around when creating each
instance of a select2 widget, the query function that was built would
use the last ajax url that was set on the options object for all select2
widgets. If the ajax url is set via the data-ajax-url then each select item should be allowed to have a distinct url for fetching options. Currently the last url encountered is used by all calls.
