### PR TITLE
Update select2.js for <option>Text only</option>

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -803,7 +803,7 @@ the specific language governing permissions and limitations under the Apache Lic
                         var group;
                         if (element.is("option")) {
                             if (query.matcher(term, element.text(), element)) {
-                                collection.push({id:element.attr("value"), text:element.text(), element: element.get(), css: element.attr("class"), disabled: equal(element.attr("disabled"), "disabled") });
+                                collection.push({id:element.val(), text:element.text(), element: element.get(), css: element.attr("class"), disabled: equal(element.attr("disabled"), "disabled") });
                             }
                         } else if (element.is("optgroup")) {
                             group={text:element.attr("label"), children:[], element: element.get(), css: element.attr("class")};


### PR DESCRIPTION
If there's only text on <option> but "value" attribute, it should use text, use element.val() instead of element.attr("value")
