### PR TITLE
Searching mode in dropdown while searching

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1363,7 +1363,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 postRender(stayActive);
             }
 
-            var maxSelSize = $.isFunction(opts.maximumSelectionSize) ? opts.maximumSelectionSize() : opts.maximumSelectionSize;
+            var maxSelSize = this.getMaximumSelectionSize();
             if (maxSelSize >=1) {
                 data = this.data();
                 if ($.isArray(data) && data.length >= maxSelSize && checkFormatter(opts.formatSelectionTooBig, "formatSelectionTooBig")) {


### PR DESCRIPTION
Fix for issue #943. Make the dropdown go into searching mode while searching and ensure spinner shows during this period as well.
