### PR TITLE
Makes it so we don't query every time we select when maximumSelectionSize is 0

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2325,7 +2325,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 if (this.countSelectableResults()>0) {
                     this.search.width(10);
                     this.resizeSearch();
-                    if (this.val().length >= this.getMaximumSelectionSize()) {
+                    if (this.getMaximumSelectionSize() > 0 && this.val().length >= this.getMaximumSelectionSize()) {
                         // if we reached max selection size repaint the results so choices
                         // are replaced with the max selection reached message
                         this.updateResults(true);


### PR DESCRIPTION
a maximumSelectionSize of zero means unlimited, which means 
we shouldn't be updating results if it's set to 0
