### PR TITLE
.select2("data", null) causes an error

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2701,7 +2701,7 @@ the specific language governing permissions and limitations under the Apache Lic
         minimumInputLength: 0,
         maximumInputLength: null,
         maximumSelectionSize: 0,
-        id: function (e) { return e.id; },
+        id: function (e) { return e == undefined ? null : e.id; },
         matcher: function(term, text) {
             return (''+text).toUpperCase().indexOf((''+term).toUpperCase()) >= 0;
         },


### PR DESCRIPTION
bugfix: .select2("data", null) for remote datasource causes an error "ReferenceError: e is not defined"
