### PR TITLE
Fix: IE Class Retention (Issue #937)

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2724,8 +2724,8 @@ the specific language governing permissions and limitations under the Apache Lic
             });
         },
         blurOnChange: false,
-        selectOnBlur: false,
-        adaptContainerCssClass: function(c) { return c; },
+        selectOnBlur: false,   
+        adaptContainerCssClass: function(c) { if (typeof c === 'object' && c.length) return c + ''; return c; },
         adaptDropdownCssClass: function(c) { return null; }
     };
 


### PR DESCRIPTION
In adaptContainerCssClass, variable "c" in a string in FF, but an object in IE.  We've adapted the function so that if it is an object and has a length, then return it as a string, otherwise to return the object (null/undefined?)

This should fix https://github.com/ivaynberg/select2/issues/937
Credit to @frntz for also identifying the origin of the issue
