### PR TITLE
Centering select2 vertically

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -7,7 +7,7 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     /* inline-block for ie7 */
     zoom: 1;
     *display: inline;
-    vertical-align: top;
+    vertical-align: middle;
 }
 
 .select2-container,


### PR DESCRIPTION
This makes Select2 behave much more sane when it's put inline inbetween
text.

Obviously, this is not the silver bullet, but I think it's a more sane default. Specific requirements should obviously be dealt with in additional CSS.

This fixes #1031.
