### PR TITLE
Bugfix: Avoid implosion of empty <option>s

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -339,6 +339,8 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     margin: 0;
     cursor: pointer;
 
+    min-height: 1em;
+
     -webkit-touch-callout: none;
       -webkit-user-select: none;
        -khtml-user-select: none;


### PR DESCRIPTION
When using select2 on

``` html
<select>
  <option value="empty"></option>
  <option>Val 1</option>
  <option>Val 2</option>
</select>
```

The top option will not have the correct height.

This fixes #1041.
