### PR TITLE
Fix : #600

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -611,7 +611,15 @@ the specific language governing permissions and limitations under the Apache Lic
             this.container.attr("id", this.containerId);
 
             // cache the body so future lookups are cheap
-            this.body = thunk(function() { return opts.element.closest("body"); });
+            this.body = thunk(function() {
+	            if (opts.dropdownContainer === undefined || opts.dropdownContainer === "body") {
+	            	return opts.element.closest("body");
+	            }
+	            if (opts.dropdownContainer === "auto") {
+	            	return opts.element.closest("[position='absolute']") || opts.element.closest("body");
+	            }
+            	return opts.dropdownContainer;
+            });
 
             syncCssClasses(this.container, this.opts.element, this.opts.adaptContainerCssClass);
 


### PR DESCRIPTION
New pull request for #600.
Add dropdownContainer with the possible values :
"body" - default - use body
"auto" - closest absolute
jquery/dom node - use as is

Works very well with IE8+, without any overlapping issue
![select2-ie8](https://f.cloud.github.com/assets/579170/269915/d8a475f0-8fb2-11e2-8a41-1c475924925d.png)
