### PR TITLE
Add option to automatically size dropdown width

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -147,6 +147,15 @@ Version: @@ver@@ Timestamp: @@timestamp@@
             box-shadow: 0 4px 5px rgba(0, 0, 0, .15);
 }
 
+.select2-drop-auto-width {
+    border-top: 1px solid #aaa;
+    width: auto;
+}
+
+.select2-drop-auto-width .select2-search {
+    padding-top: 4px;
+}
+
 .select2-drop.select2-drop-above {
     margin-top: 1px;
     border-top: 1px solid #aaa;


### PR DESCRIPTION
Similar to the work from https://github.com/ivaynberg/select2/pull/210, but minus jQuery UI and I adjust dropdown width when the scrollbar is present as well.  Tested with several examples in Firefox, Chrome, and IE7-9.  All worked fine but visually IE can be a bit too wide sometimes.
