### PR TITLE
fix a bug when use multi

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2297,7 +2297,7 @@ the specific language governing permissions and limitations under the Apache Lic
         focus: function () {
             this.close();
             this.search.focus();
-            this.opts.element.triggerHandler("focus");
+            //this.opts.element.triggerHandler("focus");
         },
 
         // multi


### PR DESCRIPTION
trigger "focus" event in focus function make chrome error: "Uncaught RangeError: Maximum call stack size exceeded"
