### PR TITLE
Use $.prop() to get "multiple" attribute

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2667,7 +2667,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 opts.element = $(this);
 
                 if (opts.element.get(0).tagName.toLowerCase() === "select") {
-                    multiple = opts.element.attr("multiple");
+                    multiple = opts.element.prop("multiple");
                 } else {
                     multiple = opts.multiple || false;
                     if ("tags" in opts) {opts.multiple = multiple = true;}


### PR DESCRIPTION
The string 
opts.element.attr("multiple") 
returns:
1) string "multiple" - if element have attribute multiple (<select name="..." multiple></select>)
2) undefined - if element have not attribute multiple (<select name="..."></select>)
It is written in the documentation:
"As of jQuery 1.6, the .attr() method returns undefined for attributes that have not been set."
"To retrieve and change DOM properties, use the .prop() method."
(http://api.jquery.com/attr/)

I am propose use "prop" function. The string
opts.element.prop("multiple")
returns:
1) boolean "true" - if element have attribute multiple
2) boolean "false" - if element have not attribute multiple

After, the "multiple" variable use in check of the condition:
select2 = multiple ? new MultiSelect2() : new SingleSelect2();
Better use true/false variable value than "multiple"/undefined in this condition.

Tested in Opera 12 and IE 8.0.7601
