### PR TITLE
Fix for random scrolling when using hierarchical data

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1203,7 +1203,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 return;
             }
 
-            children = this.findHighlightableChoices();
+            children = this.findHighlightableChoices().find('.select2-result-label');
 
             child = $(children[index]);
 


### PR DESCRIPTION
When using hierarchical data there is a random scroll jump when hovering over select options. The reason is that in the case of hierarchical data the highlightable choices are `<ul>` and thus their outer height is many pixels (includes the children's height as well). A fix is to make the height calculations by using the the label divs.
