### PR TITLE
Hide the closet button when select2 is disabled

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -957,6 +957,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.enabled=true;
             this.container.removeClass("select2-container-disabled");
             this.opts.element.removeAttr("disabled");
+            this.container.find("abbr").show();
         },
 
         // abstract


### PR DESCRIPTION
Hide the close button on select2 single drop downs when it is disabled as per this issue:

https://github.com/ivaynberg/select2/issues/1108
