### PR TITLE
Fix focus issue on multi-value select (closes #1109)

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2194,6 +2194,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.search.bind("blur", this.bind(function(e) {
                 this.container.removeClass("select2-container-active");
                 this.search.removeClass("select2-focused");
+                this.selection.find(".select2-search-choice-focus").removeClass("select2-search-choice-focus");
                 if (!this.opened()) this.clearSearch();
                 e.stopImmediatePropagation();
             }));


### PR DESCRIPTION
Inside the multi-value select box, when you hit backspace next to the
choice, it gets the `select2-search-choice-focus` class, but that class
is not being removed when select box loses the focus.
