### PR TITLE
Extend $.fn.select2.ajaxDefaults into opts.ajax

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -355,8 +355,8 @@ the specific language governing permissions and limitations under the Apache Lic
                 var requestNumber = requestSequence, // this request's sequence number
                     data = options.data, // ajax data function
                     url = ajaxUrl, // ajax url string or function
-                    transport = options.transport || $.ajax,
-                    type = options.type || 'GET', // set type of request (GET or POST)
+                    transport = options.transport,
+                    type = options.type, // set type of request (GET or POST)
                     params = {};
 
                 data = data ? data.call(self, query.term, query.page, query.context) : null;
@@ -839,9 +839,13 @@ the specific language governing permissions and limitations under the Apache Lic
                 if (!("query" in opts)) {
 
                     if ("ajax" in opts) {
-                        if ($.fn.select2.ajaxDefaults) {//extend default ajax options
-                            opts.ajax = $.extend({}, $.fn.select2.ajaxDefaults, opts.ajax);
-                        }
+                        //extend default ajax options
+                        var ajaxDefaults = $.fn.select2.ajaxDefaults || {};
+                        opts.ajax = $.extend({}, {
+                            transport: $.ajax,
+                            type: 'GET'
+                        }, $.fn.select2.ajaxDefaults, opts.ajax);
+
                         ajaxUrl = opts.element.data("ajax-url");
                         if (ajaxUrl && ajaxUrl.length > 0) {
                             opts.ajax.url = ajaxUrl;


### PR DESCRIPTION
Following #1083, if the user provides a $.fn.select2.ajaxDefaults object, it's properties are merged into opts.ajax to be used as defaults.
(To be sure, this time I tested it against the main page with all the examples...)
