### PR TITLE
Fix: Incorrect Bower specification

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,8 +1,8 @@
 {
     "name": "select2",
     "version": "3.3.2",
-    "main": ["select2.js", "select2.css", "select2.png", "select2x2.png", "spinner.gif"],
+    "main": ["select2.js", "select2.css", "select2.png", "select2x2.png", "select2-spinner.gif"],
     "dependencies": {
-        "jquery": "~1.4.4"
+        "jquery": ">= 1.4.4"
     }
 }


### PR DESCRIPTION
- ~ version means 1.4.x, not >= 1.4 which is what we want
- there is no `spinner.gif`, but there is a `select2-spinner.gif`
