### PR TITLE
Highlighted option based on scroll event

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -228,6 +228,7 @@ the specific language governing permissions and limitations under the Apache Lic
     function installDebouncedScroll(threshold, element) {
         var notify = debounce(threshold, function (e) { element.trigger("scroll-debounced", e);});
         element.bind("scroll", function (e) {
+        	element.parent().trigger("mousemove");     
             if (indexOf(e.target, element.get()) >= 0) notify(e);
         });
     }


### PR DESCRIPTION
The default select normally highlights an option element based on where your mouse pointer is located within the select window and which element the pointer is hovered over when scrolling through a select. This patch simply triggers the mouse movement that is used to highlight the option when scrolling the select by binding the parent mousemove event to the element's scroll event.
