### PR TITLE
Fix IE8 clickable issues

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1608,7 +1608,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 "class": "select2-container"
             }).html([
                 "<a href='javascript:void(0)' onclick='return false;' class='select2-choice' tabindex='-1'>",
-                "   <span></span><abbr class='select2-search-choice-close' style='display:none;'></abbr>",
+                "   <span>&nbsp;</span><abbr class='select2-search-choice-close' style='display:none;'></abbr>",
                 "   <div><b></b></div>" ,
                 "</a>",
                 "<input class='select2-focusser select2-offscreen' type='text'/>",


### PR DESCRIPTION
I added a non-breaking space to the empty span, because it seems to be discarded by the IE8 rendering engine. This previously rendered all but the text in the select unclickable.
