### PR TITLE
Update component.json jQuery dependency to v1.6.4

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,6 +3,6 @@
     "version": "3.3.2",
     "main": ["select2.js", "select2.css", "select2.png", "select2x2.png", "select2-spinner.gif"],
     "dependencies": {
-        "jquery": ">= 1.4.4"
+        "jquery": ">= 1.6.4"
     }
 }


### PR DESCRIPTION
The dependency was originally set to v1.4.4
However `$().prop()` is used throughout select2 and was not introduced until v1.6

http://api.jquery.com/prop/
