### PR TITLE
Remove inline styles

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -628,6 +628,18 @@ disabled look for disabled choices in the results dropdown
     width: 1px;
 }
 
+.select2-display-none {
+    display: none;
+}
+
+.select2-measure-scrollbar {
+    position: absolute;
+    top: -10000px;
+    left: -10000px;
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+}
 /* Retina-ize icons */
 
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 144dpi)  {

--- a/select2.js
+++ b/select2.js
@@ -96,7 +96,7 @@ the specific language governing permissions and limitations under the Apache Lic
             return k >= 112 && k <= 123;
         }
     },
-    MEASURE_SCROLLBAR_TEMPLATE = "<div style='position:absolute; top:-10000px; left:-10000px; width:100px; height:100px; overflow:scroll;'></div>";
+    MEASURE_SCROLLBAR_TEMPLATE = "<div class='select2-measure-scrollbar'></div>";
 
     $document = $(document);
 
@@ -1628,11 +1628,11 @@ the specific language governing permissions and limitations under the Apache Lic
                 "class": "select2-container"
             }).html([
                 "<a href='javascript:void(0)' onclick='return false;' class='select2-choice' tabindex='-1'>",
-                "   <span>&nbsp;</span><abbr class='select2-search-choice-close' style='display:none;'></abbr>",
+                "   <span>&nbsp;</span><abbr class='select2-search-choice-close select2-display-none'></abbr>",
                 "   <div><b></b></div>" ,
                 "</a>",
                 "<input class='select2-focusser select2-offscreen' type='text'/>",
-                "<div class='select2-drop' style='display:none'>" ,
+                "<div class='select2-drop select2-display-none'>" ,
                 "   <div class='select2-search'>" ,
                 "       <input type='text' autocomplete='off' class='select2-input'/>" ,
                 "   </div>" ,
@@ -2117,7 +2117,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 "    <input type='text' autocomplete='off' class='select2-input'>" ,
                 "  </li>" ,
                 "</ul>" ,
-                "<div class='select2-drop select2-drop-multi' style='display:none;'>" ,
+                "<div class='select2-drop select2-drop-multi select2-display-none'>" ,
                 "   <ul class='select2-results'>" ,
                 "   </ul>" ,
                 "</div>"].join(""));


### PR DESCRIPTION
Removing these inline styles makes Select2 compatible with a Content Security Policy implementing style-src (http://www.w3.org/TR/CSP/#style-src).
