### PR TITLE
Search width inconsistencies in different browsers due to fractional pixels

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2618,7 +2618,7 @@ the specific language governing permissions and limitations under the Apache Lic
               searchWidth = minimumWidth;
             }
 
-            this.search.width(searchWidth);
+            this.search.width(Math.floor(searchWidth));
         },
 
         // multi


### PR DESCRIPTION
Floor the searchWidth calculation due to inconsistencies between fractional pixel handling in different browsers.

This can cause the input box to break to a newline in certain situations when it doesn't need to particularly in Firefox and IE.
