### PR TITLE
Mobile devices focus problem

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -235,6 +235,11 @@ the specific language governing permissions and limitations under the Apache Lic
     function focus($el) {
         if ($el[0] === document.activeElement) return;
 
+		/* Set focus immediately within event handler, otherwise mobile browsers will not set the focus
+		 See: http://typeof.it/30/how-to-show-the-virtual-keyboard-using-javascript-in-ios/
+		 */
+		$el.focus();
+
         /* set the focus in a 0 timeout - that way the focus is set after the processing
             of the current event has finished - which seems like the only reliable way
             to set focus */
@@ -2278,7 +2283,8 @@ the specific language governing permissions and limitations under the Apache Lic
                 e.stopImmediatePropagation();
             }));
 
-            this.container.delegate(selector, "mousedown", this.bind(function (e) {
+			// Need to bind to "click" additionally so that focus can be set on input field on mobile devices
+			this.container.delegate(selector, "mousedown click", this.bind(function (e) {
                 if (!this.enabled) return;
                 if ($(e.target).closest(".select2-search-choice").length > 0) {
                     // clicked inside a select2 search choice, do not open


### PR DESCRIPTION
This update resolves problem with the virtual keyboard if user clicks on select2 plugin but not directly into input filed. That's mean if user clicks on container which include input field (but not inside input field) then on mobile devices the virtual keyboard will not come up. It happens currently because the container trigger only onMousedown event.

This update solves problem of hidden virtual keyboard if focus() is set on input field by the software (not by the user). In most of devices the focus() on input field should be set only by the onMouseup and onClick event to avoid this problem. For other events the virtual keyboard will not appear. This problem is also described here http://typeof.it/30/how-to-show-the-virtual-keyboard-using-javascript-in-ios/ with example here http://jsfiddle.net/DLV2F/87/
