### PR TITLE
select2-drop-mask background and transparency

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -123,11 +123,6 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     left: 0;
     top: 0;
     z-index: 9998;
-    background-color: #fff;
-    opacity: 0;
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)"; /* works in IE 8 */
-        filter: "alpha(opacity=0)"; /* expected to work in IE 8 */
-        filter: alpha(opacity=0); /* IE 4-7 */
 }
 
 .select2-drop {


### PR DESCRIPTION
Removing select2-drop-mask background and transparency to help out corporate-modified IE 8 and IE 7 browsers that disable the "filter" property in CSS.
