### PR TITLE
Changing from &apos; to &#39; because &apos; isn't html standard and doesn't work in IE8

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2868,7 +2868,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 '<': '&lt;',
                 '>': '&gt;',
                 '"': '&quot;',
-                "'": '&apos;',
+                "'": '&#39;',
                 "/": '&#47;'
             };
 


### PR DESCRIPTION
A very small change to use &#39; instead of &apos;
