### PR TITLE
Display formatNoMatches when all ajax results are selected

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2592,6 +2592,11 @@ the specific language governing permissions and limitations under the Apache Lic
                 self.highlight(0);
             }
 
+            //If all results are chosen render formatNoMAtches
+            if(!this.opts.createSearchChoice && !choices.filter('.select2-result:not(.select2-selected)').length > 0){
+                this.results.append("<li class='select2-no-results'>" + self.opts.formatNoMatches(self.search.val()) + "</li>");
+            }
+
         },
 
         // multi


### PR DESCRIPTION
I've implemented this 3-liner in the postprocessResults method. 

I'm thinking a better approach would be to filter out already selected results in the moment they are received from the server. But that would require far more change and I wasn't entirely sure what it would entail so I kept it simple.
