### PR TITLE
Add tokenizeOnBlur option

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1545,6 +1545,12 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         blur: function () {
+            // if tokenizeOnBlur == true, add untokenized input to tags
+            if(this.opts.tokenizeOnBlur && this.search.val() !== "") {
+                var val=this.search.val();
+                if($.trim(val)!='') this.onSelect({id:val,text:val});
+            }
+
             // if selectOnBlur == true, select the currently highlighted option
             if (this.opts.selectOnBlur)
                 this.selectHighlighted({noFocus: true});


### PR DESCRIPTION
This option, when set to true, will take any untokenized search query and tokenize it on blur, instead of clearing it out.

This is useful for tagging interfaces, where users generally expect untokenized entries to be serialized and saved on form submit. They're generally surprised their entered data was cleared out rather than submitted, even if they didn't hit the separator character to tokenize the last entry.
