### PR TITLE
Namespaced events

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1014,7 +1014,7 @@ the specific language governing permissions and limitations under the Apache Lic
         triggerChange: function (details) {
 
             details = details || {};
-            details= $.extend({}, details, { type: "change", val: this.val() });
+            details = $.Event("change.select2", $.extend({}, details, { val: this.val() }));
             // prevents recursive triggering
             this.opts.element.data("select2-change-triggered", true);
             this.opts.element.trigger(details);
@@ -1387,7 +1387,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             data = choice.data("select2-data");
             if (data) {
-                this.opts.element.trigger({ type: "select2-highlight", val: this.id(data), choice: data });
+                this.opts.element.trigger($.Event("highlight.select2", { val: this.id(data), choice: data }));
             }
         },
 
@@ -1583,7 +1583,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
                 postRender();
 
-                this.opts.element.trigger({ type: "select2-loaded", data:data });
+                this.opts.element.trigger($.Event("loaded.select2", { data:data }));
             })});
         },
 
@@ -1928,7 +1928,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 this.setPlaceholder();
 
                 if (triggerChange !== false){
-                    this.opts.element.trigger({ type: "select2-removed", val: this.id(data), choice: data });
+                    this.opts.element.trigger($.Event("removed.select2", { val: this.id(data), choice: data }));
                     this.triggerChange({removed:data});
                 }
             }
@@ -2071,7 +2071,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.opts.element.val(this.id(data));
             this.updateSelection(data);
 
-            this.opts.element.trigger({ type: "select2-selected", val: this.id(data), choice: data });
+            this.opts.element.trigger($.Event("selected.select2", { val: this.id(data), choice: data }));
 
             this.close();
 
@@ -2252,13 +2252,13 @@ the specific language governing permissions and limitations under the Apache Lic
 
             } else {
                 if (selected.length) {
-                    this.opts.element.trigger("choice-deselected", selected);
+                    this.opts.element.trigger("choice-deselected.select2", selected);
                 }
                 selected.removeClass("select2-search-choice-focus");
                 if (choice && choice.length) {
                     this.close();
                     choice.addClass("select2-search-choice-focus");
-                    this.opts.element.trigger("choice-selected", choice);
+                    this.opts.element.trigger("choice-selected.select2", choice);
                 }
             }
         },
@@ -2563,7 +2563,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.addSelectedChoice(data);
 
-            this.opts.element.trigger({ type: "selected", val: this.id(data), choice: data });
+            this.opts.element.trigger($.Event("selected.select2", { val: this.id(data), choice: data }));
 
             if (this.select || !this.opts.closeOnSelect) this.postprocessResults();
 
@@ -2678,7 +2678,7 @@ the specific language governing permissions and limitations under the Apache Lic
             }
             selected.remove();
 
-            this.opts.element.trigger({ type: "removed", val: this.id(data), choice: data });
+            this.opts.element.trigger($.Event("removed.select2", { val: this.id(data), choice: data }));
             this.triggerChange({ removed: data });
         },
 


### PR DESCRIPTION
http://docs.jquery.com/Namespaced_Events

This pull requests allows us to keep the standard events (`open`, `change`, `close`, etc) without having them bubble up and trigger events that were not intended (closing modals, for example).

Using the `[event].select2` syntax, people can still catch the event as `[event]`, but the events are not caught by other plugins, as the namespaces would not match.
