### PR TITLE
this.autofocus is undefined on destroy inside init

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -756,7 +756,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     .removeData("select2")
                     .unbind(".select2")
                     .attr({"tabindex": this.elementTabIndex})
-                    .prop("autofocus", this.autofocus)
+                    .prop("autofocus", this.autofocus||false)
                     .show();
             }
         },


### PR DESCRIPTION
Fixed undefined this.autofocus on destroy while creating on element that already have select2 applied
