### PR TITLE
Removed BOM.

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Version: @@ver@@ Timestamp: @@timestamp@@
 */
 .select2-container {

--- a/select2.js
+++ b/select2.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2012 Igor Vaynberg
 
 Version: @@ver@@ Timestamp: @@timestamp@@


### PR DESCRIPTION
This removes the Byte Order Mark from the source files. [Using a BOM with UTF-8 files is not recommended](https://en.wikipedia.org/wiki/Byte_Order_Mark#cite_note-3).
