### PR TITLE
Add css classes for selected items

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2087,7 +2087,7 @@ the specific language governing permissions and limitations under the Apache Lic
         // single
         updateSelection: function (data) {
 
-            var container=this.selection.find("span"), formatted;
+            var container=this.selection.find("span"), formatted, cssClass;
 
             this.selection.data("select2-data", data);
 
@@ -2636,7 +2636,7 @@ the specific language governing permissions and limitations under the Apache Lic
             var choice = enableChoice ? enabledItem : disabledItem,
                 id = this.id(data),
                 val = this.getVal(),
-                formatted;
+                formatted,
                 cssClass;
 
             formatted=this.opts.formatSelection(data, choice.find("div"));


### PR DESCRIPTION
Selected items can now have a css class applied to them allowing, a state or similar sort of information to be communicated.

For some set of selectable items, when one has been selected I want to be able to set the background colour to green or red etc.

https://github.com/ivaynberg/select2/issues/1312
