### PR TITLE
Fix for unselecting items with ids of type array

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2670,7 +2670,8 @@ the specific language governing permissions and limitations under the Apache Lic
         unselect: function (selected) {
             var val = this.getVal(),
                 data,
-                index;
+                index,
+                i;
 
             selected = selected.closest(".select2-search-choice");
 
@@ -2686,13 +2687,19 @@ the specific language governing permissions and limitations under the Apache Lic
                 return;
             }
 
-            index = indexOf(this.id(data), val);
-
-            if (index >= 0) {
-                val.splice(index, 1);
-                this.setVal(val);
-                if (this.select) this.postprocessResults();
+            if (Object.prototype.toString.call( this.id(data) ) !== '[object Array]') {
+              index = [indexOf(this.id(data), val)];
+            } else {
+              index = this.id(data).map(function(id){ return indexOf(id, val);})
             }
+
+            for (i in index) {
+                if (i >= 0) {
+                    val.splice(i, 1);
+                    this.setVal(val);
+                }
+            }
+            if (this.select) this.postprocessResults();
             selected.remove();
 
             this.opts.element.trigger({ type: "removed", val: this.id(data), choice: data });


### PR DESCRIPTION
It may be useful to include elements in the select drop down which act as a convenience selection and add many other items of the same id. For example:
- Australia (id: [1,2,3,4,5,6,7])
- New South Wales (id: 1)
- Victoria (id: 2)
- Queensland (id: 3)
  etc

This change resolves the issue where removing one from a multiselect box causes the value to not be correctly updated because `indexOf( [1,2,3,4], ...)` returns `-1` because each element of the array should be checked individually.
