### PR TITLE
Fixed typo of one character

### DIFF
--- a/index.html
+++ b/index.html
@@ -1035,7 +1035,7 @@ $(document).ready(function () {
                     <dt>element</dt><dd>Uses javascript to calculate the width of the source element.</dd>
                     <dt>copy</dt><dd>Copies the value of the width style attribute set on the source element</dd>
                     <dt>resolve</dt><dd>First attempts to <u>copy</u> than falls back on <u>element</u></dd>
-                    <dt>other values</dt><dd>if the width attribute contains a function it will be avaluated, otherwise the value is used verbatim</dd>
+                    <dt>other values</dt><dd>if the width attribute contains a function it will be evaluated, otherwise the value is used verbatim</dd>
                 </dl>
             </td></tr>
             <tr><td>minimumInputLength</td><td>int</td><td>Number of characters necessary to start a search</td></tr>


### PR DESCRIPTION
I can't help with code right now, but spotted this, so here's a pull =] <3

'avaluated' to 'evaluated'
