### PR TITLE
Sync translation template with source

### DIFF
--- a/select2_locale_en.js.template
+++ b/select2_locale_en.js.template
@@ -9,7 +9,7 @@
     $.extend($.fn.select2.defaults, {
         formatNoMatches: function () { return "No matches found"; },
         formatInputTooShort: function (input, min) { var n = min - input.length; return "Please enter " + n + " more character" + (n == 1 ? "" : "s"); },
-        formatInputTooLong: function (input, max) { var n = input.length - max; return "Please enter " + n + " less character" + (n == 1? "" : "s"); },
+        formatInputTooLong: function (input, max) { var n = input.length - max; return "Please delete " + n + " character" + (n == 1 ? "" : "s"); },
         formatSelectionTooBig: function (limit) { return "You can only select " + limit + " item" + (limit == 1 ? "" : "s"); },
         formatLoadMore: function (pageNumber) { return "Loading more results..."; },
         formatSearching: function () { return "Searching..."; }


### PR DESCRIPTION
This change syncs the translation template with the actual string
used for `$.fn.select2.defaults.formatInputTooLong`.

The source was changed by 5193dc40.
