### PR TITLE
Shorten Japanese translation for `formatNoMatches`

### DIFF
--- a/select2_locale_ja.js
+++ b/select2_locale_ja.js
@@ -5,7 +5,7 @@
     "use strict";
 
     $.extend($.fn.select2.defaults, {
-        formatNoMatches: function () { return "該当項目なし"; },
+        formatNoMatches: function () { return "該当なし"; },
         formatInputTooShort: function (input, min) { var n = min - input.length; return "後" + n + "文字入れてください"; },
         formatInputTooLong: function (input, max) { var n = input.length - max; return "検索文字列が" + n + "文字長すぎます"; },
         formatSelectionTooBig: function (limit) { return "最多で" + limit + "項目までしか選択できません"; },


### PR DESCRIPTION
Remove unnecessary word from Japanese translation for `formatNoMatches`.
