### PR TITLE
Remove duplication of "No matches found" message

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2739,7 +2739,9 @@ the specific language governing permissions and limitations under the Apache Lic
 
             //If all results are chosen render formatNoMAtches
             if(!this.opts.createSearchChoice && !choices.filter('.select2-result:not(.select2-selected)').length > 0){
-                this.results.append("<li class='select2-no-results'>" + self.opts.formatNoMatches(self.search.val()) + "</li>");
+            	if(!data || data && !data.more) {
+            	    this.results.append("<li class='select2-no-results'>" + self.opts.formatNoMatches(self.search.val()) + "</li>");
+            	}
             }
 
         },


### PR DESCRIPTION
In case if data is fetched in chunks, not at once, "No matches found" message is shown as many times as we requested for it.
Lets say we have 15 items, and data is fetched 5 at a time. After all items are selected, "No matches found" message would be duplicated 3 times.
