### PR TITLE
Remove duplication of "No matches found" message on multi select2 clearing

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2504,6 +2504,10 @@ the specific language governing permissions and limitations under the Apache Lic
             } else {
                 this.search.val("").width(10);
             }
+
+            if(this.results.find('.select2-no-results').length > 0 ) {
+                this.close();
+            }
         },
 
         // multi


### PR DESCRIPTION
_Steps to reproduce:_
1. Select all items in a multi select input and make sure that _"No matches found"_ message is shown.
2. Trigger clearing on the input with _val_, for example: 

``` javascript
$('some-component-selector').select2('val', '');
```

_Expected Result:_ the input is cleared and _"No matches found"_ message is hidden.

_Actual Result:_ _"No matches found"_ message is shown as many times as we clear the input.
