### PR TITLE
Drop-mask not working in IE (a CSS solution)

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -144,6 +144,10 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     left: 0;
     top: 0;
     z-index: 9998;
+    /* styles required for IE to work */
+    background-color: #fff;
+    opacity: 0;
+    filter: alpha(opacity=0);
 }
 
 .select2-drop {


### PR DESCRIPTION
Drop-mask is not working in IE to cover controls, this solution applies to v3.4.0 but can also be applied to 3.4.1 without using the check for browser opacity support and adding an iframe undermask. 

Added new styles to .select2-drop-mask:

<pre>
.select2-drop-mask {
    border: 0;
    margin: 0;
    padding: 0;
    position: absolute;
    left: 0;
    top: 0;
    z-index: 9998;
    <b>/* styles required for IE to work */</b>
    background-color: #fff;
    opacity: 0;
    filter: alpha(opacity=0);
}
</pre>
