### PR TITLE
Easier use of span elements for selection formatting

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -86,7 +86,7 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     margin-right: 42px;
 }
 
-.select2-container .select2-choice span {
+.select2-container .select2-choice > span {
     margin-right: 26px;
     display: block;
     overflow: hidden;


### PR DESCRIPTION
Using span elements in custom templates for formatSelection() requires additional css rules because they inherit styles from the span wrapping the selection; I made a simple change in the CSS rule to avoid this.
