### PR TITLE
fix: data not passed in select2-loaded event

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1617,7 +1617,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
                 postRender();
 
-                this.opts.element.trigger({ type: "select2-loaded", data:data });
+                this.opts.element.trigger({ type: "select2-loaded", items: data });
             })});
         },
 


### PR DESCRIPTION
When triggering `select2-loaded` event items are passed via `data` property that is standart $.Event field and can not be modified in trigger. So that data remains `undefined`:

``` js
this.opts.element.trigger({ type: "select2-loaded", data: data });
```

jsFiddle: http://jsfiddle.net/Agdpu/

I've renamed it to `items` and everything works:

``` js
this.opts.element.trigger({ type: "select2-loaded", items: data });
```

But basically, I would suggest to think about passing parameters to all events via second argument of `trigger`:

``` js
this.opts.element.trigger({ type: "select2-loaded"}, data);
```

It's more recommended way by jquery and avoids such bugs with naming.
