### PR TITLE
Always call createSearchChoice and tokenizer with the Select2 object as this.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -598,7 +598,7 @@ the specific language governing permissions and limitations under the Apache Lic
             input = input.substring(index + separator.length);
 
             if (token.length > 0) {
-                token = opts.createSearchChoice(token, selection);
+                token = opts.createSearchChoice.call(this, token, selection);
                 if (token !== undefined && token !== null && opts.id(token) !== undefined && opts.id(token) !== null) {
                     dupe = false;
                     for (i = 0, l = selection.length; i < l; i++) {
@@ -1586,7 +1586,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 this.context = (data.context===undefined) ? null : data.context;
                 // create a default choice and prepend it to the list
                 if (this.opts.createSearchChoice && search.val() !== "") {
-                    def = this.opts.createSearchChoice.call(null, search.val(), data.results);
+                    def = this.opts.createSearchChoice.call(self, search.val(), data.results);
                     if (def !== undefined && def !== null && self.id(def) !== undefined && self.id(def) !== null) {
                         if ($(data.results).filter(
                             function () {
@@ -2640,7 +2640,7 @@ the specific language governing permissions and limitations under the Apache Lic
         // multi
         tokenize: function() {
             var input = this.search.val();
-            input = this.opts.tokenizer(input, this.data(), this.bind(this.onSelect), this.opts);
+            input = this.opts.tokenizer.call(this, input, this.data(), this.bind(this.onSelect), this.opts);
             if (input != null && input != undefined) {
                 this.search.val(input);
                 if (input.length > 0) {


### PR DESCRIPTION
Giving `createSearchChoice` access to the Select2 object allows me to filter my created search choices based on both the results from a query and from the currently selected choices (the current selection isn't easily accessed when `createSearchChoice` is called to generate a search query result):

``` javascript
  function createTagSearchChoice(term, results) {
    var lowerTerm = term.toLowerCase();
    var data = this.data();
    if (data && data.length) {
      results = results.concat(data);
    }
    var $matchingdata = $(results).filter(function() {
      return 0 === this.id.toLowerCase().localeCompare(lowerTerm);
    });

    if (0 !== $matchingdata.length) {
      return null;
    }

    return {id: term, count: 0};
  }
```

One other thing to consider is that `createSearchChoice` is called somewhat inconsistently currently.  It is sometimes passed `.data()` and sometimes the result of a query.  It would probably break old code, but it might be worth passing the query results and the current `.data()` as separate parameters: `createSearchChoice(term, queryResults, currentSelections)`
