### PR TITLE
Add accurate comment to the 'equal' function

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -132,8 +132,10 @@ the specific language governing permissions and limitations under the Apache Lic
         if (a === b) return true;
         if (a === undefined || b === undefined) return false;
         if (a === null || b === null) return false;
-        if (a.constructor === String) return a+'' === b+''; // IE requires a+'' instead of just a
-        if (b.constructor === String) return b+'' === a+''; // IE requires b+'' instead of just b
+        // Check whether 'a' or 'b' is a string (primitive or object).
+        // The concatenation of an empty string (+'') converts its argument to a string's primitive.
+        if (a.constructor === String) return a+'' === b+''; // a+'' - in case 'a' is a String object
+        if (b.constructor === String) return b+'' === a+''; // b+'' - in case 'b' is a String object
         return false;
     }
 


### PR DESCRIPTION
The comment:

```
if (a.constructor === String) return a+'' === b+''; // IE requires a+'' instead of just a
```

https://github.com/ivaynberg/select2/blob/3.4.0/select2.js#L135
doesn't exhaustively explain why the `a+''` is required while `a` being a string.
The reason is that it might be a String object, in which case the identity check (`===`) will fail, e.g.:

```
var n = 1
var s = "1";
s === n+""  // true
new String(s) === n+""; // false
new String(s) === s;  // false
new String(s) === new String(s);  // false
```
