### PR TITLE
Ignore old queries, remove highlight when beginning a new query.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -392,7 +392,6 @@ the specific language governing permissions and limitations under the Apache Lic
      */
     function ajax(options) {
         var timeout, // current scheduled but not yet executed request
-            requestSequence = 0, // sequence used to drop out-of-order responses
             handler = null,
             quietMillis = options.quietMillis || 100,
             ajaxUrl = options.url,
@@ -401,9 +400,7 @@ the specific language governing permissions and limitations under the Apache Lic
         return function (query) {
             window.clearTimeout(timeout);
             timeout = window.setTimeout(function () {
-                requestSequence += 1; // increment the sequence
-                var requestNumber = requestSequence, // this request's sequence number
-                    data = options.data, // ajax data function
+                var data = options.data, // ajax data function
                     url = ajaxUrl, // ajax url string or function
                     transport = options.transport || $.fn.select2.ajaxDefaults.transport,
                     // deprecated - to be removed in 4.0  - use params instead
@@ -433,9 +430,6 @@ the specific language governing permissions and limitations under the Apache Lic
                     dataType: options.dataType,
                     data: data,
                     success: function (data) {
-                        if (requestNumber < requestSequence) {
-                            return;
-                        }
                         // TODO - replace query.page with query so users have access to term, page, etc.
                         var results = options.results(data, query.page);
                         query.callback(results);
@@ -1511,6 +1505,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 input,
                 term = search.val(),
                 lastTerm = $.data(this.container, "select2-last-term"),
+                // sequence number used to drop out-of-order responses
                 queryNumber;
 
             // prevent duplicate queries against the same term


### PR DESCRIPTION
This commit fixes two issues I was having:

If queries come back out of order, it's bad news.  Mainly where this shows up is if you have a `minimumInputLength`, if you go above then below it very fast, it will display the `formatInputTooShort` message, and after the query comes back, replace it with the outdated query results. e.g.:
You have a `minimumInputLength` of `1`.
You type "c" and then immediately hit backspace.  It shows the `formatInputTooShort` message, but then when the query comes back it shows the query results (even though you've already deleted your search term).

If you begin typing while search results are showing, the most recent highlight will continue to be highlighted, even if it no longer applies to the current term, e.g.:
You type "c", it shows the results: "cake" and "cookies", "cake" is highlighted.
You type "o" (now the search term is "co"), it continues to highlight "cake" until the search query comes back and displays "cookies" as the only result and highlights it.
