### PR TITLE
Trimming in opts.createSearchChoice

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -960,7 +960,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     } else if ("tags" in opts) {
                         opts.query = tags(opts.tags);
                         if (opts.createSearchChoice === undefined) {
-                            opts.createSearchChoice = function (term) { return {id: term, text: term}; };
+                            opts.createSearchChoice = function (term) { return {id: $.trim(term), text: $.trim(term)}; };
                         }
                         if (opts.initSelection === undefined) {
                             opts.initSelection = function (element, callback) {


### PR DESCRIPTION
Adds trim to opts.createSearchChoice default to avoid mismatches with val object. Fixes #1484
