### PR TITLE
Added select2-loaded event trigger in loadMoreIfNeeded

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1498,6 +1498,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     self.positionDropdown();
                     self.resultsPage = page;
                     self.context = data.context;
+                    this.opts.element.trigger({ type: "select2-loaded", items: data });
                 })});
             }
         },


### PR DESCRIPTION
The 'select2-loaded' event does not fire when subsequent items are loaded in the loadMoreIfNeeded function.  This uses the same convention as #1455:

```
this.opts.element.trigger({ type: "select2-loaded", items: data });
```

However, I would also recommend that both be replaced with the second suggestion in #1455 to use the jQuery data field instead of a unique 'items' property:

```
this.opts.element.trigger({ type: "select2-loaded"}, data);
```
