### PR TITLE
Remove the byte order mark

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2012 Igor Vaynberg
 
 Version: @@ver@@ Timestamp: @@timestamp@@


### PR DESCRIPTION
As far as I can see this has been reported and fixed three times before (issues #30 and #306, and pull request #1306), but the BOM keeps coming back.
