### PR TITLE
Changes to help support Content Security Poilicy

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1768,27 +1768,28 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // single
 
-    	createContainer: function () {
-			var container = $(document.createElement("div")).attr({
-				"class": "select2-container"
-			})
-			container.append($([
-				"    <a href='javascript:void(0)'  class='select2-choice'>",
-				"   <span></span><abbr class='select2-search-choice-close' style='display:none;'></abbr>",
-				"   <div><b></b></div>" ,
-				"</a>",
-				""].join("")).on('click', function() {return false;}));
+	createContainer: function () {
+		var container = $(document.createElement("div")).attr({
+			"class": "select2-container"
+		})
+		
+		container.append($([
+			"<a href='javascript:void(0)' class='select2-choice' tabindex='-1'>",
+			"   <span class='select2-chosen'>&nbsp;</span><abbr class='select2-search-choice-close'></abbr>",
+			"   <span class='select2-arrow'><b></b></span>",
+			"</a>"].join("")).on('click', function() {return false;}));
 			
-			container.append($(["<div class='select2-drop select2-offscreen'>" ,
-				"   <div class='select2-search'>" ,
-				"       <input type='text' autocomplete='off' class='select2-input'/>" ,
-				"   </div>" ,
-				"   <ul class='select2-results'>" ,
-				"   </ul>" ,
-				"</div>"].join("")));	
-			return container;
-		},	
-
+			container.append($(["<input class='select2-focusser select2-offscreen' type='text'/>",
+			"<div class='select2-drop select2-display-none'>",
+			"   <div class='select2-search'>",
+			"       <input type='text' autocomplete='off' autocorrect='off' autocapitalize='off' spellcheck='false' class='select2-input'/>",
+			"   </div>",
+			"   <ul class='select2-results'>",
+			"   </ul>",
+			"</div>"].join("")));
+		return container;
+	},
+	
 
         // single
         enableInterface: function() {


### PR DESCRIPTION
I have enabled Content Security Policy on my application (blocks inline JavaScript), this stopped the onclick handler from working in modified code.  I've modified the code to use a event handler instead which works for me on JQuery 1.10.2. 
