### PR TITLE
Fixed Tab key not respecting opts.selectOnBlur

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1907,7 +1907,10 @@ the specific language governing permissions and limitations under the Apache Lic
                         killEvent(e);
                         return;
                     case KEY.TAB:
-                        this.selectHighlighted({noFocus: true});
+                        // if selectOnBlur == true, select the currently highlighted option
+                        if (this.opts.selectOnBlur) {
+                            this.selectHighlighted({noFocus: true});
+                        }
                         return;
                     case KEY.ESC:
                         this.cancel(e);
@@ -2487,7 +2490,10 @@ the specific language governing permissions and limitations under the Apache Lic
                         killEvent(e);
                         return;
                     case KEY.TAB:
-                        this.selectHighlighted({noFocus:true});
+                        // if selectOnBlur == true, select the currently highlighted option
+                        if (this.opts.selectOnBlur) {
+                            this.selectHighlighted({noFocus:true});
+                        }
                         this.close();
                         return;
                     case KEY.ESC:


### PR DESCRIPTION
When the drop down was open and an item was highlighted, then pressing tab would select the item regardless of the "selectOnBlur" option.
