### PR TITLE
Added "disableUpDown" Options for Constructor to support use Up And Down Key move focus between cell and cell

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1941,7 +1941,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     return;
                 }
 
-                if (e.which == KEY.DOWN || e.which == KEY.UP
+                if ((e.which == KEY.DOWN && !this.opts.disableUpDown) || (e.which == KEY.UP && !this.opts.disableUpDown)
                     || (e.which == KEY.ENTER && this.opts.openOnEnter)) {
 
                     if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) return;


### PR DESCRIPTION
 Added "disableUpDown" Options for Constructor to support use Up And Down Key move focus between cell and cell in table when use Select2 as editor for some Grid just like SlickGrid

Unlike just Select2`s behavier, when press Down and Up Key, then drop
down list will opening immediately, It is unnecessary when use Select2
as Grid Cell Editor, these grids like SlickGrid
