### PR TITLE
add zepto compatibiliy

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -20,7 +20,7 @@ the specific language governing permissions and limitations under the Apache Lic
 */
 (function ($) {
     if(typeof $.fn.each2 == "undefined") {
-        $.fn.extend({
+        $.extend($.fn, {
             /*
             * 4-10 times faster .each replacement
             * use it carefully, as it overrides jQuery context of element on each iteration


### PR DESCRIPTION
Changing the way we extend $.fn with each2() function now select2 should be compatible with Zepto.js (http://zeptojs.com/).

Besides zepto.js it also needs data.js (https://github.com/madrobby/zepto/blob/master/src/data.js).

Zepto.js + data.js minified and gzipped are below 12kb. I think this is around half the size of jQuery.

Zepto doesn't support IE but it's great for mobile devices with modern browsers and bad connections.

Is there any test suite I have to pass to get this merged?

Thanks!
