### PR TITLE
improve PT locales

### DIFF
--- a/select2_locale_pt-BR.js
+++ b/select2_locale_pt-BR.js
@@ -6,8 +6,8 @@
 
     $.extend($.fn.select2.defaults, {
         formatNoMatches: function () { return "Nenhum resultado encontrado"; },
-        formatInputTooShort: function (input, min) { var n = min - input.length; return "Informe " + n + " caracter" + (n == 1? "" : "es"); },
-        formatInputTooLong: function (input, max) { var n = input.length - max; return "Apague " + n + " caracter" + (n == 1? "" : "es"); },
+        formatInputTooShort: function (input, min) { var n = min - input.length; return "Informe " + n + " caractere" + (n == 1? "" : "s"); },
+        formatInputTooLong: function (input, max) { var n = input.length - max; return "Apague " + n + " caractere" + (n == 1? "" : "s"); },
         formatSelectionTooBig: function (limit) { return "Só é possível selecionar " + limit + " elemento" + (limit == 1 ? "" : "s"); },
         formatLoadMore: function (pageNumber) { return "Carregando mais resultados..."; },
         formatSearching: function () { return "Buscando..."; }

--- a/select2_locale_pt-PT.js
+++ b/select2_locale_pt-PT.js
@@ -6,8 +6,8 @@
 
     $.extend($.fn.select2.defaults, {
         formatNoMatches: function () { return "Nenhum resultado encontrado"; },
-        formatInputTooShort: function (input, min) { var n = min - input.length; return "Introduza " + n + " caracter" + (n == 1 ? "" : "es"); },
-        formatInputTooLong: function (input, max) { var n = input.length - max; return "Apague " + n + " caracter" + (n == 1 ? "" : "es"); },
+        formatInputTooShort: function (input, min) { var n = min - input.length; return "Introduza " + n + " car" + (n == 1 ? "ácter" : "acteres"); },
+        formatInputTooLong: function (input, max) { var n = input.length - max; return "Apague " + n + " car" + (n == 1 ? "ácter" : "acteres"); },
         formatSelectionTooBig: function (limit) { return "Só é possível selecionar " + limit + " elemento" + (limit == 1 ? "" : "s"); },
         formatLoadMore: function (pageNumber) { return "A carregar mais resultados..."; },
         formatSearching: function () { return "A pesquisar..."; }


### PR DESCRIPTION
Brazilian Portuguese:
- Singular form ends with "e" (`caractere`).

European Portuguese:
- Singular form has accent (`carácter`), while the plural one doesn't as these have different syllables.
  - Both carácter and caráter are valid orthography per AO-1990. I'm not sure which one is preferred for European Portuguese hence I've kept the form which was already being used, just added the lacking accent to it.

Reference:
- http://pt.wikipedia.org/wiki/Caractere
- https://pt.wiktionary.org/wiki/caractere
