### PR TITLE
Add 'nextSearchTerm' function

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -694,7 +694,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.dropdown = this.container.find(".select2-drop");
             this.dropdown.addClass(evaluate(opts.dropdownCssClass));
             this.dropdown.data("select2", this);
-			
+
             syncCssClasses(this.dropdown, this.opts.element, this.opts.adaptDropdownCssClass);
 
             this.results = results = this.container.find(resultsSelector);
@@ -775,6 +775,8 @@ the specific language governing permissions and limitations under the Apache Lic
             this.autofocus = opts.element.prop("autofocus");
             opts.element.prop("autofocus", false);
             if (this.autofocus) this.focus();
+            
+            this.nextSearchTerm = undefined;
         },
 
         // abstract
@@ -1822,7 +1824,16 @@ the specific language governing permissions and limitations under the Apache Lic
                 len = this.search.val().length;
                 el.setSelectionRange(len, len);
             }
-
+            
+            // initializes search's value with nextSearchTerm (if defined by user)
+            // ignore nextSearchTerm if the dropdown is opened by the user pressing a letter
+            if(this.search.val() === "") {
+                if(this.nextSearchTerm != undefined){
+                    this.search.val(this.nextSearchTerm);
+                    this.search.select();
+                }
+            }
+            
             this.focusser.prop("disabled", true).val("");
             this.updateResults(true);
             this.opts.element.trigger($.Event("select2-open"));
@@ -2201,6 +2212,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.opts.element.trigger({ type: "select2-selected", val: this.id(data), choice: data });
 
+            this.nextSearchTerm=this.opts.nextSearchTerm(data, data.text);
             this.close();
 
             if (!options || !options.noFocus)
@@ -3167,7 +3179,8 @@ the specific language governing permissions and limitations under the Apache Lic
         blurOnChange: false,
         selectOnBlur: false,
         adaptContainerCssClass: function(c) { return c; },
-        adaptDropdownCssClass: function(c) { return null; }
+        adaptDropdownCssClass: function(c) { return null; },
+        nextSearchTerm: function(selectedObject, currentSearchTerm) { return undefined; }
     };
 
     $.fn.select2.ajaxDefaults = {


### PR DESCRIPTION
Clean version of [pull request #1519](https://github.com/ivaynberg/select2/pull/1519):
- Given a previous selection `nextSearchTerm` determines what the next search term should be.
- Remove some leftover tabs.
- Fix a typo: 'install the' instead of 'install sthe'.
