### PR TITLE
Fix missing dropdownCssClass on init

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -692,10 +692,11 @@ the specific language governing permissions and limitations under the Apache Lic
             this.container.data("select2", this);
 
             this.dropdown = this.container.find(".select2-drop");
-            this.dropdown.addClass(evaluate(opts.dropdownCssClass));
-            this.dropdown.data("select2", this);
 
             syncCssClasses(this.dropdown, this.opts.element, this.opts.adaptDropdownCssClass);
+            
+            this.dropdown.addClass(evaluate(opts.dropdownCssClass));
+            this.dropdown.data("select2", this);
 
             this.results = results = this.container.find(resultsSelector);
             this.search = search = this.container.find("input.select2-input");


### PR DESCRIPTION
Fixes issue #1615 where dropdownCssClass is no longer applied.
