### PR TITLE
Cleanup CSS

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -124,7 +124,6 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     z-index: 9998;
     /* styles required for IE to work */
     background-color: #fff;
-    opacity: 0;
     filter: alpha(opacity=0);
 }
 


### PR DESCRIPTION
Removes outdated or never used vendor prefixes and one duplicate property. Saves around 1.5 KB in file size.

Source for gradients and browser market share is http://caniuse.com/#feat=css-gradients

Regarding khtml I suggest the research from @paulirish at Modernizr/Modernizr#454

IMO the the moz prefix could be dropped for gradients as well, but there are a bit more users affected so I didn't want to dump this in here.
