### PR TITLE
Fix the focus when list is closed on the mouse click event

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1267,7 +1267,7 @@ the specific language governing permissions and limitations under the Apache Lic
                         if (self.opts.selectOnBlur) {
                             self.selectHighlighted({noFocus: true});
                         }
-                        self.close({focus:false});
+                        self.close({focus:true});
                         e.preventDefault();
                         e.stopPropagation();
                     }


### PR DESCRIPTION
In single selection instance, when you click on the "title" of select2, the container is marked active but you no longer have the possibility to move the focus (with tab key).
