### PR TITLE
Reset focus to the default element (<body>) when closing the dropdown.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1328,6 +1328,8 @@ the specific language governing permissions and limitations under the Apache Lic
             this.clearSearch();
             this.search.removeClass("select2-active");
             this.opts.element.trigger($.Event("select2-close"));
+
+            document.activeElement.blur();
         },
 
         /**


### PR DESCRIPTION
Fixes issue #1654.
