### PR TITLE
Remove isPlaceholderOptionSelected from setPlaceholder

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2143,7 +2143,7 @@ the specific language governing permissions and limitations under the Apache Lic
         setPlaceholder: function () {
             var placeholder = this.getPlaceholder();
 
-            if (this.isPlaceholderOptionSelected() && placeholder !== undefined) {
+            if (placeholder !== undefined) {
 
                 // check for a placeholder option if attached to a select
                 if (this.select && this.getPlaceholderOption() === undefined) return;


### PR DESCRIPTION
The placeholder should be set if any valid placeholder has been specified, not just through setting the placeholder arg when calling select2(). The new line sets the placeholder is getPlaceholder() returns a valid value (e.g. if data-placeholder, placeholder, or placeholder options are set).
