### PR TITLE
In multi, autoselect the next option on select.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2749,6 +2749,7 @@ the specific language governing permissions and limitations under the Apache Lic
                         this.updateResults(true);
                     }
                     this.positionDropdown();
+                    this.highlight(0);
                 } else {
                     // if nothing left to select close
                     this.close();


### PR DESCRIPTION
When you hit enter twice within a multiselect without closeOnSelect, you end up selecting the option twice. This is because the option, after being added the first time, is still considered "selected."

https://github.com/ivaynberg/select2/issues/243

Our solution is to select the next option automatically. This is a behavioral change, but we do believe it to be the right one; if a user hits enter multiple times, it is most likely because the user wants to select multiple items.
