### PR TITLE
Clicking outside of dropdown should remove select2-container-active class.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1321,7 +1321,7 @@ the specific language governing permissions and limitations under the Apache Lic
             $("#select2-drop-mask").hide();
             this.dropdown.removeAttr("id"); // only the active dropdown has the select2-drop id
             this.dropdown.hide();
-            this.container.removeClass("select2-dropdown-open");
+            this.container.removeClass("select2-dropdown-open").removeClass("select2-container-active");
             this.results.empty();
 
 


### PR DESCRIPTION
If you open a select2 dropdown, then click anywhere to close it, it does not remove the `select2-container-active` class. This can lead to it appearing as if multiple select2 dropdowns are selected.

I made [select2.js#L1324](https://github.com/duckinator/select2/blob/3c2d7f7310c5323827069eab6be1d7a0243dfc0c/select2.js#L1324) remove the `select2-container-active` class, mirroring the behavior found at [select2.js#L1248](https://github.com/ivaynberg/select2/blob/c4529b8700fb1cc2de5e06b9177147581e0e69d5/select2.js#L1248). It already worked when navigating using the keyboard.

Closes #1661.
