### PR TITLE
Avoid locked options to be selected and deleted.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2445,7 +2445,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.selection = selection = this.container.find(selector);
 
             var _this = this;
-            this.selection.on("click", ".select2-search-choice", function (e) {
+            this.selection.on("click", ".select2-search-choice:not(.select2-locked)", function (e) {
                 //killEvent(e);
                 _this.search[0].focus();
                 _this.selectChoice($(this));


### PR DESCRIPTION
Fix for issue #1634.

Avoid the locked options to be selected and deleted.
