### PR TITLE
formatResultCssClass option ignored when attached to select

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -948,7 +948,6 @@ the specific language governing permissions and limitations under the Apache Lic
                 });
                 // this is needed because inside val() we construct choices from options and there id is hardcoded
                 opts.id=function(e) { return e.id; };
-                opts.formatResultCssClass = function(data) { return data.css; };
             } else {
                 if (!("query" in opts)) {
 
@@ -3154,7 +3153,7 @@ the specific language governing permissions and limitations under the Apache Lic
         sortResults: function (results, container, query) {
             return results;
         },
-        formatResultCssClass: function(data) {return undefined;},
+        formatResultCssClass: function(data) {return data.css;},
         formatSelectionCssClass: function(data, container) {return undefined;},
         formatNoMatches: function () { return "No matches found"; },
         formatInputTooShort: function (input, min) { var n = min - input.length; return "Please enter " + n + " more character" + (n == 1? "" : "s"); },


### PR DESCRIPTION
Working on #1682 I noticed that a custom implementation of the function `formatResultCssClass` is never called as its behavior is always overwriten by:

``` javascript
opts.formatResultCssClass = function(data) { return data.css; }; 
```

So I removed that line and made `return data.css` as the default behavior in the user options. This way it is possible to provide a custom implementation of `formatResultCssClass`.

Let me know if that works.
