### PR TITLE
Edit the default initSelection function to pass all tag properties

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -974,10 +974,11 @@ the specific language governing permissions and limitations under the Apache Lic
                             opts.initSelection = function (element, callback) {
                                 var data = [];
                                 $(splitVal(element.val(), opts.separator)).each(function () {
-                                    var id = this, text = this, tags=opts.tags;
+                                    var obj = { id: this, text: this },
+                                        tags = opts.tags;
                                     if ($.isFunction(tags)) tags=tags();
-                                    $(tags).each(function() { if (equal(this.id, id)) { text = this.text; return false; } });
-                                    data.push({id: id, text: text});
+                                    $(tags).each(function() { if (equal(this.id, obj.id)) { obj = this; return false; } });
+                                    data.push(obj);
                                 });
 
                                 callback(data);


### PR DESCRIPTION
The function will now pass all properties of the objects passed as tags to the constructor, not just the "id" and "text" properties. Because a tag is not always just an id and a text, just like when you provide the items with the "data" object instead.

This makes sure these properties are always available at the runtime of formatSelection(), which is not currently the case when the field is repopulated on a triggered "change" event.

It would allow me to do this without overriding initSelection() in the constructor :

$el.select2({
...,
tags: [{
  //id
  id: 1,
  //the string that will matched against the user's query
  text: 'martin smith greatmartin@provider.com'
  //the label of the item that will be shown if this tag is selected
  label: 'M. Smith',
}],
formatSelection: function(object, container){
  return object.label || object.text;
});
