### PR TITLE
Fix focus on select

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2225,7 +2225,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.close();
 
             if (!options || !options.noFocus)
-                this.selection.focus();
+                this.focusser.focus();
 
             if (!equal(old, this.id(data))) { this.triggerChange({added:data,removed:oldData}); }
         },


### PR DESCRIPTION
I noticed this issue while using the [bootstrap integration](https://github.com/t0m/select2-bootstrap-css). When selecting an option, focus was going back to the `select2-choice` element. This would break the flow of navigating the form solely via keyboard, as it would take an extra tab to get back to the `select2-focusser` element. This is illustrated below:

![select2-bootstrap-bad](https://f.cloud.github.com/assets/195134/1100255/9f9a1cbc-1750-11e3-8aa8-4b1960e2ab5b.gif)

Notice how after selecting a choice, the `select2-choice` anchor is focused (yellow), then I must press tab again to focus the `select2-focusser` input, then propagating up to give the all-important `select2-container-active` class to the container, giving the nice blue border.

This breaks the flow of the form (requiring two tab presses) and looks bad if using bootstrap. This fix sends focus right to the `select2-focusser` input on select, and returns it to expected behavior:

![select2-bootstrap-good](https://f.cloud.github.com/assets/195134/1100283/124f1324-1752-11e3-9e20-3be4f44a106b.gif)
