### PR TITLE
Remove negative selector for `.select2-selected`

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1402,7 +1402,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         findHighlightableChoices: function() {
-            return this.results.find(".select2-result-selectable:not(.select2-selected):not(.select2-disabled)");
+            return this.results.find(".select2-result-selectable:not(.select2-disabled)");
         },
 
         // abstract


### PR DESCRIPTION
We use a select2 instance for tag selection and want to display the current selected tags in the dropdown. Styling the selected elements can be done by selecting the `.select2-selected` class:

``` css
.select2-results .select2-selected {
   display: list-item;
   // More specific styling for a selected element
}
```

When applying this CSS to select2, the behaviour of the dropdown gets unexpected. An example can be found in jsFiddle: http://jsfiddle.net/nSWAz/ Steps to follow:
1. Give the dropdown focus
2. Mouseover the "yellow" option
3. The dropdown will scroll to the topmost position

This pull request changes how the "highlightableChoices" are selected. I don't have a complete overview of the purpose of this method, but I've tested the behaviour of select2 and all seems to be working. Both when displaying and hiding the selected options, the dropdown functions properly and scrolling works ok.
