### PR TITLE
dropdown repostion fix when previous postion changes container position

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1130,7 +1130,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         positionDropdown: function() {
-            var $dropdown = this.dropdown,
+            var $dropdown = this.dropdown.hide(),
                 offset = this.container.offset(),
                 height = this.container.outerHeight(false),
                 width = this.container.outerWidth(false),
@@ -1148,6 +1148,8 @@ the specific language governing permissions and limitations under the Apache Lic
                 above,
                 css,
                 resultsListNode;
+
+            $dropdown.show();
 
             if (this.opts.dropdownAutoWidth) {
                 resultsListNode = $('.select2-results', $dropdown)[0];


### PR DESCRIPTION
Had some issues with dropdown position if showing it creates a scroll on the page.
so I changed the code so it will hide the dropdown before it recalculate its fixed position

![pos](https://f.cloud.github.com/assets/1829789/1149082/3f7aab5e-1ed4-11e3-9a51-a1a687e2edef.png)

example of the problem
http://jsfiddle.net/CGBRX/
