### PR TITLE
Use more specific selector for finding options of a select

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1708,7 +1708,7 @@ the specific language governing permissions and limitations under the Apache Lic
         // abstract
         getPlaceholderOption: function() {
             if (this.select) {
-                var firstOption = this.select.children().first();
+                var firstOption = this.select.children('option').first();
                 if (this.opts.placeholderOption !== undefined ) {
                     //Determine the placeholder option based on the specified placeholderOption setting
                     return (this.opts.placeholderOption === "first" && firstOption) ||


### PR DESCRIPTION
I'm using Select2 with Ember.js. Ember automatically inserts `script` tags for its own purposes, which breaks Select2's placeholder. The generated html looks like this:

``` html
<select>
  <script id="metamorph-7-start" type="text/x-placeholder"></script>
  <option value=""></option>
  <script id="metamorph-7-end" type="text/x-placeholder"></script>
</select>
```

With this small PR, Select2 works with Ember seamlessly.
