### PR TITLE
Compatibility with jQuery 1.9 +

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1854,7 +1854,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.parent.close.apply(this, arguments);
 
             params = params || {focus: true};
-            this.focusser.removeAttr("disabled");
+            this.focusser.prop("disabled", false);
 
             if (params.focus) {
                 this.focusser.focus();
@@ -1866,7 +1866,7 @@ the specific language governing permissions and limitations under the Apache Lic
             if (this.opened()) {
                 this.close();
             } else {
-                this.focusser.removeAttr("disabled");
+                this.focusser.prop("disabled", false);
                 this.focusser.focus();
             }
         },
@@ -1879,7 +1879,7 @@ the specific language governing permissions and limitations under the Apache Lic
         // single
         cancel: function () {
             this.parent.cancel.apply(this, arguments);
-            this.focusser.removeAttr("disabled");
+            this.focusser.prop("disabled", false);
             this.focusser.focus();
         },
 


### PR DESCRIPTION
removeAttr("disabled') is no longer correct as of version 1.9 of jQuery. Should use prop("disabled", false) instead.

See http://jquery.com/upgrade-guide/1.9/#attr-versus-prop-
