### PR TITLE
added if condition to formatNoMatches func

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1639,7 +1639,12 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
 
                 if (data.results.length === 0 && checkFormatter(opts.formatNoMatches, "formatNoMatches")) {
-                    render("<li class='select2-no-results'>" + opts.formatNoMatches(search.val()) + "</li>");
+                    var msg = opts.formatNoMatches(search.val());
+                    if(typeof msg === 'object')
+                        render(msg);
+                    else
+                        render("<li class='select2-no-results'>" + msg + "</li>");
+
                     return;
                 }
 


### PR DESCRIPTION
- if no matches found message is string, just render it, otherwise pass it to render function as an object

The reason I did is that I was using ui-select2 for AngularJS. I wanted to place a button when there is no results for the search. It looks like this:

![image](https://f.cloud.github.com/assets/3432700/1162130/c276ab68-2003-11e3-8af2-da7512e37577.png)

Here is the no matches found string I was passing to formatNoMatches function:

``` javascript
var msg = '<p>No matches found. <button style="float:right;" data-ng-click="inviteUser(term)" type="button" class="btn btn-mini btn-info ng-binding">Invite!</button></p>';
```

Problem here is that when user clicks on invite button, it doesnt call Angular function inviteUser, because we didn't compile it. After I compile this html using:

``` javascript
            return $compile(msg)($scope);
```

it returns me javascript object. And when I pass this object to render function;

``` javascript
render("<li class='select2-no-results'>" + opts.formatNoMatches(search.val()) + "</li>");
```

here is the output:

```
<li class='select2-no-results'>[object object]</li>
```

To avoid this, I put if-else statement. If it is object, don't include li tags, otherwise use it as a string.

There is this directive to allow us use this library in AngularJS
https://github.com/angular-ui/ui-select2

But I couldn't have time to modify it to fix this problem. Please let me know if there is simple way to achieve this.

Thanks.
