### PR TITLE
append label only when formatted is not undefined

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -883,9 +883,9 @@ the specific language governing permissions and limitations under the Apache Lic
                             formatted=opts.formatResult(result, label, query, self.opts.escapeMarkup);
                             if (formatted!==undefined) {
                                 label.html(formatted);
+                                node.append(label);
                             }
 
-                            node.append(label);
 
                             if (compound) {
 


### PR DESCRIPTION
I'm using select2 to fetch remote infinite data, but all of the data belong to a optgroup, like

```
Empty (optgroup)
  box1
  box2
  ...
```

it works well for the first request, but from second request, it generates Empty optgroup every time, which is not my expectation.

My solution is override formatResult method, return undefined if the optgroup already exists, then fork select2, check `formatResult` result, if it is undefined, I don't append the container.
