### PR TITLE
Allow minimumInputLength to be specified as a function

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1359,6 +1359,11 @@ the specific language governing permissions and limitations under the Apache Lic
         },
 
         // abstract
+        getMinimumInputLength: function() {
+            return evaluate(this.opts.minimumInputLength);
+        },
+
+        // abstract
         ensureHighlightVisible: function () {
             var results = this.results, children, index, child, hb, rb, y, more;
 
@@ -1568,9 +1573,10 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             }
 
-            if (search.val().length < opts.minimumInputLength) {
+            var minInpLen = this.getMinimumInputLength();
+            if (search.val().length < minInpLen) {
                 if (checkFormatter(opts.formatInputTooShort, "formatInputTooShort")) {
-                    render("<li class='select2-no-results'>" + opts.formatInputTooShort(search.val(), opts.minimumInputLength) + "</li>");
+                    render("<li class='select2-no-results'>" + opts.formatInputTooShort(search.val(), minInpLen) + "</li>");
                 } else {
                     render("");
                 }


### PR DESCRIPTION
I needed modify minimumInputLength programmatically, based on which way the widget was activated.

This patch changes minimumInputLength so it can be either an integer or a function which returns an integer, similar to maximumSelectionSize.
