### PR TITLE
Add option for placing created search choices at start or end of list

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1633,7 +1633,11 @@ the specific language governing permissions and limitations under the Apache Lic
                             function () {
                                 return equal(self.id(this), self.id(def));
                             }).length === 0) {
-                            data.results.unshift(def);
+                            if (this.opts.createdSearchChoiceFirst) {
+                                data.results.unshift(def);
+                            } else {
+                                data.results.push(def);
+                            }
                         }
                     }
                 }
@@ -3186,7 +3190,8 @@ the specific language governing permissions and limitations under the Apache Lic
         selectOnBlur: false,
         adaptContainerCssClass: function(c) { return c; },
         adaptDropdownCssClass: function(c) { return null; },
-        nextSearchTerm: function(selectedObject, currentSearchTerm) { return undefined; }
+        nextSearchTerm: function(selectedObject, currentSearchTerm) { return undefined; },
+        createdSearchChoiceFirst: true
     };
 
     $.fn.select2.ajaxDefaults = {


### PR DESCRIPTION
`createSearchChoice` would by default put a user's search term above existing entries; the changes here introduce a `createdSearchChoiceFirst` boolean option to define whether a user's search term should go at the start or the end of the list.

By default `createdSearchChoiceFirst` is set to `true`, so this will behave exactly as it did without this option. If `createdSearchChoiceFirst` is set to `false` then a user's search term will come up last.
