### PR TITLE
Introduced getOuterHeight and getOuterWidth

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1182,7 +1182,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 offset = this.container.offset(),
                 height = getOuterHeight(this.container),
                 width = getOuterWidth(this.container),
-				dropHeight = getOuterHeight($dropdown),
+                dropHeight = getOuterHeight($dropdown),
                 viewPortRight = $(window).scrollLeft() + $(window).width(),
                 viewportBottom = $(window).scrollTop() + $(window).height(),
                 dropTop = offset.top + height,


### PR DESCRIPTION
getOuterHeight and getOuterWidth use element.getBoundingClientRect (if
available) to get the height or width with fractions. jQuery.outerHeight
and jQuery.outerWidth truncate to an integer, sometimes giving a
slightly incorrect result.

This gave a slight misalignment when using select2 with bootstrap 3.
