### PR TITLE
Adding a optional parentElement

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -674,7 +674,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.container.attr("id", this.containerId);
 
             // cache the body so future lookups are cheap
-            this.body = thunk(function() { return opts.element.closest("body"); });
+            this.body = thunk(function() { return opts.parentElement || opts.element.closest("body"); });
 
             syncCssClasses(this.container, this.opts.element, this.opts.adaptContainerCssClass);
 


### PR DESCRIPTION
Page 1: uses select2 plugin
![screen shot 2013-09-27 at 2 43 04 pm-small](https://f.cloud.github.com/assets/1859514/1224803/90f65904-2755-11e3-9959-75a83cf8b619.png)
Page 2: still displays dropdown
![screen shot 2013-09-27 at 2 43 19 pm-small](https://f.cloud.github.com/assets/1859514/1224806/96ce3cca-2755-11e3-8566-8f7e38b173ac.png)

dropdown menu lingers around in backbone js apps.

At present select2 appends the created div elements to body tag.
But when I use select2 with my Backbone JS application I face problems because body tag is not emptied every time. I only render a part of the body.
So I found it beneficial to externally control the parentElement to which select2 adds new elements.
These elements are automatically deleted when parentElement is destroyed.
