### PR TITLE
Fix selection first element from "postprocessResults"

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1404,7 +1404,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         findHighlightableChoices: function() {
-            return this.results.find(".select2-result-selectable:not(.select2-disabled)");
+            return this.results.find(".select2-result-selectable:not(.select2-disabled, .select2-selected)");
         },
 
         // abstract


### PR DESCRIPTION
Fix selection first element from "postprocessResults" - exclude selected elements from highlightable elements
