### PR TITLE
Fixed leaked body click event in IE

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1282,9 +1282,9 @@ the specific language governing permissions and limitations under the Apache Lic
                 });
             }
 
-            // ensure the mask is always right before the dropdown
-            if (this.dropdown.prev()[0] !== mask[0]) {
-                this.dropdown.before(mask);
+            // ensure the mask is always the first element in the dropdown container
+            if (this.container.first()[0] !== mask[0]) {
+                this.container.prepend(mask);
             }
 
             // move the global id to the correct dropdown


### PR DESCRIPTION
This is a fix for https://github.com/ivaynberg/select2/issues/1058 which still occurs in version 3.4.3.

Here is an example with buggy version 3.4.3:
http://jsfiddle.net/nfAXH/
Only in IE, when clicking on the select2, a click on the body is leaked.

Here is the exact same example with the fix:
http://jsfiddle.net/zH4yY/
Now when clicking on the on the select2 in Internet Explorer, no click event is leaked anymore.

Why?
Because the "#select2-drop-mask" is moved inside the container (as you can see in this commit). And as of line 714

```
  this.container.on("click", killEvent);
```

any click on the container gets killed.
