### PR TITLE
Fixes #1758

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2775,6 +2775,9 @@ the specific language governing permissions and limitations under the Apache Lic
                 this.close();
                 this.search.width(10);
             } else {
+                
+                this.clearSearch();
+                
                 if (this.countSelectableResults()>0) {
                     this.search.width(10);
                     this.resizeSearch();


### PR DESCRIPTION
This is a fix for issue 1758: https://github.com/ivaynberg/select2/issues/1758

We use select2 at www.ecscapethecity.org and after some extensive user testing we figured it makes for a better user experience when the text a user entered is removed when closeOnSelect is false.

We want our users to select multiple tags easily - hence the closeOnSelect false - after a select has triggered the remaining text limits their view on other remaining tags. I have watched our testers hitting the delete key extensively because of this.
