### PR TITLE
Added Zepto compatibility. Please see my messages in the pull request.

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -261,11 +261,6 @@ Version: @@ver@@ Timestamp: @@timestamp@@
             box-shadow: 0 0 5px rgba(0, 0, 0, .3);
 }
 
-.using-zepto.select2-container-active .select2-choice,
-.using-zepto.select2-container-active .select2-choices {
-    z-index: 9999;
-}
-
 .select2-dropdown-open .select2-choice {
     border-bottom-color: transparent;
     -webkit-box-shadow: 0 1px 0 #fff inset;

--- a/select2.js
+++ b/select2.js
@@ -37,7 +37,7 @@ the specific language governing permissions and limitations under the Apache Lic
         });
     }
 
-    if(typeof $.data == "undefined") {
+    if(typeof $.data === "undefined") {
         $.extend($, {
             data : function(elem, key, value){
                 return $(elem).data(key, value);
@@ -48,8 +48,30 @@ the specific language governing permissions and limitations under the Apache Lic
         });
     }
 
-    if(typeof $.fn.scrollLeft == "undefined") {
-        $.extend($, {
+    if(typeof $.fn.outerWidth === "undefined"){
+        $.extend($.fn, {
+            outerWidth : function(value){
+                if(!value){
+                    return this.width();
+                }
+                return this.width(value);
+            },
+        });
+    }
+
+    if(typeof $.fn.outerHeight === "undefined"){
+        $.extend($.fn, {
+            outerHeight : function(value){
+                if(!value){
+                    return this.height();
+                }
+                return this.height(value);
+            },
+        });
+    }
+
+    if(typeof $.fn.scrollLeft === "undefined") {
+        $.extend($.fn, {
             scrollLeft : function(value){
               if (!this.length) return
               var hasScrollLeft = 'scrollLeft' in this[0]
@@ -1156,9 +1178,9 @@ the specific language governing permissions and limitations under the Apache Lic
         positionDropdown: function() {
             var $dropdown = this.dropdown,
                 offset = this.container.offset(),
-                height = (typeof this.container.outerHeight !== "undefined") ? this.container.outerHeight(false) : this.container.height(),
-                width = (typeof this.container.outerWidth!== "undefined") ?this.container.outerWidth(false) : this.container.width(),
-                dropHeight = (typeof $dropdown.outerHeight !== "undefined") ? $dropdown.outerHeight(false) : $dropdown.height(false),
+                height = this.container.outerHeight(false),
+                width = this.container.outerWidth(false),
+                dropHeight = $dropdown.outerHeight(false),
                 $window = $(window),
                 windowWidth = $window.width(),
                 windowHeight = $window.height(),
@@ -1168,7 +1190,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 dropLeft = offset.left,
                 enoughRoomBelow = dropTop + dropHeight <= viewportBottom,
                 enoughRoomAbove = (offset.top - dropHeight) >= this.body().scrollTop(),
-                dropWidth = (typeof $dropdown.outerWidth !== "undefined") ? $dropdown.outerWidth(false) : $dropdown.width(false),
+                dropWidth = $dropdown.outerWidth(false),
                 enoughRoomOnRight = dropLeft + dropWidth <= viewPortRight,
                 aboveNow = $dropdown.hasClass("select2-drop-above"),
                 bodyOffset,
@@ -1196,14 +1218,14 @@ the specific language governing permissions and limitations under the Apache Lic
             if (changeDirection) {
                 $dropdown.hide();
                 offset = this.container.offset();
-                height = (typeof this.container.outerHeight !== "undefined") ? this.container.outerHeight(false) : this.container.height(),
-                width = (typeof this.container.outerWidth!== "undefined") ?this.container.outerWidth(false) : this.container.width(),
-                dropHeight = (typeof $dropdown.outerHeight !== "undefined") ? $dropdown.outerHeight(false) : $dropdown.height(false),
-                viewPortRight = $window.scrollLeft() + windowWidth,
-                viewportBottom = $window.scrollTop() + windowHeight,
-                dropTop = offset.top + height,
-                dropLeft = offset.left,
-                dropWidth = (typeof $dropdown.outerWidth !== "undefined") ? $dropdown.outerWidth(false) : $dropdown.width(false),
+                height = this.container.outerHeight(false);
+                width = this.container.outerWidth(false);
+                dropHeight = $dropdown.outerHeight(false);
+                viewPortRight = $window.scrollLeft() + windowWidth;
+                viewportBottom = $window.scrollTop() + windowHeight;
+                dropTop = offset.top + height;
+                dropLeft = offset.left;
+                dropWidth = $dropdown.outerWidth(false);
                 enoughRoomOnRight = dropLeft + dropWidth <= viewPortRight;
                 $dropdown.show();
             }
@@ -1213,7 +1235,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 $dropdown.addClass('select2-drop-auto-width');
                 $dropdown.css('width', '');
                 // Add scrollbar width to dropdown if vertical scrollbar is present
-                dropWidth = (typeof $dropdown.outerWidth !== "undefined") ? $dropdown.outerWidth(false) : $dropdown.width(false), + (resultsListNode.scrollHeight === resultsListNode.clientHeight ? 0 : scrollBarDimensions.width);
+                dropWidth = $dropdown.outerWidth(false) + (resultsListNode.scrollHeight === resultsListNode.clientHeight ? 0 : scrollBarDimensions.width);
                 dropWidth > width ? width = dropWidth : dropWidth = width;
                 enoughRoomOnRight = dropLeft + dropWidth <= viewPortRight;
             }


### PR DESCRIPTION
So, I've ported the select2 plugin to work with Zepto, this pull request gonna be a little lengthy, but please bear with me. 

**Zepto requirements**
Besides the modules included in Zepto by default it also, needs the data and selector Zepto module.

**What is changed?**
Firstly, if you use jQuery the code is the same, I used safety checks so it only uses the modified code, if you use Zepto.
- **`$`** - the plugin can use both jQuery and Zepto, but it prioritizes jQuery if you have both
- **`outerWidth, outerHeight`** - it uses `width()`, and `height()` instead which is the same in Zepto as `outerHeight(false)` / `outerWidth(false)` in jQuery.
- **`scrollLeft()`** - this isnt availabale in Zepto for some reason (they have scrollTop, so I don't understand why) Now if you use the plugin with Zepto it adds the `scrollLeft()` function to the `$` object. I also sent a pull request to Zepto with the same implementation, but until they accept it, it is here and it  works
- **`addClas(), toggleClass()`** -there is a bug in Zepto, if you call these two function with empty parameters it freezes, the script (as it will try to acces the split() method of a undefined or a null object). I fixed it here and also sent a pull request to Zepto.
- **updated selectors** - if you use Zepto instead of the `$(':not')` selector, you use the `$.fn.not()` function, which does the same thing basically.
- **CSS changes** - I added a class if you are using Zepto, so you can easily detect it. Also when the dropdown is open you can't see the selecteed choice by default, so I added a CSS rule that sets it z-index higher (but only if you are using Zepto

I think these are the most important changes, I made.

**How these changes enlarge the plugin's size?**
I only checked the unminified version. The plugin's size is increased by 2 kilobytes, the CSS's increased by kilobyte. This includes some patches to Zepto (like the scrollLeft and addClass functions) which can be removed when/if they accept my pull requests. (of course that would also mean loosing backward compatibility too)

**So really EVERYTHING works?**
If you are using jQuery it uses the same code so, yeah everything. For the Zepto, as I couldn't find any tests its hard to tell. I only needed a very minimal select (only used the minimumWidth and minimumResultsForSearch options), and that works perfectly. If you find issues with it I'm willing to contribute and fix it, so just add them as issues.
