### PR TITLE
Modified syncCssClasses to use output of adapter when applying classes.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -349,7 +349,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 if (this.indexOf("select2-") !== 0) {
                     adapted = adapter(this);
                     if (adapted) {
-                        replacements.push(this);
+                        replacements.push(adapted);
                     }
                 }
             });


### PR DESCRIPTION
The docs for adaptContainerCssClass and adaptDropdownCssClass state that the two functions can be used to change the classes being applied to the container/dropdown when classes are synced, but syncCssClasses was only using the output to determine if classes should be applied or not.
