### PR TITLE
Styling fixes for RTL direction

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -460,6 +460,10 @@ disabled look for disabled choices in the results dropdown
     float: left;
     list-style: none;
 }
+html[dir="rtl"] .select2-container-multi .select2-choices li
+{
+    float: right;
+}
 .select2-container-multi .select2-choices .select2-search-field {
     margin: 0;
     padding: 0;
@@ -518,6 +522,11 @@ disabled look for disabled choices in the results dropdown
     background-image: -moz-linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%);
     background-image: linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%);
 }
+html[dir="rtl"] .select2-container-multi .select2-choices .select2-search-choice
+{
+    margin-left: 0;
+    margin-right: 5px;
+}
 .select2-container-multi .select2-choices .select2-search-choice .select2-chosen {
     cursor: default;
 }
@@ -536,6 +545,10 @@ disabled look for disabled choices in the results dropdown
     font-size: 1px;
     outline: none;
     background: url('select2.png') right top no-repeat;
+}
+html[dir="rtl"] .select2-search-choice-close {
+    right: auto;
+    left: 3px;
 }
 
 .select2-container-multi .select2-search-choice-close {


### PR DESCRIPTION
- Align the selects to the right
- Place the close button on the left to not cover parts of the label.
