### PR TITLE
Allow jQuery objects to be returned by formatNoMatches

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1668,7 +1668,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
 
                 if (data.results.length === 0 && checkFormatter(opts.formatNoMatches, "formatNoMatches")) {
-                    render("<li class='select2-no-results'>" + opts.formatNoMatches(search.val()) + "</li>");
+                    render($(opts.formatNoMatches(search.val())).wrap("<li class='select2-no-results'></li>").parent());
                     return;
                 }
 


### PR DESCRIPTION
The change is identical in behaviour, only with the added benefit of creating more interactive messages - perhaps a link with some events attached, for example:

No results, /click here to learn why/

Also, it would probably be in good style to use jQuery wrap() instead of wrapping with string concatenations
