### PR TITLE
Allow formatSelection to return a DOM or jQuery element

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2500,7 +2500,9 @@ the specific language governing permissions and limitations under the Apache Lic
             var _this = this;
             this.selection.on("click", ".select2-search-choice:not(.select2-locked)", function (e) {
                 //killEvent(e);
-                _this.search[0].focus();
+                if (_this.opts.focusSearchChoice) {
+                    _this.search[0].focus();
+                }
                 _this.selectChoice($(this));
             });
 
@@ -3219,6 +3221,7 @@ the specific language governing permissions and limitations under the Apache Lic
         dropdownCss: {},
         containerCssClass: "",
         dropdownCssClass: "",
+        focusSearchChoice: true,
         formatResult: function(result, container, query, escapeMarkup) {
             var markup=[];
             markMatch(result.text, query.term, markup, escapeMarkup);


### PR DESCRIPTION
Instead of coercing all results of `formatSelection` into a string, check to see if the function returns a string or a jQuery/DOM object.  If that's the case, just insert it directly into the DOM.

This allows users to return more complicated objects, with event listeners, etc. attached.
