### PR TITLE
Added option to keep search results after select close

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1664,7 +1664,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 queryNumber = ++this.queryCount;
 
                 if (opts.formatSearching && this.findHighlightableChoices().length === 0) {
-                    render("<li class='select2-searching'>" + opts.formatSearching() + "</li>");
+                    render("<li class='select2-searching'>" + evaluate(opts.formatSearching) + "</li>");
                 }
 
                 search.addClass("select2-active");


### PR DESCRIPTION
This PR extends [PR#1273](https://github.com/ivaynberg/select2/pull/1273) and addresses issues [#694](https://github.com/ivaynberg/select2/issues/694) and [#1347](https://github.com/ivaynberg/select2/issues/1347)
Also, usage of this option fixes incorrect scrollbar position after re-opening select.
One thing I can't understand is a line:

```
this.search.val(this.focusser.val());
```

I've commented this line in my PR because I do not understand it's purpose.
Comments are welcome.

PS: git shows many changed lines because it takes into account whitespaces in diff. Use 'git diff -w' to view actual diff.
