### PR TITLE
Solved unexpected click events on BODY in Internet Explorer

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -310,7 +310,7 @@ the specific language governing permissions and limitations under the Apache Lic
         event.preventDefault();
         event.stopImmediatePropagation();
         // same as above
-		$(event.delegateTarget).trigger(event.type + "Silent");
+        $(event.delegateTarget).trigger(event.type + "Silent");
     }
 
     function measureTextWidth(e) {


### PR DESCRIPTION
Summary of the issue targeted by this pull request : Select2 triggers unexpected clicks on the body tag, but only in Internet Explorer. See issue https://github.com/ivaynberg/select2/issues/1058

This small patch only makes Select2 compatible with the XClick plugin I created here : https://github.com/louisameline/XClick. This plugin mostly solves the x-clicks issue in Internet Explorer, which is more complex and may impact any scripts, not just Select2.

So, once this patch has been merged into Select2, users who wish to adress this click event issue can just include the XClick plugin on their page and call :

```
var XClick = new $.XClick();
XClick.prebind('body');
```

That's as hard as it gets.

Thanks !

**_Edit**_ : although XClick addresses the x-click issue in general in a more reliable manner, jpotterm's solution is way shorter and should be enough for Select2's use case (I have not extensively tested it though). Not sure if his solution should include a dirty browser detection though, as it would be a pity if it caused a bug in other browsers one day.
