### PR TITLE
Fix some coding issues found with jshint

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1044,7 +1044,8 @@ the specific language governing permissions and limitations under the Apache Lic
             observer = window.MutationObserver || window.WebKitMutationObserver|| window.MozMutationObserver;
             if (observer !== undefined) {
                 if (this.propertyObserver) { delete this.propertyObserver; this.propertyObserver = null; }
-                this.propertyObserver = new Observer(this.mutationCallback);
+                /*jshint -W055 */
+                this.propertyObserver = new observer(this.mutationCallback);
                 this.propertyObserver.observe(el.get(0), { attributes:true, subtree:false });
             }
         },


### PR DESCRIPTION
Found while validating all the scripts we're using.
Used jshint config:

{
"es3" : true,
"eqeqeq" : false,
"eqnull" : true,
"lastsemic" : true,
"evil" : true,
"asi" : true,
"sub" : true,
"boss" : true,
"expr" : true,
"proto" : true,     // http://jshint.com/docs/options/#proto
"loopfunc" : true,  // http://jshint.com/docs/options/#loopfunc
"laxcomma" : true,  // http://jshint.com/docs/options/#laxcomma
"laxbreak" : true   // http://jshint.com/docs/options/#laxbreak
}

Violations found (linenumbers against 3.4.5):

```
52: 'KEY' is already defined.
245: Unnecessary semicolon.
414: Possible strict violation.
613: Possible strict violation.
638: Missing '()' invoking a constructor.
1043: A constructor name should start with an uppercase letter.
1291: Use '===' to compare with '0'.
1394: Use '===' to compare with '0'.
1491: Use '===' to compare with '0'.
1624: Use '!==' to compare with 'undefined'.
1760: Possible strict violation.
1762: Possible strict violation.
1763: Possible strict violation.
1764: Possible strict violation.
1766: Possible strict violation.
1777: Possible strict violation.
1780: Possible strict violation.
1784: Possible strict violation.
1788: Possible strict violation.
1789: Possible strict violation.
1791: Possible strict violation.
1793: Unnecessary semicolon.
1864: Use '!==' to compare with 'undefined'.
2349: Use '===' to compare with 'undefined'.
2539: Use '===' to compare with '0'.
2751: Use '!==' to compare with 'undefined'.
2823: Use '!==' to compare with 'undefined'.
2827: Use '!==' to compare with 'undefined'.
2927: Confusing use of '!'.
3000: 'current' is already defined.
3001: 'old' is already defined.
3009: Mixed spaces and tabs.
```
