### PR TITLE
fix for Uncaught TypeError: Object #<Object> has no method 'abort'

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -431,7 +431,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 data = data ? data.call(self, query.term, query.page, query.context) : null;
                 url = (typeof url === 'function') ? url.call(self, query.term, query.page, query.context) : url;
 
-                if (handler) { handler.abort(); }
+                if (handler && typeof handler.abort === "function") { handler.abort(); }
 
                 if (options.params) {
                     if ($.isFunction(options.params)) {


### PR DESCRIPTION
Prevents "Uncaught TypeError: Object #<Object> has no method 'abort'" error for case when non-jQuery promise is used as a handler (AngularJS $promise for example). This is required for better integration with angular-ui-select2 directive.
