### PR TITLE
replace most of jquery function calls with string concatenation in populate()

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -887,7 +887,7 @@ the specific language governing permissions and limitations under the Apache Lic
                             label += ">";
                             formatted=opts.formatResult(result, label, query, self.opts.escapeMarkup);
                             if (formatted!==undefined) {
-                              label += formatted;
+                                label += formatted;
                             }
                             label += "</div>";
 


### PR DESCRIPTION
This significantly speeds up the time populate takes on large datasets.

With 6000 entries the time goes from 980ms to 760ms. A performance increase of 22%.

Also see relevant discussion in issue #781.
