### PR TITLE
Only pick up direct children when retrieving data in 'multiple' mode

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3123,7 +3123,7 @@ the specific language governing permissions and limitations under the Apache Lic
             var self=this, ids, old;
             if (arguments.length === 0) {
                  return this.selection
-                     .find(".select2-search-choice")
+                     .children(".select2-search-choice")
                      .map(function() { return $(this).data("select2-data"); })
                      .get();
             } else {


### PR DESCRIPTION
Prevents accidentally returning the selected items of any select2's embedded in the HTML of this selection's items.

Yes, we are actually embedding select2's within a select2's result items. I was surprised by how well it worked, besides this minor issue.
