### PR TITLE
Cancel dropdown positioning if element isn't attached to the document

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1130,6 +1130,9 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         positionDropdown: function() {
+            if (this.body().length === 0)
+                return;
+
             var $dropdown = this.dropdown,
                 offset = this.container.offset(),
                 height = this.container.outerHeight(false),


### PR DESCRIPTION
If the element isn't attached to the document (which can be determined by whether `body()` returns an empty list), then `positionDropdown()` errors out spectacularly. This adds a check right before its body.
