### PR TITLE
Fix dropdown items not being reset after filtering and selecting when `closeOnSelect` is `false`

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2786,6 +2786,9 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.opts.element.trigger({ type: "selected", val: this.id(data), choice: data });
 
+            this.clearSearch();
+            this.updateResults();
+
             if (this.select || !this.opts.closeOnSelect) this.postprocessResults(data, false, this.opts.closeOnSelect===true);
 
             if (this.opts.closeOnSelect) {


### PR DESCRIPTION
This fixes a bug wherein, when using the standard filtering function and with `closeOnSelect: false`, if the user typed a few characters and hit Enter, the filter would still be applied to the dropdown after selecting the item, even though the text input was blank.
