### PR TITLE
Remove workaround which causes focus to return to select2

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1986,18 +1986,6 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             }));
 
-            this.search.on("blur", this.bind(function(e) {
-                // a workaround for chrome to keep the search field focussed when the scroll bar is used to scroll the dropdown.
-                // without this the search field loses focus which is annoying
-                if (document.activeElement === this.body().get(0)) {
-                    window.setTimeout(this.bind(function() {
-                        if (this.opened()) {
-                            this.search.focus();
-                        }
-                    }), 0);
-                }
-            }));
-
             this.focusser.on("keydown", this.bind(function (e) {
                 if (!this.isInterfaceEnabled()) return;
 


### PR DESCRIPTION
The workaround below causes a problem in the following use case:
1. open the drop down
2. click on the page (outside of the select2 control)
result: the focus returns to the select2 control

The issue that was supposed to be fixed by this workaround -
https://github.com/ivaynberg/select2/issues/939
An issue about the problem this workaround creates -
https://github.com/ivaynberg/select2/pull/1667
