### PR TITLE
remove paste event

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -738,7 +738,7 @@ the specific language governing permissions and limitations under the Apache Lic
             }
 
             installKeyUpChangeEvent(search);
-            search.on("keyup-change input paste", this.bind(this.updateResults));
+            search.on("keyup-change input", this.bind(this.updateResults));
             search.on("focus", function () { search.addClass("select2-focused"); });
             search.on("blur", function () { search.removeClass("select2-focused");});
 


### PR DESCRIPTION
I'm not sure what for there is "paste" event. It seems that "input" triggered on paste. But when executing both events, I get 2 xhr
- "paste" event with term what I got before paste
- "input" event with term what I got after paste

Second xhr can execute faster than first, because it contains less data. Thus I've got full list of result, instead of filtered by pasted value.
