### PR TITLE
Fix #1946: remove an hard coded title attribute.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1820,7 +1820,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 "<div class='select2-drop select2-display-none'>",
                 "   <div class='select2-search'>",
                 "       <input type='text' autocomplete='off' autocorrect='off' autocapitalize='off' spellcheck='false' class='select2-input' role='combobox' aria-expanded='true'",
-                "       aria-autocomplete='list' title='Search field' />",
+                "       aria-autocomplete='list' />",
                 "   </div>",
                 "   <ul class='select2-results' role='listbox'>",
                 "   </ul>",


### PR DESCRIPTION
The original title is copied if defined (see https://github.com/ivaynberg/select2/blob/master/select2.js#L1954) and it's sufficient for accessibility purpose.

We shouldn't force the title attribute, it's especially annoying if people are using tooltip implementation based on the title attribute such as Bootstrap tooltip.
