### PR TITLE
Fix problem with positioning the dropdown when it is on RHS

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1208,7 +1208,7 @@ the specific language governing permissions and limitations under the Apache Lic
             }
 
             if (!enoughRoomOnRight) {
-               dropLeft -= (dropLeft + dropWidth) - viewPortRight;
+                dropLeft = offset.left + this.container.outerWidth(false) - dropWidth;
             }
 
             css =  {


### PR DESCRIPTION
In the stable version this line looks like:

dropLeft = offset.left + width - dropWidth;

In line (1193) the variable width is set to dropWidth which means we are always going to end up with 

dropLeft = offset.left + X - X
or
dropLeft = offset.left

Which means we are still aligned to the left of the button and this is a bug.

This current solution from @ef9f1dea is just aligning the select2-drop closer to the center which is not what it did before the dropdownAutoWidth.

The line I submitted the select2-drop now aligns to the RHS of the button when that button is on the RHS of the page.
