### PR TITLE
Remove hardcoded class names from $.fn.select2

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3185,7 +3185,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     if ("tags" in opts) {opts.multiple = multiple = true;}
                 }
 
-                select2 = multiple ? new window.Select2["class"].multi() : window.Select2["class"].single();
+                select2 = multiple ? new window.Select2["class"].multi() : new window.Select2["class"].single();
                 select2.init(opts);
             } else if (typeof(args[0]) === "string") {
 


### PR DESCRIPTION
## The problem

I find it quite hard to extend select2 (maybe it's just me -- JS is not my specialty) because it guards its internals rather heavily. In particular, it's not possible to influence the constructor of future select2 instances because the code that creates them references constructors captured through closure that are not accessible from a global context.
## The solution

select2 already exposes the constructors for its instances through window.Select2, but those are effectively read-only (changes to them do not matter to the plugin). This patch makes the plugin refer back to those exposed constructors when creating instances, making them "read-write".

It seems to me that this change can only be a good thing.
