### PR TITLE
Add hideSelectionFromResult property

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2225,13 +2225,14 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // single
         postprocessResults: function (data, initial, noHighlightUpdate) {
-            var selected = 0, self = this, showSearchInput = true;
+            var selected = 0, selectedElm = null, self = this, showSearchInput = true;
 
             // find the selected element in the result list
 
             this.findHighlightableChoices().each2(function (i, elm) {
                 if (equal(self.id(elm.data("select2-data")), self.opts.element.val())) {
                     selected = i;
+                    selectedElm = elm;
                     return false;
                 }
             });
@@ -2239,7 +2240,11 @@ the specific language governing permissions and limitations under the Apache Lic
             // and highlight it
             if (noHighlightUpdate !== false) {
                 if (initial === true && selected >= 0) {
-                    this.highlight(selected);
+                    if(this.opts.hideSelectionFromResult){
+                        selectedElm.addClass("select2-selected");
+                    } else {
+                        this.highlight(selected);
+                    }
                 } else {
                     this.highlight(0);
                 }
@@ -2960,9 +2965,11 @@ the specific language governing permissions and limitations under the Apache Lic
             choices.each2(function (i, choice) {
                 var id = self.id(choice.data("select2-data"));
                 if (indexOf(id, val) >= 0) {
-                    choice.addClass("select2-selected");
-                    // mark all children of the selected parent as selected
-                    choice.find(".select2-result-selectable").addClass("select2-selected");
+                    if(self.opts.hideSelectionFromResult === undefined || self.opts.hideSelectionFromResult) {
+                        choice.addClass("select2-selected");
+                        // mark all children of the selected parent as selected
+                       choice.find(".select2-result-selectable").addClass("select2-selected");
+                    }
                 }
             });
 
@@ -3277,7 +3284,8 @@ the specific language governing permissions and limitations under the Apache Lic
         selectOnBlur: false,
         adaptContainerCssClass: function(c) { return c; },
         adaptDropdownCssClass: function(c) { return null; },
-        nextSearchTerm: function(selectedObject, currentSearchTerm) { return undefined; }
+        nextSearchTerm: function(selectedObject, currentSearchTerm) { return undefined; },
+        hideSelectionFromResult: undefined
     };
 
     $.fn.select2.ajaxDefaults = {


### PR DESCRIPTION
Add a property that allows the user to hide or display the selected item(s) in the result list. This functionality can be used for both single and multi select boxes. It was tested with inline options, data source, array data and tag array.

By default, the `hideSelectionFromResult` boolean property is `undefined` and leaves the expected behavior intact: the selected item from a single select box is visible inside the result list while the selected items from a multi select box are hidden from the result list. This default behavior can be overriden by setting the `hideSelectionFromResult` property to `true` or `false`.

Related issues: 
#1267 - Select a tag multiple times
#1538 - Ability to hide currently selected value in dropdown
