### PR TITLE
Add hideSelectionFromResult function

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2257,13 +2257,14 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // single
         postprocessResults: function (data, initial, noHighlightUpdate) {
-            var selected = 0, self = this, showSearchInput = true;
+            var selected = 0, selectedElm = null, self = this, showSearchInput = true;
 
             // find the selected element in the result list
 
             this.findHighlightableChoices().each2(function (i, elm) {
                 if (equal(self.id(elm.data("select2-data")), self.opts.element.val())) {
                     selected = i;
+                    selectedElm = elm;
                     return false;
                 }
             });
@@ -2271,7 +2272,14 @@ the specific language governing permissions and limitations under the Apache Lic
             // and highlight it
             if (noHighlightUpdate !== false) {
                 if (initial === true && selected >= 0) {
-                    this.highlight(selected);
+                    // By default, the selected item is displayed inside the result list from a single select
+                    // User can provide an implementation for 'hideSelectionFromResult' and hide it 
+                    if(this.opts.hideSelectionFromResult !== undefined && selectedElm !== null) {
+                        if(this.opts.hideSelectionFromResult(selectedElm))
+                            selectedElm.addClass("select2-selected");
+                    }
+                    else
+                        this.highlight(selected);
                 } else {
                     this.highlight(0);
                 }
@@ -2995,9 +3003,14 @@ the specific language governing permissions and limitations under the Apache Lic
             choices.each2(function (i, choice) {
                 var id = self.id(choice.data("select2-data"));
                 if (indexOf(id, val) >= 0) {
-                    choice.addClass("select2-selected");
-                    // mark all children of the selected parent as selected
-                    choice.find(".select2-result-selectable").addClass("select2-selected");
+                    // By default, the selected item is hidden from the result list inside a multi select
+                    // User can provide an implementation for 'hideSelectionFromResult' and allow the same
+                    // element to be selected multiple times.
+                    if(self.opts.hideSelectionFromResult === undefined || self.opts.hideSelectionFromResult(choice)) {
+                        choice.addClass("select2-selected");
+                        // mark all children of the selected parent as selected
+                        choice.find(".select2-result-selectable").addClass("select2-selected");
+                    }
                 }
             });
 
@@ -3313,7 +3326,8 @@ the specific language governing permissions and limitations under the Apache Lic
         selectOnBlur: false,
         adaptContainerCssClass: function(c) { return c; },
         adaptDropdownCssClass: function(c) { return null; },
-        nextSearchTerm: function(selectedObject, currentSearchTerm) { return undefined; }
+        nextSearchTerm: function(selectedObject, currentSearchTerm) { return undefined; },
+        hideSelectionFromResult: function(selectedObject) { return undefined; }
     };
 
     $.fn.select2.ajaxDefaults = {


### PR DESCRIPTION
Update to PR #2032: transform `hideSelectionFromResult` property into a function that the user can implement for single and multi select boxes. 

For instance, a basic example to remove the selected item from the result list inside a single select boxes:

![hideselectionfromresultsingle](https://f.cloud.github.com/assets/369777/1951526/cd16acb8-8182-11e3-950a-02c891c36652.png)

In the case of a multi select box, `hideSelectionFromResult` could be used to allow the same item to be selected more than once.
