### PR TITLE
Use dppx instead of non-existing ppx resolution unit

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -628,7 +628,7 @@ html[dir="rtl"] .select2-search-choice-close {
 
 /* Retina-ize icons */
 
-@media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 2ppx)  {
+@media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 2dppx)  {
     .select2-search input,
     .select2-search-choice-close,
     .select2-container .select2-choice abbr,


### PR DESCRIPTION
Commit 4f4d77d36e9f42cbfe406d87c0ef2b809f394c9e introduced a bug by using an unit called "ppx" which does not even exist. It should be written "dppx", like stated in bug #1964. More information can also be found [here](https://developer.mozilla.org/de/docs/Web/CSS/resolution) and [here](http://www.w3.org/TR/css3-values/#resolution).
