### PR TITLE
Change default width to 'resolve'

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3294,7 +3294,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
     // plugin defaults, accessible to users
     $.fn.select2.defaults = {
-        width: "copy",
+        width: "resolve",
         loadMorePadding: 0,
         closeOnSelect: true,
         openOnEnter: true,


### PR DESCRIPTION
When I first tried out this awesome plugin, I wound up with unusable selects of only a few pixels width. This change to the default fixed it. I can change the defaults in my own application, but I'm submitting this for your review because it seems to be a more sensible default - "resolve" will use "copy" if available then fall back on "element"
