### PR TITLE
Allow chaining for .select2('readonly', ...)

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1146,12 +1146,11 @@ the specific language governing permissions and limitations under the Apache Lic
         // abstract
         readonly: function(enabled) {
             if (enabled === undefined) enabled = false;
-            if (this._readonly === enabled) return false;
+            if (this._readonly === enabled) return;
             this._readonly = enabled;
 
             this.opts.element.prop("readonly", enabled);
             this.enableInterface();
-            return true;
         },
 
         // abstract


### PR DESCRIPTION
`.select2('readonly', ...)` returns a `boolean`, which is wrong/makes no sense and makes chaining impossible, see http://jsfiddle.net/u8m62/.

This was fixed for `enable` in version 3.4.5 already, see sommit https://github.com/ivaynberg/select2/commit/a6c5302e719cc159d39ac3a8b778d2b4ed9dce76 and bug #1536 (last sentence of the bug report).

This should be fixed for 'readonly' now as well!
