### PR TITLE
When adding n values to multi, avoiding looping over them n times

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2832,7 +2832,6 @@ the specific language governing permissions and limitations under the Apache Lic
             // filter out duplicates
             $(data).each(function () {
                 if (indexOf(self.id(this), ids) < 0) {
-                    ids.push(self.id(this));
                     filtered.push(this);
                 }
             });
@@ -2841,9 +2840,9 @@ the specific language governing permissions and limitations under the Apache Lic
             this.selection.find(".select2-search-choice").remove();
             $(data).each(function () {
                 self.addSelectedChoice(this);
-                val.push(self.id(this));
+                ids.push(self.id(this));
             });
-            self.setUniqueVal(val);
+            self.setUniqueVal(ids);
             self.postprocessResults();
         },
 


### PR DESCRIPTION
@ivaynberg Currently, every time you call `$input.select2('val', array)`, the `setVal()` function is called for every array entry, and `setVal()` loops over the entire array of values to ensure uniqueness. When the number of values being set is fairly large (on the order of hundreds), this has a dramatic impact on rendering performance.

This commit adds a new internal method, `setUniqueVal()`, to call when a value array is already known to be unique (as is the case when the call originates from `updateSelection`).
