### PR TITLE
fix Android 4.2.1 - setVal()

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3103,6 +3103,11 @@ the specific language governing permissions and limitations under the Apache Lic
         setVal: function (val) {
             var unique;
             if (this.select) {
+                // WORKAROUND to fix Android 4.2.1 Chrome bug, when we remove a selected value,
+                // it puts a empty string value for the first index, if we don't use the workaround below;
+                // ( ex: We want to remove US -> before:["CA","US"] after:["","CA"] )
+                this.select.val([]);
+                // END workaround
                 this.select.val(val);
             } else {
                 unique = [];


### PR DESCRIPTION
Workaround to fix Android 4.2.1 Chrome bug, when we remove a selected value.
It puts a empty string value for the first index.

( ex: We want to remove US -> before:["CA","US"] after:["","CA"] )
