### PR TITLE
Fix evaluation of formatLoadMore

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1570,7 +1570,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     self.postprocessResults(data, false, false);
 
                     if (data.more===true) {
-                        more.detach().appendTo(results).text(self.opts.formatLoadMore(page+1));
+                        more.detach().appendTo(results).text(evaluate(self.opts.formatLoadMore, page+1));
                         window.setTimeout(function() { self.loadMoreIfNeeded(); }, 10);
                     } else {
                         more.remove();


### PR DESCRIPTION
Following up on #2092 I found one more place where we need to use evaluate() rather than trying to call a fn directly.
