### PR TITLE
Bugfix - only selected options that are not disabled should be used when initializing a dropdown

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2214,7 +2214,7 @@ the specific language governing permissions and limitations under the Apache Lic
             if (opts.element.get(0).tagName.toLowerCase() === "select") {
                 // install the selection initializer
                 opts.initSelection = function (element, callback) {
-                    var selected = element.find("option").filter(function() { return this.selected });
+                    var selected = element.find("option").filter(function() { return this.selected && !this.disabled });
                     // a single select box always has a value, no need to null check 'selected'
                     callback(self.optionToData(selected));
                 };
@@ -2488,7 +2488,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
                     var data = [];
 
-                    element.find("option").filter(function() { return this.selected }).each2(function (i, elm) {
+                    element.find("option").filter(function() { return this.selected && !this.disabled }).each2(function (i, elm) {
                         data.push(self.optionToData(elm));
                     });
                     callback(data);


### PR DESCRIPTION
If you disable a selected `option` via Javascript, then that option is not included in the `select` value. However, Select2 will not remove the selected & disabled option and it shows up in the list of selected values.

Javascript will only return `option` value(s) that are not disabled. However, the `prepareOpts` methods return a list of all `selected` options regardless of whether they are disabled. Thus when the Select2 dropdown is displayed, these disabled options are also included in the list of selected options.

```
$('#buddy_ids').val()  // Get select value (multi-select enabled)
    ["12"]

$('#buddy_ids option:selected')
    [ <option value=​"12">​Diet Coach​</option>​ ]

$('#buddy_ids option:selected').attr('disabled', true)  // Disable the lone selected option
    [ <option value=​"12" disabled=​"disabled">​Diet Coach​</option>​ ]

$('#buddy_ids option:selected')   // Selected AND disabled....
    [ <option value=​"12" disabled=​"disabled">​Diet Coach​</option>​ ]

$('#buddy_ids').val()   // Verify that the selected & disabled option is not returned
    []

$('#buddy_ids').trigger('change')  // Tell Select2 that the options have changed

$('#s2id_buddy_ids div')   // The Select2 display includes the selected & disabled option
    [ <div>​Diet Coach​</div>​ ]

$('#s2id_buddy_ids .select2-choices div')
    [ <div>​Diet Coach​</div>​ ]

```

The `prepareOpts` methods should filter out disabled options when returning a list of selected options.
