### PR TITLE
Enable other components to detect mousedown

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2118,8 +2118,6 @@ the specific language governing permissions and limitations under the Apache Lic
                 } else if (this.isInterfaceEnabled()) {
                     this.open();
                 }
-
-                killEvent(e);
             }));
 
             dropdown.on("mousedown touchstart", this.bind(function() { this.search.focus(); }));


### PR DESCRIPTION
Currently selection.on("mousedown touchstart"...) --> killEvent(e);
This prevent others component detecting mousedown on outside their popup (other dropdown coponents, datepicker,...)
I don't know why the kill iwas placed there.
Tested on IE7, IE8, IE11 and FF
