### PR TITLE
Add `shouldFocusInput` option [Fix #1541]

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1340,7 +1340,7 @@ the specific language governing permissions and limitations under the Apache Lic
                         if (self.opts.selectOnBlur) {
                             self.selectHighlighted({noFocus: true});
                         }
-                        self.close({focus:true});
+                        self.close();
                         e.preventDefault();
                         e.stopPropagation();
                     }
@@ -1927,14 +1927,13 @@ the specific language governing permissions and limitations under the Apache Lic
         },
 
         // single
-        close: function (params) {
+        close: function () {
             if (!this.opened()) return;
             this.parent.close.apply(this, arguments);
 
-            params = params || {focus: true};
             this.focusser.prop("disabled", false);
 
-            if (params.focus) {
+            if (this.opts.shouldFocusInput(this)) {
                 this.focusser.focus();
             }
         },
@@ -1945,7 +1944,9 @@ the specific language governing permissions and limitations under the Apache Lic
                 this.close();
             } else {
                 this.focusser.prop("disabled", false);
-                this.focusser.focus();
+                if (this.opts.shouldFocusInput(this)) {
+                    this.focusser.focus();
+                }
             }
         },
 
@@ -1958,7 +1959,10 @@ the specific language governing permissions and limitations under the Apache Lic
         cancel: function () {
             this.parent.cancel.apply(this, arguments);
             this.focusser.prop("disabled", false);
-            this.focusser.focus();
+
+            if (this.opts.shouldFocusInput(this)) {
+                this.focusser.focus();
+            }
         },
 
         // single
@@ -2339,10 +2343,13 @@ the specific language governing permissions and limitations under the Apache Lic
             this.nextSearchTerm = this.opts.nextSearchTerm(data, this.search.val());
             this.close();
 
-            if (!options || !options.noFocus)
+            if ((!options || !options.noFocus) && this.opts.shouldFocusInput(this)) {
                 this.focusser.focus();
+            }
 
-            if (!equal(old, this.id(data))) { this.triggerChange({added:data,removed:oldData}); }
+            if (!equal(old, this.id(data))) {
+                this.triggerChange({ added: data, removed: oldData });
+            }
         },
 
         // single
@@ -3345,7 +3352,15 @@ the specific language governing permissions and limitations under the Apache Lic
         nextSearchTerm: function(selectedObject, currentSearchTerm) { return undefined; },
         hideSelectionFromResult: function(selectedObject) { return undefined; },
         searchInputPlaceholder: '',
-        createSearchChoicePosition: 'top'
+        createSearchChoicePosition: 'top',
+        shouldFocusInput: function (instance) {
+            // Never focus the input if search is disabled
+            if (instance.opts.minimumResultsForSearch < 0) {
+                return false;
+            }
+
+            return true;
+        }
     };
 
     $.fn.select2.ajaxDefaults = {


### PR DESCRIPTION
This adds a `shouldFocusInput` option that determines whether or not the focusser should be automatically focused.  By default, the focusser will always be focused, unless `minimumResultsForSearch` is less than zero.

`close` on single selects took an option `params` argument which at one point was used to tell the focusser to not automatically focus.  This was [added at one point](https://github.com/ivaynberg/select2/commit/e162a4802cddfb95fdef8793fc83fc07897650ec) when tweaking the mask and [later reverted](https://github.com/ivaynberg/select2/commit/9bc68f089e4d81e0dd0e8de943071ae36a3394cd) to fix a bug that came as a result.  The leftovers of this code has been removed in this commit.
