### PR TITLE
Update and improve Persian (fa) translations

### DIFF
--- a/select2_locale_fa.js
+++ b/select2_locale_fa.js
@@ -2,16 +2,18 @@
  * Select2 Persian translation.
  * 
  * Author: Ali Choopan <choopan@arsh.co>
+ * Author: Ebrahim Byagowi <ebrahim@gnu.org>
  */
 (function ($) {
     "use strict";
 
     $.extend($.fn.select2.defaults, {
+        formatMatches: function (matches) { return matches + " نتیجه موجود است، کلیدهای جهت بالا و پایین را برای گشتن استفاده کنید."; },
         formatNoMatches: function () { return "نتیجه‌ای یافت نشد."; },
-        formatInputTooShort: function (input, min) { var n = min - input.length; return " لطفا بیش از"+n+"کاراکتر وارد نمایید "; },
-        formatInputTooLong: function (input, max) { var n = input.length - max; return " لطفا" + n + " کاراکتر را حذف کنید."; },
+        formatInputTooShort: function (input, min) { var n = min - input.length; return "لطفاً " + n + " نویسه بیشتر وارد نمایید"; },
+        formatInputTooLong: function (input, max) { var n = input.length - max; return "لطفاً " + n + " نویسه را حذف کنید."; },
         formatSelectionTooBig: function (limit) { return "شما فقط می‌توانید " + limit + " مورد را انتخاب کنید"; },
-        formatLoadMore: function (pageNumber) { return "در حال بارگذاری موارد بیشتر …"; },
-        formatSearching: function () { return "در حال جستجو"; }
+        formatLoadMore: function (pageNumber) { return "در حال بارگیری موارد بیشتر…"; },
+        formatSearching: function () { return "در حال جستجو…"; }
     });
 })(jQuery);


### PR DESCRIPTION
As there is [a plan](https://www.mediawiki.org/wiki/Outreach_Program_for_Women/Round_8#Switching_Semantic_Forms_autocompletion_to_Select2) to use this library on MediaWiki, [as a MediaWiki translator](https://translatewiki.net/wiki/User:Ebraminio) I felt I should improve its translations here before it would be used on Wikipedia. Some notes that I've applied on this commit and I'm mentioning them for future reference:
- Space or any character should be placed on logical place so when it will used on RTL context it will be shown on its correct place, so " لطفا" that you see on LTR context visually right in fact is wrong and "لطفا " on deployment will be seen on its right place.
- Per [Orthography guide of Persian Academy](http://www.persianacademy.ir/fa/vijegidas.aspx), use of ًـ is not optional but needed.
- «بارگذاری» means "Upload" and «بارگیری» means "Load". It shouldn't be confused.
- «نویسه» is very common equivalent to character, e.g. [1](http://www.yjc.ir/fa/news/4570840/%D9%86%D9%88%DB%8C%D8%B3%D9%87-%D8%AE%D9%88%D8%A7%D9%86-%D9%86%D9%88%D8%B1%DB%8C), no need to use transliteration of "Character".
