### PR TITLE
Unit of measure px is redundant

### DIFF
--- a/select2-bootstrap.css
+++ b/select2-bootstrap.css
@@ -9,7 +9,7 @@
 
 .form-control.select2-container {
     height: auto !important;
-    padding: 0px;
+    padding: 0;
 }
 
 .form-control.select2-container.select2-dropdown-open {


### PR DESCRIPTION
Remove 'px' when property is set to 0.
