### PR TITLE
Update select2.css to prevent float & width style to leak in

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -80,6 +80,8 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     white-space: nowrap;
 
     text-overflow: ellipsis;
+    float: none;
+    width: auto;
 }
 
 .select2-container .select2-choice abbr {


### PR DESCRIPTION
I had a problem where float and width style leaked into the select2 container and caused the select to go the next line (fixed by float: none) and the width of the the select2-chosen span got shortened (fixed by width: auto).

I'm not really sure if this change breaks anything, have only tested it with IE8 & FF27.
