### PR TITLE
Add placeholder support to angular models

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1790,7 +1790,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     //Determine the placeholder option based on the specified placeholderOption setting
                     return (this.opts.placeholderOption === "first" && firstOption) ||
                            (typeof this.opts.placeholderOption === "function" && this.opts.placeholderOption(this.select));
-                } else if (firstOption.text() === "" && firstOption.val() === "") {
+                } else if (firstOption.text() === "" && (firstOption.val() === "" || firstOption.val() === "?")) {
                     //No explicit placeholder option specified, use the first if it's blank
                     return firstOption;
                 }


### PR DESCRIPTION
When the ngModel directive is used, angular automatically inserts an
empty <option value="?" selected="selected"></option> element if the
model does not have any value selected. This prevents the correct
functionality of the placeholder because the value echoed by angular is
not empty (rather, it prints a question mark). The only alternative
would be passing a custom function to every select2 instance for
comparison.
