### PR TITLE
Fix Focus war with modals

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -773,7 +773,8 @@ the specific language governing permissions and limitations under the Apache Lic
             // trap all mouse events from leaving the dropdown. sometimes there may be a modal that is listening
             // for mouse events outside of itself so it can close itself. since the dropdown is now outside the select2's
             // dom it will trigger the popup close, which is not what we want
-            this.dropdown.on("click mouseup mousedown", function (e) { e.stopPropagation(); });
+            // focusin can cause focus wars between modals and select2 since the dropdown is outside the modal.
+            this.dropdown.on("click mouseup mousedown focusin", function (e) { e.stopPropagation(); });
 
             this.nextSearchTerm = undefined;
 


### PR DESCRIPTION
Bootstrap's modal (and maybe others) require focus to maintain in the modal (because that what a modal is). The dropdown is outside of the modal, so we need to stopPropagation on the focusin event so the modal doesn't try to steal back the focus.

This bug was causing an infinte loop of focus being set between the modal and select2. It is tough on the browser and prevents the search input from working at all.
