### PR TITLE
Fix bug related to dropdown position in Firefox and IE

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1179,7 +1179,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 dropTop = offset.top + height,
                 dropLeft = offset.left,
                 enoughRoomBelow = dropTop + dropHeight <= viewportBottom,
-                enoughRoomAbove = (offset.top - dropHeight) >= this.body().scrollTop(),
+                enoughRoomAbove = (offset.top - dropHeight) >= $window.scrollTop(),
                 dropWidth = $dropdown.outerWidth(false),
                 enoughRoomOnRight = dropLeft + dropWidth <= viewPortRight,
                 aboveNow = $dropdown.hasClass("select2-drop-above"),


### PR DESCRIPTION
There's a bug when the dropdown is above the select component and we scroll down the page: the dropdown is not moved below the select (the opposite happens, i.e., if the dropdown is below and we scroll up, it's moved above). This can be seen in the [main page of select2](http://ivaynberg.github.io/select2#basics), in the first example using Firefox or IE.

I think this happens because select2 gets scrollTop value from body to check if there is enough room above the component (`enoughRoomAbove = (offset.top - dropHeight) >= this.body().scrollTop()`), but it's better to get from window instead (`$window.scrollTop()`). Getting scrollTop from window is supported by a larger number of browsers.

jsfiddle:
- old: http://jsfiddle.net/QR5KJ/
- new: http://jsfiddle.net/QR5KJ/1
