### PR TITLE
Update select2.js

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1806,7 +1806,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     //Determine the placeholder option based on the specified placeholderOption setting
                     return (this.opts.placeholderOption === "first" && firstOption) ||
                            (typeof this.opts.placeholderOption === "function" && this.opts.placeholderOption(this.select));
-                } else if (firstOption.text() === "" && firstOption.val() === "") {
+                } else if ($.trim(firstOption.text()) === "" && firstOption.val() === "") {
                     //No explicit placeholder option specified, use the first if it's blank
                     return firstOption;
                 }


### PR DESCRIPTION
Fixes unpleasant glitch where initializing select2 on select where first input option tag has non-breakable space in innerText causes selected option to be displayed as "undefined" until user changes selection. (i.e. HTML was like <option value>&nbsp;</option>, that's what Rails 3 f.select helper generate by default).
