### PR TITLE
Fix search focus on mobile

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2827,7 +2827,9 @@ the specific language governing permissions and limitations under the Apache Lic
             }
 
             this.updateResults(true);
-            this.search.focus();
+            if (this.opts.shouldFocusInput(this)) {
+                this.search.focus();
+            }
             this.opts.element.trigger($.Event("select2-open"));
         },
 


### PR DESCRIPTION
This prevents the search input box gaining focus and showing the keyboard on mobile for single selects (which it seems was only partially fixed in #1541).

However, I'm not quite clear what the "focusser" element is for and can see that the `shouldFocusInput()` method has only been used for the focusser element in d87e93dd45ade99e7894ac4854bf65e8f59667d4.

Is this along the right lines of what should be done? There are other instances in the code which call `this.search.focus()` without calling and checking the result of `shouldFocusInput()` which should also be updated if so.

This will close #1541 again.
