### PR TITLE
Added translation for formatMatches

### DIFF
--- a/select2_locale_uk.js
+++ b/select2_locale_uk.js
@@ -8,15 +8,16 @@
     "use strict";
 
     $.extend($.fn.select2.defaults, {
+        formatMatches: function (matches) { return character(matches, "результат") + " знайдено, використовуйте клавіші зі стрілками вверх та вниз для навігації."; },
         formatNoMatches: function () { return "Нічого не знайдено"; },
-        formatInputTooShort: function (input, min) { return "Введіть буль ласка ще" + character(min - input.length, "символ"); },
-        formatInputTooLong: function (input, max) { return "Введіть буль ласка на" + character(input.length - max, "символ") + " менше"; },
-        formatSelectionTooBig: function (limit) { return "Ви можете вибрати лише" + character(limit, "елемент"); },
+        formatInputTooShort: function (input, min) { return "Введіть буль ласка ще " + character(min - input.length, "символ"); },
+        formatInputTooLong: function (input, max) { return "Введіть буль ласка на " + character(input.length - max, "символ") + " менше"; },
+        formatSelectionTooBig: function (limit) { return "Ви можете вибрати лише " + character(limit, "елемент"); },
         formatLoadMore: function (pageNumber) { return "Завантаження даних…"; },
         formatSearching: function () { return "Пошук…"; }
     });
 
     function character (n, word) {
-        return " " + n + " " + word + (n%10 < 5 && n%10 > 0 && (n%100 < 5 || n%100 > 19) ? n%10 > 1 ? "и" : "" : "ів");
+        return n + " " + word + (n%10 < 5 && n%10 > 0 && (n%100 < 5 || n%100 > 19) ? n%10 > 1 ? "и" : "" : "ів");
     }
 })(jQuery);


### PR DESCRIPTION
In accordance with changes in the file select2_locale_en.js.template
Move space from "character" function to translation strings.
