### PR TITLE
Allow an empty string to be used as the placeholder title.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2219,7 +2219,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         isPlaceholderOptionSelected: function() {
             var placeholderOption;
-            if (!this.getPlaceholder()) return false; // no placeholder specified so no option should be considered
+            if (this.getPlaceholder() === undefined) return false; // no placeholder specified so no option should be considered
             return ((placeholderOption = this.getPlaceholderOption()) !== undefined && placeholderOption.prop("selected"))
                 || (this.opts.element.val() === "")
                 || (this.opts.element.val() === undefined)


### PR DESCRIPTION
In select2 3.3.1 it was possible to use '' as a placeholder title. There is a bug in select2 3.4.6 that prevents this. Patch attached.

Test HTML page: https://gist.github.com/davidfstr/ae14cd13de9395018377
