### PR TITLE
Ignore focus and error on IE7 for disabled select2

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2583,8 +2583,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.selection = selection = this.container.find(selector);
 
             var _this = this;
-            this.selection.on("click", ".select2-search-choice:not(.select2-locked)", function (e) {
-                //killEvent(e);
+            this.selection.on("click", ".select2-container:not(.select2-container-disabled) .select2-search-choice:not(.select2-locked)", function (e) {
                 _this.search[0].focus();
                 _this.selectChoice($(this));
             });


### PR DESCRIPTION
For disabled components, focus event was triggered.
On modern browser this error was ignored but not on IE7.

This PR save weird focus event and IE7 JS error.
