### PR TITLE
Fix pixel width rounding on responsive container

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1172,7 +1172,7 @@ the specific language governing permissions and limitations under the Apache Lic
             var $dropdown = this.dropdown,
                 offset = this.container.offset(),
                 height = this.container.outerHeight(false),
-                width = this.container.outerWidth(false),
+                width = this.container[0].getBoundingClientRect().width,
                 dropHeight = $dropdown.outerHeight(false),
                 $window = $(window),
                 windowWidth = $window.width(),
@@ -1212,7 +1212,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 $dropdown.hide();
                 offset = this.container.offset();
                 height = this.container.outerHeight(false);
-                width = this.container.outerWidth(false);
+                width = this.container[0].getBoundingClientRect().width;
                 dropHeight = $dropdown.outerHeight(false);
                 viewPortRight = $window.scrollLeft() + windowWidth;
                 viewportBottom = $window.scrollTop() + windowHeight;


### PR DESCRIPTION
The dropdown width is set by jQuery's outerWidth, which rounds the
calculated width of the container to an integer. This is problematic
on responsive layouts that rely on percentage widths. The
Element.getBoundingClientRect() will return the width as fraction.

This is a problem because in my responsive layout the dropdown element width was off by 1px from the text input.

I wanted to be sure that the new method returned the same width (padding & border included, margin excluded) : http://jsfiddle.net/Y9mbR/3/

Here's an example of an element with a calculated width that is not an integer: http://jsfiddle.net/EsGQm/1/
