### PR TITLE
.destroy() should destroy all selected select2

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3298,7 +3298,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     value = select2[method].apply(select2, args.slice(1));
                 }
                 if (indexOf(args[0], valueMethods) >= 0
-                    || (indexOf(args[0], propertyMethods) && args.length == 1)) {
+                    || (indexOf(args[0], propertyMethods) >= 0 && args.length == 1)) {
                     return false; // abort the iteration, ready to return first matched value
                 }
             } else {


### PR DESCRIPTION
Fixes #1726 and #2187

Current master (broken): http://jsfiddle.net/LUsMb/2404/
My fork including fix: http://jsfiddle.net/LUsMb/2653/
