### PR TITLE
Fix issue #2226

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -736,7 +736,6 @@ the specific language governing permissions and limitations under the Apache Lic
 
             installFilteredMouseMove(this.results);
             this.dropdown.on("mousemove-filtered touchstart touchmove touchend", resultsSelector, this.bind(this.highlightUnderEvent));
-            this.dropdown.on("touchend", resultsSelector, this.bind(this.selectHighlighted));
             this.dropdown.on("touchmove", resultsSelector, this.bind(this.touchMoved));
             this.dropdown.on("touchstart touchend", resultsSelector, this.bind(this.clearTouchMoved));
 
@@ -766,7 +765,7 @@ the specific language governing permissions and limitations under the Apache Lic
             search.on("focus", function () { search.addClass("select2-focused"); });
             search.on("blur", function () { search.removeClass("select2-focused");});
 
-            this.dropdown.on("mouseup", resultsSelector, this.bind(function (e) {
+            this.dropdown.on("click", resultsSelector, this.bind(function (e) {
                 if ($(e.target).closest(".select2-result-selectable").length > 0) {
                     this.highlightUnderEvent(e);
                     this.selectHighlighted(e);
@@ -1334,7 +1333,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 mask.attr("id","select2-drop-mask").attr("class","select2-drop-mask");
                 mask.hide();
                 mask.appendTo(this.body());
-                mask.on("mousedown touchstart click", function (e) {
+                mask.on("click", function (e) {
                     // Prevent IE from generating a click event on the body
                     reinsertElement(mask);
 
@@ -2117,7 +2116,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             }));
 
-            selection.on("mousedown touchstart", "abbr", this.bind(function (e) {
+            selection.on("click", "abbr", this.bind(function (e) {
                 if (!this.isInterfaceEnabled()) return;
                 this.clear();
                 killEventImmediately(e);
@@ -2125,7 +2124,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 this.selection.focus();
             }));
 
-            selection.on("mousedown touchstart", this.bind(function (e) {
+            selection.on("click", this.bind(function (e) {
                 // Prevent IE from generating a click event on the body
                 reinsertElement(selection);
 
@@ -2142,7 +2141,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 killEvent(e);
             }));
 
-            dropdown.on("mousedown touchstart", this.bind(function() { this.search.focus(); }));
+            dropdown.on("click", this.bind(function() { this.search.focus(); }));
 
             selection.on("focus", this.bind(function(e) {
                 killEvent(e);


### PR DESCRIPTION
This is a fix for clicks being triggered on underlying elements after dropdown is removed.

It somewhat resolves the hell around using all possible events for no reason. As a result dropdown gets removed on `mouseup` and mobile webkit triggers click event on the underlying element.

Also `selectHighlighted` got called twice for no reason.

This is a working solution for #2226.
