### PR TITLE
Prevent the cursor from setting it to initial position in IE

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1221,6 +1221,9 @@ the specific language governing permissions and limitations under the Apache Lic
                 dropWidth = $dropdown.outerWidth(false);
                 enoughRoomOnRight = dropLeft + dropWidth <= viewPortRight;
                 $dropdown.show();
+
+                // fix so the cursor does not move to the left within the search-textbox in IE
+                this.focusSearch();
             }
 
             if (this.opts.dropdownAutoWidth) {


### PR DESCRIPTION
Fixes #2028 and #2211.

The fix is based on [this comment](https://github.com/ivaynberg/select2/issues/2028#issuecomment-32418126).

Now the bug doesn't occur anymore as you can see here: http://mkurz.github.io/select2/select2-latest.html (Forked the gh-pages and provided the patched select2.js)
