### PR TITLE
Fix for "leaking clicks"

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -735,10 +735,23 @@ the specific language governing permissions and limitations under the Apache Lic
             this.container.on("click", killEvent);
 
             installFilteredMouseMove(this.results);
-            this.dropdown.on("mousemove-filtered touchstart touchmove touchend", resultsSelector, this.bind(this.highlightUnderEvent));
-            this.dropdown.on("touchend", resultsSelector, this.bind(this.selectHighlighted));
+
+            this.dropdown.on("mousemove-filtered", resultsSelector, this.bind(this.highlightUnderEvent));
+            this.dropdown.on("touchstart touchmove touchend", resultsSelector, this.bind(function (event) {
+                this._touchEvent = true;
+                this.highlightUnderEvent(event);
+            }));
             this.dropdown.on("touchmove", resultsSelector, this.bind(this.touchMoved));
             this.dropdown.on("touchstart touchend", resultsSelector, this.bind(this.clearTouchMoved));
+
+            // Waiting for a click event on touch devices to select option and hide dropdown
+            // otherwise click will be triggered on an underlying element
+            this.dropdown.on('click', this.bind(function (event) {
+                if (this._touchEvent) {
+                    this._touchEvent = false;
+                    this.selectHighlighted();
+                }
+            }));
 
             installDebouncedScroll(80, this.results);
             this.dropdown.on("scroll-debounced", resultsSelector, this.bind(this.loadMoreIfNeeded));


### PR DESCRIPTION
Ok, this is another solution for clicks that are triggered on underlying elements on mobile devices.

This time `mousedown` and `mouseup` events are left intact. Instead touch-events are marked, but we are still waiting for a 'click' event to arrive. And once we got the click event we execute `selectHighlighted`, but only for marked events.

Fix for issue #2226.
