### PR TITLE
Css dept-* rules should start with 1 not 0

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -350,15 +350,13 @@ Version: @@ver@@ Timestamp: @@timestamp@@
               user-select: none;
 }
 
-.select2-results-dept-0 .select2-result-label { padding-left: 20px }
-.select2-results-dept-1 .select2-result-label { padding-left: 40px }
-.select2-results-dept-2 .select2-result-label { padding-left: 60px }
-.select2-results-dept-3 .select2-result-label { padding-left: 80px }
-.select2-results-dept-4 .select2-result-label { padding-left: 100px }
-.select2-results-dept-5 .select2-result-label { padding-left: 110px }
-.select2-results-dept-6 .select2-result-label { padding-left: 120px }
-
-
+.select2-results-dept-1 .select2-result-label { padding-left: 20px }
+.select2-results-dept-2 .select2-result-label { padding-left: 40px }
+.select2-results-dept-3 .select2-result-label { padding-left: 60px }
+.select2-results-dept-4 .select2-result-label { padding-left: 80px }
+.select2-results-dept-5 .select2-result-label { padding-left: 100px }
+.select2-results-dept-6 .select2-result-label { padding-left: 110px }
+.select2-results-dept-7 .select2-result-label { padding-left: 120px }
 
 .select2-results .select2-highlighted {
     background: #3875d7;


### PR DESCRIPTION
Fixes an issue introduced with #2203, where the padding for `select2-result-label`'s got set  wrong.

Reproduce:
Goto http://ivaynberg.github.io/select2/select2-latest.html#basics, open the dropdown, you can see the padding is wrong (the list items are indented to much). The current stable version http://ivaynberg.github.io/select2/#basics works fine.

The solution is quite easy, `select2-results-dept-*` has to start with 1.
