### PR TITLE
Remove redundant escaping from replacement

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -690,7 +690,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 .addClass("select2-hidden-accessible")
                 .appendTo(document.body);
 
-            this.containerId="s2id_"+(opts.element.attr("id") || "autogen"+nextUid()).replace(/([;&,\-\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, '\\$1');
+            this.containerId="s2id_"+(opts.element.attr("id") || "autogen"+nextUid()).replace(/([;&,\-\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, '$1');
             this.containerSelector="#"+this.containerId;
             this.container.attr("id", this.containerId);
 


### PR DESCRIPTION
Fix for issue: https://github.com/ivaynberg/select2/issues/2251

Summary: seems like replacement string has redundant \\ which was not an issue until \\-  is recently added in [abe7777b](https://github.com/ivaynberg/select2/commit/abe7777b0a1cc4b3129c608cc109db53e2f7085b)
