### PR TITLE
Testing if the dropdown is opened before call positionDropdown

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1390,7 +1390,7 @@ the specific language governing permissions and limitations under the Apache Lic
             var that = this;
             this.container.parents().add(window).each(function () {
                 $(this).on(resize+" "+scroll+" "+orient, function (e) {
-                    that.positionDropdown();
+                    if (!that.opened()) that.positionDropdown();
                 });
             });
 


### PR DESCRIPTION
Even with a closed container within the orientation, resizing and scrolling events, the positionDropdown was called, showing the container although closed.
