### PR TITLE
Testing if the dropdown is opened before call positionDropdown

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1390,7 +1390,7 @@ the specific language governing permissions and limitations under the Apache Lic
             var that = this;
             this.container.parents().add(window).each(function () {
                 $(this).on(resize+" "+scroll+" "+orient, function (e) {
-                    if (!that.opened()) that.positionDropdown();
+                    if (that.opened()) that.positionDropdown();
                 });
             });
 


### PR DESCRIPTION
Even with a closed container within the orientation, resizing and scrolling events, the positionDropdown was called, showing the container although closed.

To reproduce, I record a screencast (_sorry for my poor english_).

https://www.youtube.com/watch?v=bdY2AM0i_Ck

**Browsers tested**: Chrome 34.0.1847.116, Firefox 28.0

*please, if you can, ignore the first commit, 3f43f45. There was a logical error.
