### PR TITLE
Bugfix: "select2-selecting" event returning with bad parameters.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1100,7 +1100,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         triggerSelect: function(data) {
-            var evt = $.Event("select2-selecting", { val: this.id(data), object: data });
+            var evt = $.Event("select2-selecting", { val: this.id(data), choice: data });
             this.opts.element.trigger(evt);
             return !evt.isDefaultPrevented();
         },


### PR DESCRIPTION
"select2-selecting" event is returning with bad parameters.
"choice" remains undefined. See: http://ivaynberg.github.io/select2/#events
