### PR TITLE
Fix issue syncing CSS classes in IE9/10

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1079,9 +1079,13 @@ the specific language governing permissions and limitations under the Apache Lic
 
             });
 
-            // IE8-10
-            el.on("propertychange.select2", sync);
-
+            // IE8-10 (IE9/10 won't fire propertyChange via attachEventListener)
+            if (el.length && el[0].attachEvent) {
+                el.each(function() {
+                    this.attachEvent("onpropertychange", sync);
+                });
+            }
+            
             // hold onto a reference of the callback to work around a chromium bug
             if (this.mutationCallback === undefined) {
                 this.mutationCallback = function (mutations) {


### PR DESCRIPTION
When using jQuery.on to register for the propertychange event, addEventListener is used on IE9/10, which doesn't work for the propertychange event.

Doesn't work for IE9/10: http://jsfiddle.net/hLjhX/3/ (uses current code from GitHub)
Works for IE9/10: http://jsfiddle.net/U4LBH/1/ (uses proposed code)
