### PR TITLE
Only disable keyboard focusing for touch devices

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3384,6 +3384,15 @@ the specific language governing permissions and limitations under the Apache Lic
         searchInputPlaceholder: '',
         createSearchChoicePosition: 'top',
         shouldFocusInput: function (instance) {
+            // Attempt to detect touch devices
+            var supportsTouchEvents = (('ontouchstart' in window) ||
+                                       (navigator.msMaxTouchPoints > 0));
+
+            // Only devices which support touch events should be special cased
+            if (!supportsTouchEvents) {
+                return true;
+            }
+
             // Never focus the input if search is disabled
             if (instance.opts.minimumResultsForSearch < 0) {
                 return false;


### PR DESCRIPTION
This fixes #1541 by first checking to see if the current device is a touch device.  This also fixes #2223 that occured because of the [original fix](https://github.com/ivaynberg/select2/commit/d87e93dd45ade99e7894ac4854bf65e8f59667d4), because the hidden inputs are always focused by default on non-touch devices.

The code used for detecting touch devices was [pulled from StackOverflow](http://stackoverflow.com/a/15439809/359284).
