### PR TITLE
Recalculation dropdown height if dropdownAutoWidth is true

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1248,6 +1248,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 // Add scrollbar width to dropdown if vertical scrollbar is present
                 dropWidth = $dropdown.outerWidth(false) + (resultsListNode.scrollHeight === resultsListNode.clientHeight ? 0 : scrollBarDimensions.width);
                 dropWidth > width ? width = dropWidth : dropWidth = width;
+                dropHeight = $dropdown.outerHeight(false);
                 enoughRoomOnRight = dropLeft + dropWidth <= viewPortRight;
             }
             else {


### PR DESCRIPTION
Here is a problem: http://jsfiddle.net/JpvDt/487/
Select input (see where "Please enter 1 or more character" appeared), type 'i' (see where data appeared). That is because dropdown height is not recalculated if dropdownAutoWidth option is set to true. It's not important if we have enough space below the select2 container, but it's a problem if there is no space below.
