### PR TITLE
Cleanup jQuery DOM elements on destroy

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -829,8 +829,6 @@ the specific language governing permissions and limitations under the Apache Lic
             if (this.propertyObserver) {
                 this.propertyObserver.disconnect();
                 this.propertyObserver = null;
-                
-                this.mutationCallback = null;
             }
 
             if (select2 !== undefined) {
@@ -1096,18 +1094,13 @@ the specific language governing permissions and limitations under the Apache Lic
                 });
             }
             
-            // hold onto a reference of the callback to work around a chromium bug
-            if (this.mutationCallback === undefined) {
-                this.mutationCallback = function (mutations) {
-                    mutations.forEach(sync);
-                }
-            }
-
             // safari, chrome, firefox, IE11
             observer = window.MutationObserver || window.WebKitMutationObserver|| window.MozMutationObserver;
             if (observer !== undefined) {
                 if (this.propertyObserver) { delete this.propertyObserver; this.propertyObserver = null; }
-                this.propertyObserver = new observer(this.mutationCallback);
+                this.propertyObserver = new observer(function (mutations) {
+                    mutations.forEach(sync);
+                });
                 this.propertyObserver.observe(el.get(0), { attributes:true, subtree:false });
             }
         },


### PR DESCRIPTION
Hi,

I noticed that select2-created DOM elements were being left in detached DOM trees in the heap after select2 is destroyed. This fix cleans them up.

One thing to note--the closure in the thunk function was holding a reference that disallowed some of the DOM elements from being GC'd so I removed the entire function. I ran some performance tests using JSLitmus and didn't notice any speed degradation, but just thought I'd point that out.

Also, I removed the extra reference to the mutationHandler because the associated bug in the Chromium project has been fixed. The mutationHandler was also holding some references that prevented things from being GC'd.

Let me know if there are any questions!

Thanks,
Justin
