### PR TITLE
Fix for dots in id

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -684,8 +684,8 @@ the specific language governing permissions and limitations under the Apache Lic
                 .addClass("select2-hidden-accessible")
                 .appendTo(document.body);
 
-            this.containerId="s2id_"+(opts.element.attr("id") || "autogen"+nextUid()).replace(/([;&,\-\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, '\\$1');
-            this.containerEventName= "s2id_" + (opts.element.attr("id") || "autogen"+nextUid())
+            this.containerId="s2id_"+(opts.element.attr("id") || "autogen"+nextUid());
+            this.containerEventName= this.containerId
                 .replace(/([.])/g, '_')
                 .replace(/([;&,\-\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, '\\$1');
             this.container.attr("id", this.containerId);


### PR DESCRIPTION
As described here #2210 and #2218, commit for #1841 broke dots handling in ids. This PR replaces dots with underscores when building event handler name. Id in container's dom element is set in unescaped version.

Dots are treated specially in jQuery for event handler name - they represent namespace parts. So best would be no dots, as they misleadingly suggest namespaces for jQuery.

Here is jsFiddle with PR select2.js version - first select's id contains dots, [ ] and minus chars: http://jsfiddle.net/nzt7g/4/
