### PR TITLE
Fix issue with dropdown menu getting stuck in IE when using multiselect

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2637,7 +2637,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 .attr('for', this.search.attr('id'));
 
             this.search.on("input paste", this.bind(function() {
-                if (this.search.attr('placeholder') && !this.search.val()) return;
+                if (this.search.attr('placeholder') && this.search.val().length == 0) return;
                 if (!this.isInterfaceEnabled()) return;
                 if (!this.opened()) {
                     this.open();


### PR DESCRIPTION
Fixes #2084 with the dropdown menu getting stuck in IE. When the placeholder is removed in IE, an input event is fired: https://connect.microsoft.com/IE/feedback/details/781434/change-of-focus-to-input-with-placeholder-triggers-input-event.
