### PR TITLE
Fix query parameter in tags

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -538,9 +538,9 @@ the specific language governing permissions and limitations under the Apache Lic
         var isFunc = $.isFunction(data);
         return function (query) {
             var t = query.term, filtered = {results: []};
-            var result = $(isFunc ? data(query) : data);
+            var result = isFunc ? data(query) : data;
             if ($.isArray(result)) {
-                $(isFunc ? data() : data).each(function () {
+                $(result).each(function () {
                     var isObject = this.text !== undefined,
                         text = isObject ? this.text : this;
                     if (t === "" || query.matcher(t, text)) {


### PR DESCRIPTION
First solution broke the default way that tags work (by passing in an array). After this fix tags with arrays and tags with (ajax) callbacks will work.
