### PR TITLE
changes on updateResults, populate by @cervengoc on #781

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -923,6 +923,8 @@ the specific language governing permissions and limitations under the Apache Lic
 
                         results = opts.sortResults(results, container, query);
 
+                        // collect the created nodes for bulk append
+                        var nodes = [];
                         for (i = 0, l = results.length; i < l; i = i + 1) {
 
                             result=results[i];
@@ -962,9 +964,11 @@ the specific language governing permissions and limitations under the Apache Lic
                             }
 
                             node.data("select2-data", result);
-                            container.append(node);
+                            nodes.push(node[0]);
                         }
 
+                        // bulk append the created nodes
+                        container.append(nodes);
                         liveRegion.text(opts.formatMatches(results.length));
                     };
 


### PR DESCRIPTION
Use <strike>string concatenation</strike> Bulk DOM insertion instead of DOM manipulation at populate. 

Tested with several BIG lists and the "data" configuration ( not using query )
This does give me about a 45% speed boost as measured with chrome v35. 

Tested also on iexplore ( but no measured, still feels lighter )

Code by @cervengoc on #781
