### PR TITLE
query as third parameter to ajax results callback

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -391,7 +391,7 @@ the specific language governing permissions and limitations under the Apache Lic
      * @param options.data a function(searchTerm, pageNumber, context) that should return an object containing query string parameters for the above url.
      * @param options.dataType request data type: ajax, jsonp, other datatypes supported by jQuery's $.ajax function or the transport function if specified
      * @param options.quietMillis (optional) milliseconds to wait before making the ajaxRequest, helps debounce the ajax function if invoked too often
-     * @param options.results a function(remoteData, pageNumber) that converts data returned form the remote request to the format expected by Select2.
+     * @param options.results a function(remoteData, pageNumber, query) that converts data returned form the remote request to the format expected by Select2.
      *      The expected format is an object containing the following keys:
      *      results array of objects that will be used as choices
      *      more (optional) boolean indicating whether there are more results available


### PR DESCRIPTION
for e.g. proper cache implementation it is necessary to have the complete query in the results callback of the ajax function. to not break backwards compatibility i added it as third parameter and did not replace query.page parameter
