### PR TITLE
Stopped refresh to top when `closeOnSelect: false`

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3107,7 +3107,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             });
 
-            if (this.highlight() == -1 && noHighlightUpdate !== false){
+            if (this.highlight() == -1 && noHighlightUpdate !== false && this.opts.closeOnSelect === true){
                 self.highlight(0);
             }
 


### PR DESCRIPTION
Not really sure how the noHighlightUpdate variable is supposed to work, it is undefined all the time so it appears to be broken. I just referred to `this.opts.closeOnSelect` to get the status directly.
