### PR TITLE
query as third parameter to ajax results callback documentation

### DIFF
--- a/select2-latest.html
+++ b/select2-latest.html
@@ -1555,7 +1555,7 @@ $("#select").select2({
                     </td></tr>
                     <tr><td>results</td><td>function</td><td>
                         Function used to build the query results object from the ajax response
-                        <pre>results(data, page)</pre>
+                        <pre>results(data, page, query)</pre>
                         <table class="table table-bordered table-striped">
                             <tr><th>Parameter</th><th>Type</th><th>Description</th></tr>
                             <tr><td>data</td><td>object</td><td>Retrieved data.</td></tr>


### PR DESCRIPTION
looking at the source, the query.context is not passed to results, so i replaced it with the additional query parameter.

Documentation Pull Request for #2363
