### PR TITLE
Reword Polish string for formatInputTooShort

### DIFF
--- a/select2_locale_pl.js
+++ b/select2_locale_pl.js
@@ -3,13 +3,14 @@
  * 
  * @author  Jan Kondratowicz <jan@kondratowicz.pl>
  * @author  Uriy Efremochkin <efremochkin@uriy.me>
+ * @author  Michał Połtyn <mike@poltyn.com>
  */
 (function ($) {
     "use strict";
 
     $.extend($.fn.select2.defaults, {
         formatNoMatches: function () { return "Brak wyników"; },
-        formatInputTooShort: function (input, min) { return "Wpisz jeszcze" + character(min - input.length, "znak", "i"); },
+        formatInputTooShort: function (input, min) { return "Wpisz co najmniej" + character(min - input.length, "znak", "i"); },
         formatInputTooLong: function (input, max) { return "Wpisana fraza jest za długa o" + character(input.length - max, "znak", "i"); },
         formatSelectionTooBig: function (limit) { return "Możesz zaznaczyć najwyżej" + character(limit, "element", "y"); },
         formatLoadMore: function (pageNumber) { return "Ładowanie wyników…"; },


### PR DESCRIPTION
This is a better wording in Polish translation of `formatInputTooShort`
