### PR TITLE
Add text function for formatResult and formatSelection

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -459,7 +459,6 @@ the specific language governing permissions and limitations under the Apache Lic
      * the text.
      */
     function local(options) {
-
         var data = options, // data elements
             dataText,
             tmp,


### PR DESCRIPTION
As mentioned in  #2389, the default implementations of `formatResult` and `formatSelection` don't use the `data.text` property to get the text. 
This pull requests makes the default implementations check for such property and use it if it exists.

This is my first pull request to this project and I didn't see any contribution guidelines so feel free to point any issues.

Thanks
