### PR TITLE
Modify method to be able to display custom error messages.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1773,7 +1773,8 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
 
                 if (data.results.length === 0 && checkFormatter(opts.formatNoMatches, "formatNoMatches")) {
-                    render("<li class='select2-no-results'>" + evaluate(opts.formatNoMatches, opts.element, search.val()) + "</li>");
+                    var message = (typeof data.error === 'string') ? data.error : evaluate(opts.formatNoMatches, opts.element, search.val());
+                    render("<li class='select2-no-results'>" + message + "</li>");
                     return;
                 }
 


### PR DESCRIPTION
With this change, any developer using select2 will be able to display its custom error messages with only giving to select2 an empty resultset and a string error message. Something like:

```
dataset.results = [];
dataset.error = "Custom message goes here...";
```
