### PR TITLE
Fix error: Cannot read property 'top' of undefined

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1476,7 +1476,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         ensureHighlightVisible: function () {
-            var results = this.results, children, index, child, hb, rb, y, more;
+            var results = this.results, children, index, child, hb, rb, y, more, topOffset;
 
             index = this.highlight();
 
@@ -1496,7 +1496,9 @@ the specific language governing permissions and limitations under the Apache Lic
 
             child = $(children[index]);
 
-            hb = child.offset().top + child.outerHeight(true);
+            topOffset = (child.offset() || {}).top || 0;
+
+            hb = topOffset + child.outerHeight(true);
 
             // if this is the last child lets also make sure select2-more-results is visible
             if (index === children.length - 1) {
@@ -1510,7 +1512,7 @@ the specific language governing permissions and limitations under the Apache Lic
             if (hb > rb) {
                 results.scrollTop(results.scrollTop() + (hb - rb));
             }
-            y = child.offset().top - results.offset().top;
+            y = topOffset - results.offset().top;
 
             // make sure the top of the element is visible
             if (y < 0 && child.css('display') != 'none' ) {


### PR DESCRIPTION
Lines [1499](https://github.com/ivaynberg/select2/blob/d487fc58a889b471f7d587cc61baeca1d68de633/select2.js#L1499) and [1509](https://github.com/ivaynberg/select2/blob/d487fc58a889b471f7d587cc61baeca1d68de633/select2.js#L1509) make a call to `child.offset().top`. I don't know what's causing `child.offset()` to return undefined, but it is and it's breaking Select2 so that I can't select the last item in the list (this error occurs when I try hovering over or clicking on the last item in a list).

I can try and create a reduced case, but this fix is 100% backward compatibe, passes all the tests you have for the project and has a 0% chance of breaking anyone's working code. With this patch, my dropdown works just fine. At worst, this does _nothing_ for people, at best, it fixes a rare edge case. Like my edge case. And I'm a pretty important person to me.
