### PR TITLE
XHR request passed to the `results` function

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -439,10 +439,11 @@ the specific language governing permissions and limitations under the Apache Lic
                     url: url,
                     dataType: options.dataType,
                     data: data,
-                    success: function (data) {
+                    success: function (data, textStatus, jqXHR) {
                         // TODO - replace query.page with query so users have access to term, page, etc.
                         // added query as third paramter to keep backwards compatibility
-                        var results = options.results(data, query.page, query);
+                        // jqXHR allows to get data from headers
+                        var results = options.results(data, query.page, query, jqXHR);
                         query.callback(results);
                     }
                 });


### PR DESCRIPTION
Hi! There was no way to get paging data in case it's sent in the response headers, so no good way to detect if there's more records to show inside the `results` function. This pull request adds the whole XHR object as the 4th argument of the `results` function.
