### PR TITLE
Make it possible to force open the dropdown in a specified direction

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1311,6 +1311,11 @@ the specific language governing permissions and limitations under the Apache Lic
                 width: width
             };
 
+            // Only open the flyout on north or south, if defined
+            if (this.opts.dropdownOpenDirection) {
+              above = this.opts.dropdownOpenDirection === 'north';
+            }
+
             if (above) {
                 css.top = offset.top - dropHeight;
                 css.bottom = 'auto';


### PR DESCRIPTION
In our project we had the specific case that our client wanted the dropdown to **only** open on south / north, even if there's no space anymore to display all the suggestions there.
