### PR TITLE
Set padding/margin for select2-results list items

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -375,6 +375,8 @@ html[dir="rtl"] .select2-results {
     list-style: none;
     display: list-item;
     background-image: none;
+    padding: 0;
+    margin: 0;
 }
 
 .select2-results li.select2-result-with-children > .select2-result-label {


### PR DESCRIPTION
This pull request explicitly sets the expected padding and margin for  `.select2-results li` elements to ensure it looks correct rather than assuming `.select2-results li` will not inherit any padding or margin.

For example, if using a `reset.css` file that adds padding and margin to `<li>` tags, then the select2 menu is inheriting this padding and margin and it looks broken.  
