### PR TITLE
Basic CSS gradient fix for choices

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -586,7 +586,7 @@ html[dir="rtl"] .select2-container-multi .select2-choices li
     background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, color-stop(20%, #f4f4f4), color-stop(50%, #f0f0f0), color-stop(52%, #e8e8e8), color-stop(100%, #eee));
     background-image: -webkit-linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%);
     background-image: -moz-linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%);
-    background-image: linear-gradient(to top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%);
+    background-image: linear-gradient(to bottom, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eee 100%);
 }
 html[dir="rtl"] .select2-container-multi .select2-choices .select2-search-choice
 {


### PR DESCRIPTION
The “top” on the other styles (-moz-linear-gradient,
-webkit-linear-gradient, etc) signifies “start at the top”.  The
equivalent basic “linear-gradient” style is “to bottom”, not “to top”.

Before commit:
![image](https://cloud.githubusercontent.com/assets/3732514/3767483/cb6592fc-18cd-11e4-97c9-2095b081c268.png)

After commit:
![image](https://cloud.githubusercontent.com/assets/3732514/3767499/e6c57990-18cd-11e4-85fb-679c525e4892.png)
