### PR TITLE
Fixing 'Type mismatch' exception in destroy in IE11

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -850,7 +850,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.close();
 
-            if (element.length && element[0].detachEvent) {
+            if (element.length && element[0].detachEvent && self._sync) {
                 element.each(function () {
                     this.detachEvent("onpropertychange", self._sync);
                 });


### PR DESCRIPTION
I've found IE11 is throwing a 'Type Mismatch' exception in destroy due to self._sync being undefined. I haven't tested other versions.
