### PR TITLE
Adds check for enough room before switching right to left drop

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1222,9 +1222,10 @@ the specific language governing permissions and limitations under the Apache Lic
         // abstract
         positionDropdown: function() {
             var $dropdown = this.dropdown,
-                offset = this.container.offset(),
-                height = this.container.outerHeight(false),
-                width = this.container.outerWidth(false),
+                container = this.container,
+                offset = container.offset(),
+                height = container.outerHeight(false),
+                width = container.outerWidth(false),
                 dropHeight = $dropdown.outerHeight(false),
                 $window = $(window),
                 windowWidth = $window.width(),
@@ -1236,7 +1237,12 @@ the specific language governing permissions and limitations under the Apache Lic
                 enoughRoomBelow = dropTop + dropHeight <= viewportBottom,
                 enoughRoomAbove = (offset.top - dropHeight) >= $window.scrollTop(),
                 dropWidth = $dropdown.outerWidth(false),
-                enoughRoomOnRight = dropLeft + dropWidth <= viewPortRight,
+                enoughRoomOnRight = function() {
+                    return dropLeft + dropWidth <= viewPortRight;
+                },
+                enoughRoomOnLeft = function() {
+                    return offset.left + viewPortLeft + container.outerWidth(false)  > dropWidth;
+                },
                 aboveNow = $dropdown.hasClass("select2-drop-above"),
                 bodyOffset,
                 above,
@@ -1271,7 +1277,6 @@ the specific language governing permissions and limitations under the Apache Lic
                 dropTop = offset.top + height;
                 dropLeft = offset.left;
                 dropWidth = $dropdown.outerWidth(false);
-                enoughRoomOnRight = dropLeft + dropWidth <= viewPortRight;
                 $dropdown.show();
 
                 // fix so the cursor does not move to the left within the search-textbox in IE
@@ -1286,7 +1291,6 @@ the specific language governing permissions and limitations under the Apache Lic
                 dropWidth = $dropdown.outerWidth(false) + (resultsListNode.scrollHeight === resultsListNode.clientHeight ? 0 : scrollBarDimensions.width);
                 dropWidth > width ? width = dropWidth : dropWidth = width;
                 dropHeight = $dropdown.outerHeight(false);
-                enoughRoomOnRight = dropLeft + dropWidth <= viewPortRight;
             }
             else {
                 this.container.removeClass('select2-drop-auto-width');
@@ -1302,7 +1306,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 dropLeft -= bodyOffset.left;
             }
 
-            if (!enoughRoomOnRight) {
+            if (!enoughRoomOnRight() && enoughRoomOnLeft()) {
                 dropLeft = offset.left + this.container.outerWidth(false) - dropWidth;
             }
 


### PR DESCRIPTION
Previously, a check was done to see if there was enough space to the right to display the dropdown. If there was not then the dropdown was moved to the left. But, there may not be enough room on the left either (which is my case) which would leave the user only able to see the far right of the dropdown, missing most of the text.

![image](https://cloud.githubusercontent.com/assets/447579/3840638/cadd27ac-1e20-11e4-96e8-9dad3362d7c3.png)

This change checks if there is room on the left before making this switch.

If this check fails then it seems there isn't enough room on the left or right to display the dropdown, but I think it's better (in the case of LTR languages anyway) to display the dropdown on the right as this will give the user the best visibility of the text.

![image](https://cloud.githubusercontent.com/assets/447579/3840680/524d33ee-1e21-11e4-9943-1ab5496823c1.png)

Also - the enoughRoomOnRight variable is now a function, so no need (i think) to set its value in multiple places.

I've had to do a recalculation for the container.outerWidth() in enoughRoomOnLeft as for dynamically widened dropdowns the width variable gets reset to the width of the dropdown, not the original control.
