### PR TITLE
Added 2 new options for forcing direction of the dropdown 

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1244,16 +1244,16 @@ the specific language governing permissions and limitations under the Apache Lic
                 css,
                 resultsListNode;
 
-            // always prefer the current above/below alignment, unless there is not enough room
+            // always prefer the current above/below alignment, unless there is not enough room or the other direction is forced
             if (aboveNow) {
                 above = true;
-                if (!enoughRoomAbove && enoughRoomBelow) {
+                if ((!enoughRoomAbove && enoughRoomBelow && !this.opts.forceOpenAbove) || this.opts.forceOpenBelow) {
                     changeDirection = true;
                     above = false;
                 }
             } else {
                 above = false;
-                if (!enoughRoomBelow && enoughRoomAbove) {
+                if ((!enoughRoomBelow && enoughRoomAbove && !this.opts.forceOpenBelow) || this.opts.forceOpenAbove) {
                     changeDirection = true;
                     above = true;
                 }
@@ -3412,6 +3412,8 @@ the specific language governing permissions and limitations under the Apache Lic
         dropdownCss: {},
         containerCssClass: "",
         dropdownCssClass: "",
+        forceOpenAbove: false,
+        forceOpenBelow: false,
         formatResult: function(result, container, query, escapeMarkup) {
             var markup=[];
             markMatch(result.text, query.term, markup, escapeMarkup);


### PR DESCRIPTION
Hello,
I added simple tweak to force direction of the dropdown either bellow or above the input. The new options are

forceOpenBelow and forceOpenAbove

This was an issue discussed here:

https://groups.google.com/forum/#!topic/select2/-1GWUw3q_JA

or here:

http://stackoverflow.com/questions/19983601/prevent-select2-from-flipping-the-dropdown-upward
