### PR TITLE
Prevent multiple select2-hidden-accessible span's

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -699,12 +699,15 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.container = this.createContainer();
 
-            this.liveRegion = $("<span>", {
-                    role: "status",
-                    "aria-live": "polite"
-                })
-                .addClass("select2-hidden-accessible")
-                .appendTo(document.body);
+            this.liveRegion = $('.select2-hidden-accessible');
+            if (this.liveRegion.length == 0) {
+                this.liveRegion = $("<span>", {
+                        role: "status",
+                        "aria-live": "polite"
+                    })
+                    .addClass("select2-hidden-accessible")
+                    .appendTo(document.body);
+            }
 
             this.containerId="s2id_"+(opts.element.attr("id") || "autogen"+nextUid());
             this.containerEventName= this.containerId


### PR DESCRIPTION
Fixes #2412. Maybe the fix is a bit ugly, but what it does is to make sure that we don't already have a select2-hidden-accessible span before we create a new one. Tested in several scenarios in our application and has solved the issue for us.
