### PR TITLE
[IE8] Null checking in destroy method

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -852,7 +852,9 @@ the specific language governing permissions and limitations under the Apache Lic
 
             if (element.length && element[0].detachEvent && self._sync) {
                 element.each(function () {
-                    this.detachEvent("onpropertychange", self._sync);
+                    if (self._sync) {
+                        this.detachEvent("onpropertychange", self._sync);
+                    }
                 });
             }
             if (this.propertyObserver) {


### PR DESCRIPTION
IE8 is still broken since self._sync is undefined. We need to check that it exists first before running detachEvent.

https://github.com/ivaynberg/select2/issues/2467
https://github.com/ivaynberg/select2/issues/2498
