### PR TITLE
changing tab behaviour in multiselect; not focussing immediately on next field

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2761,7 +2761,7 @@ the specific language governing permissions and limitations under the Apache Lic
                         return;
                     case KEY.TAB:
                         this.selectHighlighted({noFocus:true});
-                        this.close();
+                        killEvent(e);
                         return;
                     case KEY.ESC:
                         this.cancel(e);


### PR DESCRIPTION
This minor change is a partial revert of 4094c1c (that solved #898). I think the behaviour is requested in that issue is correct for the  traditional, *single* option select. For the multi select version, however, it makes more sense to keep the focus on the field, since you may want to add another value while typing. Although it is the same plugin, I don't think the different behaviour is conflicting: the appearance is entirely different. I wouldn't want my users to press Enter too often: because in normal text-input fields using Enter leads to submitting the entire form.