### PR TITLE
Debounce closing on Android browser

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1244,7 +1244,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     return dropLeft + dropWidth <= viewPortRight;
                 },
                 enoughRoomOnLeft = function() {
-                    return offset.left + viewPortLeft + container.outerWidth(false)  > dropWidth;
+                    return offset.left + container.outerWidth(false)  > dropWidth;
                 },
                 aboveNow = $dropdown.hasClass("select2-drop-above"),
                 bodyOffset,


### PR DESCRIPTION
Debounces the menu from immediately closing on android browsers by introducing a delay.

This is a cleaned up branch based on the following PR https://github.com/ivaynberg/select2/pull/2644
