### PR TITLE
fixes cutoff for bottom option when selecting with keyboard

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1532,7 +1532,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             }
 
-            rb = results.offset().top + results.outerHeight(true);
+            rb = results.offset().top + results.outerHeight(false);
             if (hb > rb) {
                 results.scrollTop(results.scrollTop() + (hb - rb));
             }


### PR DESCRIPTION
When selecting options in the dropdown using the keyboard you'll notice that when you get to the last option that is visible, select2 will auto scroll just enough to include the last option in full, or at least it is attempting to. 

You can see from this screenshot 
![screenshot from 2014-09-11 17 47 40](https://cloud.githubusercontent.com/assets/2582481/4242417/8e749324-39fd-11e4-86bf-21926a6825d6.png)
that the last option gets cut off by a small number of pixels.

This is caused by a logical error when calculating how many pixels to adjust the results div's scrollTop. When grabbing the outerHeight we should _not_ include the margin of the results div since the content won't be rendered in that space.

JsFiddle before fix - js straight from from http://ivaynberg.github.io/select2/
http://jsfiddle.net/st2fe438/

JsFiddle after fix
http://jsfiddle.net/crkeLr18/1/
