### PR TITLE
update value of hidden input on init for single select

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2301,7 +2301,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 var self = this;
                 this.opts.initSelection.call(null, this.opts.element, function(selected){
                     if (selected !== undefined && selected !== null) {
-                        self.updateSelection(selected);
+                        self.val(selected);
                         self.close();
                         self.setPlaceholder();
                         self.nextSearchTerm = self.opts.nextSearchTerm(selected, self.search.val());


### PR DESCRIPTION
I believe I had the same problem as @hgpb at the very bottom of #1339.

Basically, the initial value of a single select never gets set in the hidden field. So if someone submits the form without changing from the initial, we get an empty value back. 

I think this is because val, which updates the value of the hidden input field, is never called during initSelection. Since val calls updateSelection, I believe it could be as simple as replacing updateSelection with val.

At least, it fixes the problem for me!
