### PR TITLE
Added the "emptySearchText" option

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1088,6 +1088,8 @@ the specific language governing permissions and limitations under the Apache Lic
             else if (typeof(opts.createSearchChoicePosition) !== "function")  {
                 throw "invalid createSearchChoicePosition option must be 'top', 'bottom' or a custom function";
             }
+            
+            opts.emptySearchText = opts.emptySearchText || element.data("search-text");
 
             return opts;
         },
@@ -1729,7 +1731,10 @@ the specific language governing permissions and limitations under the Apache Lic
             }
 
             if (search.val().length < opts.minimumInputLength) {
-                if (checkFormatter(opts.formatInputTooShort, "formatInputTooShort")) {
+                if (search.val().length === 0 && opts.emptySearchText) {
+                    render("<li class='select2-no-results'>" + evaluate(opts.emptySearchText, opts.element, opts.minimumInputLength) + "</li>");
+                }
+                else if (checkFormatter(opts.formatInputTooShort, "formatInputTooShort")) {
                     render("<li class='select2-no-results'>" + evaluate(opts.formatInputTooShort, opts.element, search.val(), opts.minimumInputLength) + "</li>");
                 } else {
                     render("");


### PR DESCRIPTION
Added an option which allows the developer to specify a text which is diplayed under the search box when tehre is no input. The original behaviour was that in this case select2 shows the "too short" message, which is not too informative here. With this option the user interface can be improved a lot. 

Further improvement could be to give it some default, and make it localizable.
