### PR TITLE
Added element param to formatResult and createSearchChoice function

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2436,8 +2436,8 @@ the specific language governing permissions and limitations under the Apache Lic
             var old = this.opts.element.val(),
                 oldData = this.data();
 
-            this.opts.element.val(this.id(data));
             this.updateSelection(data);
+            this.opts.element.val(this.id(data));
 
             this.opts.element.trigger({ type: "select2-selected", val: this.id(data), choice: data });
 


### PR DESCRIPTION
I added the element to formatResult and createSearchChoice function to have more flexibility.

For example, if I want to create a new result on the fly via createSearchChoice function, I need to access my "element" which has some useful data/configuration settings in its attributes (like the url to call via ajax, etc).

I did the same to formatResult because sometimes I don't want to create a new result (in database) when createSearchChoice is called BUT ONLY when this "new result" is selected (createSearchChoice returns a new result with an ID = -1 and then formatResult catch it, check if it equal to -1 and then send the ajax request to create the new result in database).
