### PR TITLE
allow markups of subsequent formatLoadMore message

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1655,7 +1655,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     self.postprocessResults(data, false, false);
 
                     if (data.more===true) {
-                        more.detach().appendTo(results).text(evaluate(self.opts.formatLoadMore, self.opts.element, page+1));
+                        more.detach().appendTo(results).html(self.opts.escapeMarkup(evaluate(self.opts.formatLoadMore, self.opts.element, page+1)));
                         window.setTimeout(function() { self.loadMoreIfNeeded(); }, 10);
                     } else {
                         more.remove();


### PR DESCRIPTION
trying to fix #2694 
- setting message with html instead of text
- invoking escapeMarkup method before setting message
