### PR TITLE
Fixed up left and width css so left can't go negative and width adjusts ...

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1314,8 +1314,8 @@ the specific language governing permissions and limitations under the Apache Lic
             }
 
             css =  {
-                left: dropLeft,
-                width: width
+                left: dropLeft > 0 ? dropLeft : 0,
+                width: dropLeft > 0 ? width : width + dropLeft
             };
 
             if (above) {


### PR DESCRIPTION
...when dropLeft goes negative.

When dropdownAutoWidth = true, and you resize your browser to a size where you have more room on the left than you do on the right hand side of the page, with the select2 options list open, the option list goes off the left-hand side of the page. 
I modified the css calculations to ensure that css.left is never less than 0, which keeps the options list from going off the page, and css.width = width + dropLeft which ensure proper width of the options list, only when dropLeft < 0. 