### PR TITLE
Supporting json objects as value for multi-select

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3206,8 +3206,21 @@ the specific language governing permissions and limitations under the Apache Lic
                 val = this.select.val();
                 return val === null ? [] : val;
             } else {
-                val = this.opts.element.val();
-                return splitVal(val, this.opts.separator);
+
+                if (this.opts.initSelection === undefined) {
+                    val = this.opts.element.val();
+                    return splitVal(val, this.opts.separator);
+                }
+                else {
+                    val = [];
+                    var self = this;
+                    this.opts.initSelection(this.opts.element, function (data) {
+                        $(data).each(function () {
+                            val.push(self.opts.id(this));
+                        });
+                    });
+                    return val;
+                }
             }
         },
 


### PR DESCRIPTION
I have a multi-select loading ajax data, combined  with an input instead of a select.
The value attribute contain a stringifyed json object array, like that:
<code>{"id":46,"text":"Santa Catarina"},{"id":6,"text":"São Paulo"}</code>

<strong>The problem is that getVal splits by default separator ',':</strong>

getVal expected result (2 records):
<code>{"id":46,"text":"Santa Catarina"}</code>
<code>{"id":6,"text":"São Paulo"}</code>

getVal current result (4 records):
<code>{"id":46</code>
<code>"text":"Santa Catarina"}</code>
<code>{"id":6</code>
<code>"text":"São Paulo"}</code>

As you can see at diff, I'm using a customized id and initSelection functions to deal with json objects.
And <strong>it's not possible (at least, it would be very, very painful and kinda ugly) to replace every json array with a custom separator between elements, on every JSON.Stringify (client), or Newtonsoft.Serialize (server).</strong>

So I'm proposing this adjust for multi-select getVal.

I'm using select2 for both: single and multi-select on our project, always with this 'json as value' approach..  all fine so far :)
