### PR TITLE
allow formatSelection to return a jQuery object

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3052,7 +3052,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
             formatted=this.opts.formatSelection(data, choice.find("div"), this.opts.escapeMarkup);
             if (formatted != undefined) {
-                choice.find("div").replaceWith("<div>"+formatted+"</div>");
+                choice.find("div").replaceWith($("<div></div>").html(formatted));
             }
             cssClass=this.opts.formatSelectionCssClass(data, choice.find("div"));
             if (cssClass != undefined) {


### PR DESCRIPTION
Closes https://github.com/ivaynberg/select2/issues/2393

Currently only strings can be returned from the formatSelection function. Greater flexibility can be provided with the ability to return a jQuery object.

i.e.

``` javascript
formatSelection: function(state) {
    return $('<div>Click me</div>').click(function() { alert('clicked'); });
}
```

Here is an example of creating an instance of select2 inside another:

![select2_template](https://cloud.githubusercontent.com/assets/4863750/4421020/be56516c-457f-11e4-95a0-5959d1691744.png)
