### PR TITLE
Move the container for the open widget above the drop mask

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -339,6 +339,10 @@ html[dir="rtl"] .select2-dropdown-open .select2-choice .select2-arrow b {
     background-position: -16px 1px;
 }
 
+.select2-dropdown-open {
+  z-index: 9999;
+}
+
 .select2-hidden-accessible {
     border: 0;
     clip: rect(0 0 0 0);


### PR DESCRIPTION
Workaround for one special case of #1715, where the drop mask occludes the widget above the drop down, so two clicks are needed to access the clear button
