### PR TITLE
Fixes results count in accessible text

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1714,7 +1714,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     self.liveRegion.text(results.text());
                 }
                 else {
-                    self.liveRegion.text(self.opts.formatMatches(results.find('.select2-result-selectable').length));
+                    self.liveRegion.text(self.opts.formatMatches(results.find('.select2-result-selectable:not(".select2-selected")').length));
                 }
             }
 


### PR DESCRIPTION
accessible help text always return the total results count. (even after users selected a item)

For example,

there're 4 tags, user selected 1 tag:

Current:
4 tags

Expected:
3 tags
