### PR TITLE
While holding ctrl key don't close multiselect

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2993,12 +2993,14 @@ the specific language governing permissions and limitations under the Apache Lic
             // keep track of the search's value before it gets cleared
             this.nextSearchTerm = this.opts.nextSearchTerm(data, this.search.val());
 
+            var closeOnSelect = this.opts.closeOnSelect && ! options.ctrlKey;
+
             this.clearSearch();
             this.updateResults();
 
-            if (this.select || !this.opts.closeOnSelect) this.postprocessResults(data, false, this.opts.closeOnSelect===true);
+            if (this.select || ! closeOnSelect) this.postprocessResults(data, false, closeOnSelect === true);
 
-            if (this.opts.closeOnSelect) {
+            if (closeOnSelect) {
                 this.close();
                 this.search.width(10);
             } else {
@@ -3156,7 +3158,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             });
 
-            if (this.highlight() == -1 && noHighlightUpdate !== false){
+            if (noHighlightUpdate !== false && this.highlight() == -1) {
                 self.highlight(0);
             }
 


### PR DESCRIPTION
Our project previously used https://github.com/harvesthq/chosen, but we switched away because it didn't support deep multi level trees.

But Chosen had done 1 thing right which is missing here - Intuitively when holding ctrl key on multiselect I wish to select multiple elements, just like in Windows OS.

So here is patch.

I know about "multiple:true" in init options, but not always we wish to keep select window open after choosing 1 element - ctrl key feels more natural. This patch doesnt interfere with multiple:true and when multiple is true - ctrl key will be ignored.

This solution doesn't touch issue #1988 (not yet merged in master), but fix mention in there wont work with this.

I can fix that by passing addition parameter to updateResults (line:2999) which calls postprocessResults (line:1826), which in turn handles highlighting (line:3126). I didnt want to do it now without talking it over. Maybe there is better way?