### PR TITLE
Make label tag for attributes apply to the newly created search element

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -845,6 +845,11 @@ the specific language governing permissions and limitations under the Apache Lic
             if (this.autofocus) this.focus();
 
             this.search.attr("placeholder", opts.searchInputPlaceholder);
+
+            // Make sure any labels that referenced the original element now reference the search instead
+            if (opts.element.attr("id")) {
+                $("label[for=" + opts.element.attr("id") + "]").attr("for", search.attr("id"));
+            }
         },
 
         // abstract


### PR DESCRIPTION
If a label tag's `for` attribute is set to the id of an element, clicking on the label focuses the other element. Previously, select2 ignored that relationship which meant labels wouldn't be clickable in the same way (even if their `for` attribute matched the id of the soon-to-be-hidden field). This will correct that problem by updating labels' `for` attributes to the values of the new search fields.
