### PR TITLE
 Add function for generation of suffix id for single container.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2086,7 +2086,7 @@ the specific language governing permissions and limitations under the Apache Lic
             var selection,
                 container = this.container,
                 dropdown = this.dropdown,
-                idSuffix = nextUid(),
+                idSuffix = this.opts.idSuffixGenerator(this.opts.element),
                 elementLabel;
 
             if (this.opts.minimumResultsForSearch < 0) {
@@ -3455,6 +3455,9 @@ the specific language governing permissions and limitations under the Apache Lic
         },
         matcher: function(term, text) {
             return stripDiacritics(''+text).toUpperCase().indexOf(stripDiacritics(''+term).toUpperCase()) >= 0;
+        },
+        idSuffixGenerator: function(element) {
+            return nextUid();
         },
         separator: ",",
         tokenSeparators: [],


### PR DESCRIPTION
Hello,

I have currently an issue with single container.
I need a possibility to customize the generation of the idSuffix for the generated `<ul "select2-results-[counter]"> <li>` which the user interacts with. 

In initContainer ( https://github.com/ivaynberg/select2/blob/master/select2.js#L2084 ) the function nextUid which uses the counter function ( https://github.com/ivaynberg/select2/blob/master/select2.js#L105 ) is used to generate the id for the replacement.

The Problem with the generated ID is that in our dynamic generated UI which gets UI Unit testet we can not be sure that it is always the same. So if the ID can not be found the unit test will fail.

My changes add the possibility to provide a function which takes the original element and uses the id to generate the suffix.

So a user can initialize select2 with an option  idSuffixGenerator. 
e.g.

``` javascript
$('select').select2({
idSuffixGenerator :function(element) {
                        var id = element.attr('id');
                        return id.length != 0 ? id : new Date().getTime();
                    };
})
```

Please let me know what you think about it.

Regards Stephan 
