### PR TITLE
Replaced nonexistent locale "no" with "nb" (Norwegian Bokmål).

### DIFF
--- a/select2_locale_nb.js
+++ b/select2_locale_nb.js
@@ -8,6 +8,7 @@
     "use strict";
 
     $.fn.select2.locales['nb'] = {
+        formatMatches: function (matches) { if (matches === 1) { return "Ett resultat er tilgjengelig, trykk enter for å velge det."; } return matches + " resultater er tilgjengelig. Bruk piltastene opp og ned for å navigere."; },
         formatNoMatches: function () { return "Ingen treff"; },
         formatInputTooShort: function (input, min) { var n = min - input.length; return "Vennligst skriv inn " + n + (n>1 ? " flere tegn" : " tegn til"); },
         formatInputTooLong: function (input, max) { var n = input.length - max; return "Vennligst fjern " + n + " tegn"; },


### PR DESCRIPTION
As “Norwegian” isn't a written language, the locale “no” doesn't exist. Instead there are the languages “Norwegian Bokmål” (nb) and “Norwegian Nynorsk” (nn). Source: http://en.wikipedia.org/wiki/Norwegian_language

The language used in this file is Norwegian Bokmål, so I renamed it accordingly to “nb”.

If backwards compatibility is a concern, the original file may be kept. When the same issue was resolved in glibc in 2003, they made “no” an alias of “nb”. Source: https://bugzilla.redhat.com/show_bug.cgi?id=83276

I have added the missing translation for formatMatches.

For correct Norwegian Bokmål punctuation, I also added a space before the ellipsises.
Source: http://www.korrekturavdelingen.no/K4ellipse.htm (in Norwegian Bokmål)
