### PR TITLE
Delete 'StarHack' code. Because select2 support IE8+.

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -5,9 +5,6 @@ Version: @@ver@@ Timestamp: @@timestamp@@
     margin: 0;
     position: relative;
     display: inline-block;
-    /* inline-block for ie7 */
-    zoom: 1;
-    *display: inline;
     vertical-align: middle;
 }
 


### PR DESCRIPTION
CSS Optimizer (ex CSSO) can't compile 'SartHack' code.
If select2 support IE8+, please delete code for 'IE6/7'. 
