### PR TITLE
this fixes some issues with select2 jumping around

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3051,7 +3051,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 enabledItem = $(
                     "<li class='select2-search-choice'>" +
                     "    <div></div>" +
-                    "    <a href='#' class='select2-search-choice-close' tabindex='-1'></a>" +
+                    "    <a href='javascript:void 0' class='select2-search-choice-close' tabindex='-1'></a>" +
                     "</li>"),
                 disabledItem = $(
                     "<li class='select2-search-choice select2-locked'>" +


### PR DESCRIPTION
In some cases having `href="#"` on an `a` tag will case the browser to jump to the top of the page. We're seeing this happen in our app with select2. Switching it to `href="javascript:void 0"` will get around this,
