### PR TITLE
Add an option to allow the search container to appear before the options

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3092,7 +3092,16 @@ the specific language governing permissions and limitations under the Apache Lic
             }
 
             choice.data("select2-data", data);
-            choice.insertBefore(this.searchContainer);
+            if (this.opts.searchFirst === true) {
+              var nextAll = this.searchContainer.nextAll();
+              if (nextAll.length > 0) {
+                choice.insertAfter(nextAll[nextAll.length - 1]);
+              } else {
+                choice.insertAfter(this.searchContainer);
+              }
+            } else {
+              choice.insertBefore(this.searchContainer);
+            }
 
             val.push(id);
             this.setVal(val);
@@ -3494,7 +3503,8 @@ the specific language governing permissions and limitations under the Apache Lic
             }
 
             return true;
-        }
+        },
+        searchFirst: false
     };
 
     $.fn.select2.locales = [];


### PR DESCRIPTION
In scenarios where the select box is displayed as a list with one selected item per line, I believe it looks and behaves better, and is more intuitive if the search container appears before the selected items in a multi select.  To this end I would like to add a new option 'searchFirst' that will allow for the search container to remain at the front of the list and new selected items to be added to the end of the list.
