### PR TITLE
Hide search box when there are no results

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1814,6 +1814,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 // handle ajax error
                 if(data.hasError !== undefined && checkFormatter(opts.formatAjaxError, "formatAjaxError")) {
                     render("<li class='select2-ajax-error'>" + evaluate(opts.formatAjaxError, opts.element, data.jqXHR, data.textStatus, data.errorThrown) + "</li>");
+                    this.showSearch(false);
                     return;
                 }
 


### PR DESCRIPTION
When minimumResultsForSearch is positive, search box is displayed when there are no results.
Duplicate of #508.
