### PR TITLE
Hide search box when there are no results

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1834,6 +1834,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
                 if (data.results.length === 0 && checkFormatter(opts.formatNoMatches, "formatNoMatches")) {
                     render("<li class='select2-no-results'>" + evaluate(opts.formatNoMatches, opts.element, search.val()) + "</li>");
+                    this.showSearch(false);
                     return;
                 }
 


### PR DESCRIPTION
When minimumResultsForSearch is positive, search box is displayed when there are no results.
Replace Pull Request #2821.
Resolves issue #508.
