### PR TITLE
Result open and intermediately close on change .select2-drop

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -801,7 +801,7 @@ the specific language governing permissions and limitations under the Apache Lic
             search.on("focus", function () { search.addClass("select2-focused"); });
             search.on("blur", function () { search.removeClass("select2-focused");});
 
-            this.dropdown.on("mouseup", resultsSelector, this.bind(function (e) {
+            this.dropdown.on("mousedown", resultsSelector, this.bind(function (e) {
                 if ($(e.target).closest(".select2-result-selectable").length > 0) {
                     this.highlightUnderEvent(e);
                     this.selectHighlighted(e);


### PR DESCRIPTION
The problem is that on mousedown an element is selected, when the dropdown is open under the 'select' element (where you click to open the dropdown), the mouse pointer is over the dropdown then on release the mouse click the element over the mouse pointer is selected.

https://github.com/ivaynberg/select2/issues/2823
