### PR TITLE
Hide search box if select is empty

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1834,6 +1834,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
                 if (data.results.length === 0 && checkFormatter(opts.formatNoMatches, "formatNoMatches")) {
                     render("<li class='select2-no-results'>" + evaluate(opts.formatNoMatches, opts.element, search.val()) + "</li>");
+                    this.showSearch(search.val());
                     return;
                 }
 


### PR DESCRIPTION
Fix #2822.
When a select box is empty (this appends in my case, I have a dynamic select box), the search box should not be shown.
