### PR TITLE
don't display a hidden input on destroy

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -870,17 +870,21 @@ the specific language governing permissions and limitations under the Apache Lic
                 select2.container.remove();
                 select2.liveRegion.remove();
                 select2.dropdown.remove();
-                element
-                    .show()
-                    .removeData("select2")
-                    .off(".select2")
-                    .prop("autofocus", this.autofocus || false);
-                if (this.elementTabIndex) {
-                    element.attr({tabindex: this.elementTabIndex});
+                element.removeData("select2")
+                    .off("select2");
+                if (!element.is("input[type='hidden']")) {
+                    element
+                        .show()
+                        .prop("autofocus", this.autofocus || false);
+                    if (this.elementTabIndex) {
+                        element.attr({tabindex: this.elementTabIndex});
+                    } else {
+                        element.removeAttr("tabindex");
+                    }
+                    element.show();
                 } else {
-                    element.removeAttr("tabindex");
+                    element.css("display", "");
                 }
-                element.show();
             }
 
             cleanupJQueryElements.call(this,


### PR DESCRIPTION
closes #2837 

Here is a JSFiddle using select2.js as it is now: http://jsfiddle.net/ckvbwrcp/
It will appear to be fine in Chrome, but if you click the update button in Firefox the styling will change.

This is the same JSFiddle, except using the code in this PR: http://jsfiddle.net/ckvbwrcp/1/
It will work in both Chrome and Firefox.

The change is in the `destroy` method. A hidden input is detected, and modifications that are only relevant to visible elements are not performed on the hidden input, so the browser will not attempt to display this element using inline styling.
