### PR TITLE
Fix bug where elements in select2 drop cannot be focused

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2181,7 +2181,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 // without this the search field loses focus which is annoying
                 if (document.activeElement === this.body.get(0)) {
                     window.setTimeout(this.bind(function() {
-                        if (this.opened()) {
+                        if (this.opened() && this.results && this.results.length > 1) {
                             this.search.focus();
                         }
                     }), 0);


### PR DESCRIPTION
Background: CiviCRM builds on select2 by adding some extra filters and controls to the select2 drop area:

![select2_drop](https://cloud.githubusercontent.com/assets/2874912/5323829/134f2b54-7ca2-11e4-9772-2bdc534da7a2.png)

Tracking down why the user was being prevented from interacting with the controls, I found that this chrome workaround had the undesired side-effect of preventing anything in the select2 drop from being focused (affected single but not multi selects for some reason). Making the condition more specific to the actual problem being worked around solves this.