### PR TITLE
Fix performance issue with setVal on MultiSelect

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3261,11 +3261,9 @@ the specific language governing permissions and limitations under the Apache Lic
                 for (var j = 0; j < old.length; j++) {
                     if (equal(this.opts.id(current[i]), this.opts.id(old[j]))) {
                         current.splice(i, 1);
-                        if(i>0){
-                            i--;
-                        }
+                        i--;
                         old.splice(j, 1);
-                        j--;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
As suggested in https://github.com/ivaynberg/select2/issues/781#issuecomment-30935226, significantly improves selection performance (90~100x faster) on a list of 2,000 items.

Also see: https://github.com/ivaynberg/select2/issues/905 and https://github.com/ivaynberg/select2/issues/2706

It will take 1s to 'select all' in patched version http://jsfiddle.net/hrro7j6L/3/ and 93s in head version http://jsfiddle.net/hrro7j6L/4/
