### PR TITLE
Don't add empty list items if formatResult return undefined.

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -972,6 +972,9 @@ the specific language governing permissions and limitations under the Apache Lic
                                 label.html(formatted);
                                 node.append(label);
                             }
+                            else {
+                                continue;
+                            }
 
 
                             if (compound) {


### PR DESCRIPTION
I'm using custom formatResult implementation and for some items that I don't want in the list I return undefined... I get an empty space inside dropdown .. I think It should just not add the item at all...
