### PR TITLE
Fixing issue #2864

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1943,7 +1943,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 } else if (this.opts.width === "copy" || this.opts.width === "resolve") {
                     // check if there is inline style on the element that contains width
                     style = this.opts.element.attr('style');
-                    if (style !== undefined) {
+                    if (typeof(style) === "string") {
                         attrs = style.split(';');
                         for (i = 0, l = attrs.length; i < l; i = i + 1) {
                             attr = attrs[i].replace(/\s/g, '');


### PR DESCRIPTION
If you call element.attr ('style') with Zepto and
there is NO inline style, you get back the
CSS2Properties object. In jQuery you would get
nothing.

To avoid calling split in an object instead of a
string we should check if we really have a string.
