### PR TITLE
Fix accessible aria activedescendant attribute

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1486,6 +1486,9 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.clearSearch();
             this.search.removeClass("select2-active");
+
+            // Remove the aria active descendant for highlighted element
+            this.search.removeAttr("aria-activedescendant");
             this.opts.element.trigger($.Event("select2-close"));
         },
 


### PR DESCRIPTION
Remove aria-activedescendant attribute after the dropdown is closed,
to make sure the aria properties is vaild for aduit-tool

[https://code.google.com/p/accessibility-developer-tools/wiki/AuditRules#AX_ARIA_04:_ARIA_state_and_property_values_must_be_valid]
