### PR TITLE
Hide element if template returns a false-like value

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -466,7 +466,13 @@ define([
   Results.prototype.template = function (result, container) {
     var template = this.options.get('templateResult');
 
-    container.innerHTML = template(result);
+    var result = template(result);
+
+    if (result) {
+        container.innerHTML = result;
+    } else {
+        container.style.display = 'none';
+    }
   };
 
   return Results;


### PR DESCRIPTION
This allows you to hide elements when using the template% formatting functions.