### PR TITLE
Properly off() the events in the "select2" namespace

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -871,7 +871,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 select2.liveRegion.remove();
                 select2.dropdown.remove();
                 element.removeData("select2")
-                    .off("select2");
+                    .off(".select2");
                 if (!element.is("input[type='hidden']")) {
                     element
                         .show()


### PR DESCRIPTION
The dot, denoting a namespace and not an event name, was missing