### PR TITLE
Fix for MaximumInputLength

### DIFF
--- a/src/js/select2/data/maximumInputLength.js
+++ b/src/js/select2/data/maximumInputLength.js
@@ -15,7 +15,7 @@ define([
       this.trigger('results:message', {
         message: 'inputTooLong',
         args: {
-          minimum: this.maximumInputLength,
+          maximum: this.maximumInputLength,
           input: params.term,
           params: params
         }


### PR DESCRIPTION
I18n translations expect a "maximum" argument for inputTooLong message, but MaximumInputLength is passing "minimum".
![screen shot 2015-02-04 at 6 54 52 am](https://cloud.githubusercontent.com/assets/64386/6037440/c417a4f8-ac3a-11e4-9b3f-b547a097fe12.png)
This renames "minimum" to "maximum" to fix this problem.