### PR TITLE
Add rel=stylesheet to the cdn link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@ slug: home
         section of your HTML.
 
 <pre class="code">
-&lt;link href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0-beta.3/css/select2.min.css" /&gt;
+&lt;link href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0-beta.3/css/select2.min.css" rel="stylesheet" /&gt;
 &lt;script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0-beta.3/js/select2.min.js"&gt;&lt;/script&gt;
 </pre>
 
@@ -118,7 +118,7 @@ slug: home
         section of your HTML.
 
 <pre class="code">
-&lt;link href="path/to/select2.min.css" /&gt;
+&lt;link href="path/to/select2.min.css" rel="stylesheet" /&gt;
 &lt;script src="path/to/select2.min.js"&gt;&lt;/script&gt;
 </pre>
       </li>


### PR DESCRIPTION
Without specifying the rel="stylesheet" in your link tag, some browsers don't interpret the file as css.