### PR TITLE
Fix: TypeError: $ is not a function

### DIFF
--- a/src/js/select2/utils.js
+++ b/src/js/select2/utils.js
@@ -202,7 +202,7 @@ define([
     // http://codereview.stackexchange.com/q/13338
     // and was designed to be used with the Sizzle selector engine.
 
-    var $el = $(el);
+    var $el = jQuery(el);
     var overflowX = el.style.overflowX;
     var overflowY = el.style.overflowY;
 


### PR DESCRIPTION
I've noticed this error on two different (WordPress) sites. It happens when focusing on the select box.

`TypeError: $ is not a function /select2.js Line 641`

Apologises if it's already been reported, I couldn't find the issue reported.