### PR TITLE
Update select2.js

### DIFF
--- a/dist/js/select2.js
+++ b/dist/js/select2.js
@@ -3983,8 +3983,8 @@ define('select2/dropdown/attachBody',[
   AttachBody.prototype._showDropdown = function (decorated) {
     this.$dropdownContainer.appendTo(this.$dropdownParent);
 
-    this._positionDropdown();
     this._resizeDropdown();
+    this._positionDropdown();
   };
 
   return AttachBody;


### PR DESCRIPTION
I find sometimes the $dropdown is not positioned right when showing above - see the screenshot below
![shotcut](https://cloud.githubusercontent.com/assets/10859433/6424410/ad77a3fe-bf33-11e4-9d39-f08d3ea77c22.png)
Test results shows that the initial width of $dropdownContainer is 0 and it makes the outerHeight of $dropdown incorrect. I change the excute order of _resizeDropdown & _positionDropdown methods in AttachBody.prototype._showDropdown(line 3983,3984), and it works. 