### PR TITLE
Update attachBody.js

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -187,8 +187,8 @@ define([
   AttachBody.prototype._showDropdown = function (decorated) {
     this.$dropdownContainer.appendTo(this.$dropdownParent);
 
-    this._positionDropdown();
     this._resizeDropdown();
+    this._positionDropdown();
   };
 
   return AttachBody;


### PR DESCRIPTION
Sometimes $dropdown is not positioned right when showing above, for the initial width of $dropdownContainer is 0(when position is absolute, 'width:100%' doesn't work) and it makes the outerHeight of $dropdown incorrect.