### PR TITLE
Remove jQuery as a jsHint global

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -40,7 +40,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
 (function ($, undefined) {
     "use strict";
-    /*global document, window, jQuery, console */
+    /*global document, window, console */
 
     if (window.Select2 !== undefined) {
         return;


### PR DESCRIPTION
Let's remove jQuery as a jsHint global so attempts to access it out-of-scope will be caught by linting.