### PR TITLE
feature: select2 don't search by parent when inited with custom data

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -518,7 +518,7 @@ the specific language governing permissions and limitations under the Apache Lic
                     }
                     group.children=[];
                     $(datum.children).each2(function(i, childDatum) { process(childDatum, group.children); });
-                    if (group.children.length || query.matcher(t, text(group), datum)) {
+                    if (group.children.length || (query.matcher(t, text(group), datum) && datum.id !== undefined)) {
                         collection.push(group);
                     }
                 } else {


### PR DESCRIPTION
When select2 is populated from the hierarchical array, search is working on the parent elements.

For example,
```
var data = [
  {
    text : 'parent 1',
    children: [
      { id: 1, text: 'child 1' },
      { id: 1, text: 'child 1' },
    ]
];
$('#e').select2({ data: data });
```
select2 initialized with this code returns `parent 1` as a search result if you search by `par`.

Now, parents don't have `id` field, so they wouldn't be searched by.