### PR TITLE
Swap inputTooLong and inputTooShort error messages

### DIFF
--- a/src/js/select2/i18n/gl.js
+++ b/src/js/select2/i18n/gl.js
@@ -4,7 +4,7 @@ define(function () {
     inputTooLong: function (args) {
       var overChars = args.input.length - args.maximum;
 
-      var message = 'Engada ';
+      var message = 'Elimine ';
 
       if (overChars === 1) {
         message += 'un carácter';
@@ -17,7 +17,7 @@ define(function () {
     inputTooShort: function (args) {
       var remainingChars = args.minimum - args.input.length;
 
-      var message = 'Elimine ';
+      var message = 'Engada ';
 
       if (remainingChars === 1) {
         message += 'un carácter';


### PR DESCRIPTION
"Engada"  is galician for "to add" and therefore should be the base text used for the inputTooShort method, asking the use to add more chars. It seems to be mistakenly defined exactly the opposite it should be (as inputTooLong was containing the right text).