### PR TITLE
Fix undefined function error

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1841,7 +1841,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
                 if (data.results.length === 0 && checkFormatter(opts.formatNoMatches, "formatNoMatches")) {
                     render("<li class='select2-no-results'>" + evaluate(opts.formatNoMatches, opts.element, search.val()) + "</li>");
-                    this.showSearch(search.val());
+                    this.showSearch && this.showSearch(search.val());
                     return;
                 }
 


### PR DESCRIPTION
PR #2828 caused an "undefined is not a function" error when no results are found in a multiselect, because it attempts to call a function that only exists for single selects. This fixes it.