### PR TITLE
bower.json: main: select2.css => core.scss

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
     "description": "Select2 is a jQuery based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results.",
     "main": [
         "dist/js/select2.js",
-        "dist/css/select2.css"
+        "src/scss/core.scss"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
Per bower/bower.json-spec#43 :
> Use source files with module exports and imports over pre-built distribution files.

Also, the example in that PR includes `/sass/motion.scss` in and excludes `/dist/movement.css` & `/dist/movement.min.css` from its `main`.