### PR TITLE
Change listener from 'mouseup' to 'click' on dropdown results

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -292,7 +292,7 @@ define([
         return;
       }
 
-      $highlighted.trigger('mouseup');
+      $highlighted.trigger('click');
     });
 
     container.on('results:select', function () {
@@ -414,7 +414,7 @@ define([
       });
     }
 
-    this.$results.on('mouseup', '.select2-results__option[aria-selected]',
+    this.$results.on('click', '.select2-results__option[aria-selected]',
       function (evt) {
       var $this = $(this);
 


### PR DESCRIPTION
This prevents the results dropdown from closing immediately again when a result was positioned directly under the cursor, for example due to CSS styles that position the dropdown with its results directly above the select2 container.