### PR TITLE
Change default value for 'width' option to NULL

### DIFF
--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -375,7 +375,7 @@ define([
         return selection.text;
       },
       theme: 'default',
-      width: 'resolve'
+      width: null
     };
   };
 


### PR DESCRIPTION
Select2 should not set a specific width by default, as this breaks the responsiveness of the plugin. Setting the default value to NULL will make Select2.prototype._resolveWidth() return NULL as well, which in turn prevents Select2.prototype._placeContainer() from applying a CSS-width to the container, which would make it unresponsive.