### PR TITLE
Fixed AjaxAdapter's super constructor call

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -10,7 +10,7 @@ define([
       this.processResults = this.ajaxOptions.processResults;
     }
 
-    ArrayAdapter.__super__.constructor.call(this, $element, options);
+    AjaxAdapter.__super__.constructor.call(this, $element, options);
   }
 
   Utils.Extend(AjaxAdapter, ArrayAdapter);


### PR DESCRIPTION
Replaced ArrayAdapter super constructor call with correct AjaxAdapter super constructor call. This will allow users to initialize an Ajax select with data.