### PR TITLE
Select current result when the tab key is pressed.

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -298,7 +298,7 @@ define([
       var key = evt.which;
 
       if (self.isOpen()) {
-        if (key === KEYS.ENTER) {
+        if (key === KEYS.ENTER || key === KEYS.TAB) {
           self.trigger('results:select');
 
           evt.preventDefault();
@@ -314,7 +314,7 @@ define([
           self.trigger('results:next');
 
           evt.preventDefault();
-        } else if (key === KEYS.ESC || key === KEYS.TAB) {
+        } else if (key === KEYS.ESC) {
           self.close();
 
           evt.preventDefault();


### PR DESCRIPTION
This results in much more natural behaviour when using a multi-select. Users expect tab completion instead of having it clear what you just typed.