### PR TITLE
Allow immediate typing when tabbing to multiple select.

### DIFF
--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -25,7 +25,11 @@ define([
     var self = this;
 
     MultipleSelection.__super__.bind.apply(this, arguments);
-
+    
+    this.$selection.on('focus', function (evt) {
+      self.$search.trigger('focus');
+    });
+    
     this.$selection.on('click', function (evt) {
       self.trigger('toggle', {
         originalEvent: evt


### PR DESCRIPTION
Fixes #3331.

I'd be willing to make this an option if someone can make the case that it shouldn't be default behaviour.

@philipwalton let me know if this works for you.