### PR TITLE
ContainerCss: Remove magic `:all:` correctly. Fixes #3446.

### DIFF
--- a/src/js/select2/compat/containerCss.js
+++ b/src/js/select2/compat/containerCss.js
@@ -22,7 +22,7 @@ define([
     containerCssAdapter = containerCssAdapter || _containerAdapter;
 
     if (containerCssClass.indexOf(':all:') !== -1) {
-      containerCssClass = containerCssClass.replace(':all', '');
+      containerCssClass = containerCssClass.replace(':all:', '');
 
       var _cssAdapter = containerCssAdapter;
 

--- a/src/js/select2/compat/dropdownCss.js
+++ b/src/js/select2/compat/dropdownCss.js
@@ -22,7 +22,7 @@ define([
     dropdownCssAdapter = dropdownCssAdapter || _dropdownAdapter;
 
     if (dropdownCssClass.indexOf(':all:') !== -1) {
-      dropdownCssClass = dropdownCssClass.replace(':all', '');
+      dropdownCssClass = dropdownCssClass.replace(':all:', '');
 
       var _cssAdapter = dropdownCssAdapter;
 


### PR DESCRIPTION
I don’t know how to adjust the tests in a meaningful way to cover this. I tried make assertions on `$container.attr('class')` or `$container.attr('class').split(/\s/).length`, but there are two classes set in selection/base.js (`select2-selection`) and selection/single.js (`select2-selection--single`) which a unit test for `ContainerCSS` should not know about.