### PR TITLE
use actual width for dropdown

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1263,6 +1263,16 @@ the specific language governing permissions and limitations under the Apache Lic
                 css,
                 resultsListNode;
 
+            // cal actual width
+            var rect = container[0].getBoundingClientRect();
+            if (rect.width) {
+              // 'width' is available for IE9+
+              width = rect.width;
+            } else {
+              // Calculate width for IE8 and below
+              width = rect.right - rect.left;
+            }
+
             // always prefer the current above/below alignment, unless there is not enough room
             if (aboveNow) {
                 above = true;
@@ -3064,7 +3074,7 @@ the specific language governing permissions and limitations under the Apache Lic
             });
             this.setVal(val);
         },
-        
+
         createChoice: function (data) {
             var enableChoice = !data.locked,
                 enabledItem = $(

--- a/select2.js
+++ b/select2.js
@@ -1263,16 +1263,6 @@ the specific language governing permissions and limitations under the Apache Lic
                 css,
                 resultsListNode;
 
-            // cal actual width
-            var rect = container[0].getBoundingClientRect();
-            if (rect.width) {
-              // 'width' is available for IE9+
-              width = rect.width;
-            } else {
-              // Calculate width for IE8 and below
-              width = rect.right - rect.left;
-            }
-
             // always prefer the current above/below alignment, unless there is not enough room
             if (aboveNow) {
                 above = true;
@@ -1304,6 +1294,16 @@ the specific language governing permissions and limitations under the Apache Lic
 
                 // fix so the cursor does not move to the left within the search-textbox in IE
                 this.focusSearch();
+            }
+
+            // cal actual width
+            var rect = container[0].getBoundingClientRect();
+            if (rect.width) {
+              // 'width' is available for IE9+
+              width = rect.width;
+            } else {
+              // Calculate width for IE8 and below
+              width = rect.right - rect.left;
             }
 
             if (this.opts.dropdownAutoWidth) {


### PR DESCRIPTION
container.width() returns rounded numbers. So sometimes seclect2 dropdown doesn't have same width with the input.
Fix: Use getBoundingClientRect()