### PR TITLE
Replace tabs with spaces for consistency

### DIFF
--- a/docs/_sass/_examples.scss
+++ b/docs/_sass/_examples.scss
@@ -41,11 +41,11 @@
 // styles for the event log in the "DOM events" section of the docs
 .s2-event-log {
   background: #002451;
-	color: white;
+  color: white;
   font-family: Menlo, 'Bitstream Vera Sans Mono', 'DejaVu Sans Mono', Monaco, Consolas, monospace;
   margin: 0 -15px 15px;
   padding: 45px 15px 15px;
-	position: relative;
+  position: relative;
 
   &:after {
     content: "Event Log";

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -78,8 +78,8 @@ define([
 
     // Hide the original select
     $element.addClass('select2-hidden-accessible');
-	$element.attr('aria-hidden', 'true');
-	
+    $element.attr('aria-hidden', 'true');
+
     // Synchronize any monitored attributes
     this._syncAttributes();
 
@@ -491,7 +491,7 @@ define([
     this.$element.attr('tabindex', this.$element.data('old-tabindex'));
 
     this.$element.removeClass('select2-hidden-accessible');
-	this.$element.attr('aria-hidden', 'false');
+    this.$element.attr('aria-hidden', 'false');
     this.$element.removeData('select2');
 
     this.dataAdapter.destroy();


### PR DESCRIPTION
Tabs remain in dist/js/select2.js and dist/js/select2.full.js, but as I understand those files are generated and should not be in commits modifying src/.