### PR TITLE
Apply select2('option') calls on all elements

### DIFF
--- a/src/js/jquery.select2.js
+++ b/src/js/jquery.select2.js
@@ -24,18 +24,21 @@ define([
 
         return this;
       } else if (typeof options === 'string') {
-        var instance = this.data('select2');
+        var ret;
+        this.each(function () {
+          var instance = $(this).data('select2');
 
-        if (instance == null && window.console && console.error) {
-          console.error(
-            'The select2(\'' + options + '\') method was called on an ' +
-            'element that is not using Select2.'
-          );
-        }
+          if (instance == null && window.console && console.error) {
+            console.error(
+              'The select2(\'' + options + '\') method was called on an ' +
+              'element that is not using Select2.'
+            );
+          }
 
-        var args = Array.prototype.slice.call(arguments, 1);
+          var args = Array.prototype.slice.call(arguments, 1);
 
-        var ret = instance[options](args);
+          ret = instance[options](args);
+        });
 
         // Check if we should be returning `this`
         if ($.inArray(options, thisMethods) > -1) {


### PR DESCRIPTION
Fixes #3413 

The idea of the patch is simple: as with `'object'` options, we iterate over `this`.

I don't know how to test destroy(), so... I did not test it. I might give it a try with some guidance. Should dist/ changes be part of the pull request? This is not mentioned in CONTRIBUTING.md.