### PR TITLE
Fixed direction bug in RTL mode of the text input

### DIFF
--- a/src/scss/theme/default/_multiple.scss
+++ b/src/scss/theme/default/_multiple.scss
@@ -59,7 +59,7 @@
 
 &[dir="rtl"] {
   .select2-selection--multiple {
-    .select2-selection__choice, .select2-selection__placeholder {
+    .select2-selection__choice, .select2-selection__placeholder, .select2-search--inline {
       float: right;
     }
 


### PR DESCRIPTION
In RTL mode, the input text for searching content is aligned to left.
This fix solves this issue.