### PR TITLE
Fixes #3503: Removes redundant 'open' event trigger

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -395,8 +395,6 @@ define([
     }
 
     this.trigger('query', {});
-
-    this.trigger('open');
   };
 
   Select2.prototype.close = function () {


### PR DESCRIPTION
The ```query``` event will fire the ```open``` event if the dropdown has not already been opened. In cases where the ```query``` event has already been triggered it makes an explicit trigger of the ```open``` event unnecessary. 