### PR TITLE
[#3531] Fix AJAX <option> doesn't have text inside

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -174,6 +174,10 @@ define([
       option.value = data.id;
     }
 
+    if (data.name) {
+      option.innerHTML = data.name;
+    }
+
     if (data.disabled) {
       option.disabled = true;
     }


### PR DESCRIPTION
Addresses #3531 

Sets `option.innerHTML` to `data.name` which we get by selecting a dropdown option.

The final result is:

```
<select class="select2-input select2-hidden-accessible" data-url="/admin/sources/1285/ajax_platform" data-ajax="true" id="source_platform_id" name="source[platform_id]" tabindex="-1" aria-hidden="true">
    <option selected="selected" value="5">YouTube</option>
    <option value="45">Twitch.tv</option>
</select>
```