### PR TITLE
#3306: Position clear button before the inline content of `.select2-selection__rendered`

### DIFF
--- a/src/scss/_single.scss
+++ b/src/scss/_single.scss
@@ -18,6 +18,10 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  .select2-selection__clear {
+    position: relative;
+  }
 }
 
 &[dir="rtl"] {


### PR DESCRIPTION
This should fix #3306, however I only tested in Google Chrome v43.0.2357.130.