### PR TITLE
Return all ajax parameters by default

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -18,9 +18,9 @@ define([
   AjaxAdapter.prototype._applyDefaults = function (options) {
     var defaults = {
       data: function (params) {
-        return {
+        return $.extend(params, {
           q: params.term
-        };
+        });
       },
       transport: function (params, success, failure) {
         var $request = $.ajax(params);


### PR DESCRIPTION
This commit resolves issue #3548