### PR TITLE
Multiple select, search field: Removes padding on mobile Safari.

### DIFF
--- a/src/scss/_multiple.scss
+++ b/src/scss/_multiple.scss
@@ -26,6 +26,7 @@
     border: none;
     font-size: 100%;
     margin-top: 5px;
+    padding: 0;
 
     &::-webkit-search-cancel-button {
       -webkit-appearance: none;


### PR DESCRIPTION
On iOS Safari (tested with iOS 7.1 and 8.4 on iOS simulator), inputs have a large default padding. With an inline width starting at 1.5em, the first characters entered are cut off when there is already a selection. See screenshots.

“X” entered:
![x-entered-and-cut-off](https://cloud.githubusercontent.com/assets/51251/8849112/4fbe01a0-313d-11e5-8776-5db6cd9156eb.png)

Styles:
![ua-styles](https://cloud.githubusercontent.com/assets/51251/8849113/5156597c-313d-11e5-9d3c-df70feebae37.png)
![applied-padding](https://cloud.githubusercontent.com/assets/51251/8849114/53068f1c-313d-11e5-8393-8e29c1b7f233.png)

Not sure if disabling the padding completely is the right solution, but it worked for us. This might affect the overall select height, but this way it’s at least consistent across browsers.