### PR TITLE
Fix IE 8-11 not showing Chinese characters

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -177,8 +177,6 @@ define([
   };
 
   AttachBody.prototype._resizeDropdown = function () {
-    this.$dropdownContainer.width();
-
     var css = {
       width: this.$container.outerWidth(false) + 'px'
     };


### PR DESCRIPTION
Fix issue in IE 8-11 that prevents typing characters that require multiple key presses to produce a single glyph.