### PR TITLE
Fix not checking for empty

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -5,7 +5,7 @@ define([
   './keys'
 ], function ($, Options, Utils, KEYS) {
   var Select2 = function ($element, options) {
-    if ($element.data('select2') != null) {
+    if ($element.data('select2')) {
       $element.data('select2').destroy();
     }
 


### PR DESCRIPTION
If $element.data('select2') is not null, but is "", script breaks