### PR TITLE
[bugfix]fix IE11 autofocus bug

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -42,7 +42,21 @@ define([
       $(this).off('keyup');
     });
 
-    this.$search.on('keyup input', function (evt) {
+    //fix IE11 autofocus bug
+    var isIE = (function () {
+      var ua = window.navigator.userAgent.toLowerCase();
+      if (ua.indexOf("msie") > 0 || ua.indexOf("trident") > 0 ) {
+          return true;
+      }
+      else {
+          return false;
+      }
+    }());
+
+    var input_event = !isIE ? 'input' : 'keydown';
+
+    this.$selection.on('keyup.search '+input_event, '.select2-search--inline',
+        function (evt) {
       self.handleSearch(evt);
     });
 


### PR DESCRIPTION
This patch fix the autofocus bug in IE11 which cause by the placeholder.
The placeholder in IE11 will always trigger 'input' event , so the select2 is always fouces.