### PR TITLE
[bugfix]fix IE11 autofocus bug

### DIFF
--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -92,8 +92,21 @@ define([
       // Unbind the duplicated `keyup` event
       self.$selection.off('keyup.search');
     });
+    
+    var isIE = (function () {
+        var ua = window.navigator.userAgent.toLowerCase();
+        if (ua.indexOf("msie") > 0 || ua.indexOf("trident") > 0 ) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }());
 
-    this.$selection.on('keyup.search input', '.select2-search--inline',
+    var input_event = !isIE ? 'input' : 'keydown';
+
+    
+    this.$selection.on('keyup.search '+input_event, '.select2-search--inline',
         function (evt) {
       var key = evt.which;
 

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -95,7 +95,7 @@ define([
     
     var isIE = (function () {
         var ua = window.navigator.userAgent.toLowerCase();
-        if (ua.indexOf("msie") > 0 || ua.indexOf("trident") > 0 ) {
+        if (ua.indexOf('msie') > 0 || ua.indexOf('trident') > 0 ) {
             return true;
         }
         else {

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -103,10 +103,10 @@ define([
         }
     }());
 
-    var input_event = !isIE ? 'input' : 'keydown';
+    var inputEvent = !isIE ? 'input' : 'keydown';
 
     
-    this.$selection.on('keyup.search '+input_event, '.select2-search--inline',
+    this.$selection.on('keyup.search '+inputEvent, '.select2-search--inline',
         function (evt) {
       var key = evt.which;
 


### PR DESCRIPTION
The input's placeholder will always trigger the 'input' event , so the select2 is autofocus and auto search when it initial , and whatever you do , it always trigger.

This patch is to fix it . When in IE ,  use keydown event to replace input event .