### PR TITLE
#3710 Fixed auto scrolling problem

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1682,7 +1682,7 @@ the specific language governing permissions and limitations under the Apache Lic
 
         // abstract
         ensureHighlightVisible: function () {
-            var results = this.results, children, index, child, hb, rb, y, more, topOffset;
+            var results = this.results, children, index, child, hb, rb, y, more, topOffset, highlightableChoices;
 
             index = this.highlight();
 
@@ -1698,7 +1698,8 @@ the specific language governing permissions and limitations under the Apache Lic
                 return;
             }
 
-            children = this.findHighlightableChoices().find('.select2-result-label');
+            highlightableChoices = this.findHighlightableChoices();
+            children = highlightableChoices.find('.select2-result-label');
 
             child = $(children[index]);
 
@@ -1708,9 +1709,15 @@ the specific language governing permissions and limitations under the Apache Lic
 
             // if this is the last child lets also make sure select2-more-results is visible
             if (index === children.length - 1) {
-                more = results.find("li.select2-more-results");
-                if (more.length > 0) {
-                    hb = more.offset().top + more.outerHeight(true);
+                // Try to get element below the last highlightable child
+                var elementBelow = $(highlightableChoices[index]).next();
+
+                // If the elementBelow exists and has the 'select2-disabled' class, select2 shouldn't treat the child as the last element
+                if(!elementBelow || !elementBelow.hasClass('select2-disabled')) {
+                    more = results.find("li.select2-more-results");
+                    if (more.length > 0) {
+                        hb = more.offset().top + more.outerHeight(true);
+                    }
                 }
             }
 


### PR DESCRIPTION
My change concerns to ensureHighlightVisible method. Original version added offset for 'get more details' when last element was highlighted. This method doesn't take into account case where selected last active element is not the last item on the list. In other words, below the selected element there are inactive / disabled elements. For such a case offset shouldn't be added. I've added additional checking whether the selected last item has a disabled sibling. If so, the offset will not be added.

Behavior before fix:
![2015-08-26 17h10_55](https://cloud.githubusercontent.com/assets/1587788/9498310/67defde2-4c19-11e5-9a72-74e089d35270.gif)


Behavior after fix:
![2015-08-26 16h49_24](https://cloud.githubusercontent.com/assets/1587788/9498330/89973de6-4c19-11e5-9c5b-307cf77ac0c8.gif)
