### PR TITLE
Add select2.css to composer generated require.css

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
       "scripts": [
         "dist/js/select2.js"
       ],
+      "styles": [
+        "dist/css/select2.css"
+      ],
       "files": [
         "dist/js/select2.js",
         "dist/js/i18n/*.js",


### PR DESCRIPTION
Hi,
I have just recognized that the provided stylesheet is not added to the require.css (generated by composer components-installer).

Is there a reason why this was not done?