### PR TITLE
Adding list of public events

### DIFF
--- a/docs/_includes/options/events.html
+++ b/docs/_includes/options/events.html
@@ -32,6 +32,22 @@
     <a href="https://api.jquery.com/on/"><code>.on</code> method</a> provided
     by jQuery.
   </p>
+  
+  <h3 id="events-public=list">List of public events</h3>
+  Non-preventable Events
+  <ul>
+    <li>open</li>
+    <li>close</li>
+    <li>select</li>
+    <li>unselect</li>
+  </ul>
+  Preventable Events
+  <ul>
+    <li>opening</li>
+    <li>closing</li>
+    <li>selecting</li>
+    <li>unselecting</li>
+  </ul>
 
   <h2 id="events-internal">
     Internal events


### PR DESCRIPTION
Adding a list of the public events, both non-preventable and preventable, to the Options documentation page. I found that the only way I could get this information was in the source code, and thought it would be helpful to have in the documenation.