### PR TITLE
prevent infinite loop between SelectOnClose and CloseOnSelect

### DIFF
--- a/src/js/select2/dropdown/closeOnSelect.js
+++ b/src/js/select2/dropdown/closeOnSelect.js
@@ -25,7 +25,11 @@ define([
       return;
     }
 
-    this.trigger('close', {});
+    // Trigger a close *unless* we've been asked to suppress. This is sent by
+    // SelectOnClose to prevent an infinite loop between triggers.
+    if (! evt.suppressCloseOnSelect) {
+      this.trigger('close', {});
+    }
   };
 
   return CloseOnSelect;

--- a/src/js/select2/dropdown/selectOnClose.js
+++ b/src/js/select2/dropdown/selectOnClose.js
@@ -21,7 +21,10 @@ define([
     }
 
     this.trigger('select', {
-        data: $highlightedResults.data('data')
+      data: $highlightedResults.data('data'),
+      // Don't want CloseOnSelect to fire if we're already closing
+      // because it causes an infinte loop.
+      suppressCloseOnSelect: true
     });
   };
 


### PR DESCRIPTION
This is a solution for #3169, based on @gmitra's suggestion.

I made an attempt to write tests for this, but I'm not terribly familiar with the select2 code base, how the decorators work under the hood, or exactly how things should be pieced together in the unit test, so I had some trouble with it. Strangely, I couldn't even get the test to reproduce the original issue (the infinite loop), so there's something pretty wrong with my test draft.

You can see my first attempt at the tests here: https://github.com/select2/select2/compare/select2:master...ianawilson:select-on-close-loop-tests

If anyone is interested to help me figure out and fix the unit tests, I'd be happy to get those in here and working.