### PR TITLE
remove the href property from the select2-search-choice-close link

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -3240,7 +3240,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 enabledItem = $(
                     "<li class='select2-search-choice'>" +
                     "    <div></div>" +
-                    "    <a href='#' class='select2-search-choice-close' tabindex='-1'></a>" +
+                    "    <a class='select2-search-choice-close' tabindex='-1'></a>" +
                     "</li>"),
                 disabledItem = $(
                     "<li class='select2-search-choice select2-locked'>" +


### PR DESCRIPTION
For some reason the URL is actually changing to '#' in the Ember.js framework version 1.13. Since this is unnecessary because the anchor tag is not actually being used as a link, perhaps it would be best to remove the href attribute altogether.