### PR TITLE
Use apply when calling methods

### DIFF
--- a/src/js/jquery.select2.js
+++ b/src/js/jquery.select2.js
@@ -35,7 +35,7 @@ define([
 
         var args = Array.prototype.slice.call(arguments, 1);
 
-        var ret = instance[options](args);
+        var ret = instance[options].apply(instance, args);
 
         // Check if we should be returning `this`
         if ($.inArray(options, thisMethods) > -1) {


### PR DESCRIPTION
Method called using apply to avoid translating multiple args into single arg.
Fixes #3756