### PR TITLE
Fix X(clear) button being unclickable

### DIFF
--- a/src/scss/_single.scss
+++ b/src/scss/_single.scss
@@ -1,3 +1,5 @@
+@import "mixins/span_z_index";
+
 .select2-selection--single {
   box-sizing: border-box;
 
@@ -9,7 +11,10 @@
   user-select: none;
   -webkit-user-select: none;
 
+  @include span-z-index(3);
+
   .select2-selection__rendered {
+    @include span-z-index(4);
     display: block;
     padding-left: 8px;
     padding-right: 20px;
@@ -17,6 +22,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    .select2-selection__clear {
+      @include span-z-index(5 !important);
+    }
   }
 }
 

--- a/src/scss/core.scss
+++ b/src/scss/core.scss
@@ -1,3 +1,5 @@
+@import "mixins/span_z_index";
+
 .select2-container {
   box-sizing: border-box;
 
@@ -8,6 +10,12 @@
 
   @import "single";
   @import "multiple";
+
+  @include span-z-index(1);
+
+  .selection {
+    @include span-z-index(2);
+  }
 }
 
 @import "dropdown";

--- a/src/scss/mixins/_span_z_index.scss
+++ b/src/scss/mixins/_span_z_index.scss
@@ -1,0 +1,6 @@
+// http://philipwalton.com/articles/what-no-one-told-you-about-z-index/
+@mixin span-z-index($index) {
+  position: relative;
+  opacity: .99;
+  z-index: $index;
+}


### PR DESCRIPTION
Addresses #3809.

The solution is to add `z-index` starting from the parent `select2-container` till the `select2-selection__clear` DOM element.

I also linked http://philipwalton.com/articles/what-no-one-told-you-about-z-index/ in the CSS as a comment since people are probably going to wonder why I set opacity when I want to just modify a `z-index`.