### PR TITLE
Speak results in dropdown

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -68,6 +68,10 @@ define([
       var $request = options.transport(options, function (data) {
         var results = self.processResults(data, params);
 
+        $.each(results.results, function(i, result) {
+            results.results[i] = self._normalizeItem(result);
+        });
+
         if (self.options.get('debug') && window.console && console.error) {
           // Check to make sure that the response included a `results` key.
           if (!results || !results.results || !$.isArray(results.results)) {

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -36,8 +36,12 @@ define([
     this.clear();
     this.hideLoading();
 
+    var messageId = this.data.generateResultId(
+      { id: this.$results.attr('id') }, {}
+    );
     var $message = $(
-      '<li role="treeitem" class="select2-results__option"></li>'
+      '<li id="' + messageId + '" role="treeitem" ' +
+        'class="select2-results__option"></li>'
     );
 
     var message = this.options.get('translations').get(params.message);
@@ -51,6 +55,7 @@ define([
     $message[0].className += ' select2-results__message';
 
     this.$results.append($message);
+    this.trigger('results:speak', { id: messageId });
   };
 
   Results.prototype.hideMessages = function () {
@@ -456,6 +461,9 @@ define([
       self.trigger('results:focus', {
         data: data,
         element: $(this)
+      });
+      self.trigger('results:speak', {
+        id: $(this).attr('id')
       });
     });
   };

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -36,12 +36,9 @@ define([
     this.clear();
     this.hideLoading();
 
-    var messageId = this.data.generateResultId(
-      { id: this.$results.attr('id') }, {}
-    );
     var $message = $(
-      '<li id="' + messageId + '" role="treeitem" ' +
-        'class="select2-results__option"></li>'
+      '<li role="treeitem" aria-live="assertive"' +
+      ' class="select2-results__option"></li>'
     );
 
     var message = this.options.get('translations').get(params.message);
@@ -55,7 +52,6 @@ define([
     $message[0].className += ' select2-results__message';
 
     this.$results.append($message);
-    this.trigger('results:speak', { id: messageId });
   };
 
   Results.prototype.hideMessages = function () {
@@ -461,9 +457,6 @@ define([
       self.trigger('results:focus', {
         data: data,
         element: $(this)
-      });
-      self.trigger('results:speak', {
-        id: $(this).attr('id')
       });
     });
   };

--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -15,7 +15,7 @@ define([
   BaseSelection.prototype.render = function () {
     var $selection = $(
       '<span class="select2-selection" role="combobox" ' +
-      'aria-autocomplete="list" aria-haspopup="true" aria-expanded="false">' +
+      ' aria-haspopup="true" aria-expanded="false">' +
       '</span>'
     );
 

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -37,6 +37,7 @@ define([
 
     container.on('close', function () {
       self.$search.val('');
+      self.$search.attr('aria-activedescendant', null);
       self.$search.trigger('focus');
     });
 
@@ -54,7 +55,7 @@ define([
       self.$search.trigger('focus');
     });
 
-    container.on('results:speak', function (params) {
+    container.on('results:focus', function (params) {
       self.$search.attr('aria-activedescendant', params.id);
     });
 

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -12,7 +12,7 @@ define([
       '<li class="select2-search select2-search--inline">' +
         '<input class="select2-search__field" type="search" tabindex="-1"' +
         ' autocomplete="off" autocorrect="off" autocapitalize="off"' +
-        ' spellcheck="false" role="textbox" />' +
+        ' spellcheck="false" role="textbox" aria-autocomplete="list" />' +
       '</li>'
     );
 
@@ -52,6 +52,10 @@ define([
 
     container.on('focus', function (evt) {
       self.$search.trigger('focus');
+    });
+
+    container.on('results:speak', function (params) {
+      self.$search.attr('aria-activedescendant', params.id);
     });
 
     this.$selection.on('focusin', '.select2-search--inline', function (evt) {

--- a/tests/a11y/search-tests.js
+++ b/tests/a11y/search-tests.js
@@ -1,0 +1,51 @@
+module('Accessibility - Search');
+
+var MultipleSelection = require('select2/selection/multiple');
+var InlineSearch = require('select2/selection/search');
+
+var $ = require('jquery');
+
+var Utils = require('select2/utils');
+var Options = require('select2/options');
+var options = new Options({});
+
+test('aria-autocomplete attribute is present', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  assert.equal(
+    $selection.find('input').attr('aria-autocomplete'),
+    'list',
+    'The search box is marked as autocomplete'
+  );
+});
+
+test('aria-activedescendant should be removed when closed', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  var $search = $selection.find('input');
+  $search.attr('aria-activedescendant', 'something');
+
+  container.trigger('close');
+
+  assert.ok(
+    !$search.attr('aria-activedescendant'),
+    'There is no active descendant when the dropdown is closed'
+  );
+});

--- a/tests/a11y/selection-tests.js
+++ b/tests/a11y/selection-tests.js
@@ -64,31 +64,6 @@ test('static aria attributes are present', function (assert) {
     'true',
     'The dropdown is considered a popup of the container'
   );
-
-  assert.equal(
-    $selection.attr('aria-autocomplete'),
-    'list',
-    'The results in the dropdown are the autocomplete list'
-  );
-});
-
-test('aria-activedescendant should be removed when closed', function (assert) {
-  var $select = $('#qunit-fixture .single');
-
-  var selection = new BaseSelection($select, options);
-  var $selection = selection.render();
-
-  var container = new MockContainer();
-  selection.bind(container, $('<span></span>'));
-
-  $selection.attr('aria-activedescendant', 'something');
-
-  container.trigger('close');
-
-  assert.ok(
-    !$selection.attr('aria-activedescendant'),
-    'There is no active descendant when the dropdown is closed'
-  );
 });
 
 test('the container should be in the tab order', function (assert) {

--- a/tests/unit.html
+++ b/tests/unit.html
@@ -55,6 +55,7 @@
     <script src="helpers.js" type="text/javascript"></script>
 
     <script src="a11y/selection-tests.js" type="text/javascript"></script>
+    <script src="a11y/search-tests.js" type="text/javascript"></script>
 
     <script src="data/array-tests.js" type="text/javascript"></script>
     <script src="data/base-tests.js" type="text/javascript"></script>


### PR DESCRIPTION
Addresses #3735

As of select2 4.0, screen readers give no indication of which result in the combo box is highlighted. Previously, when the highlighted result was changed, the screen reader would read out the text of the item. This patch restores that functionality by setting up aria-autocomplete on the search box and changing its active descendant when moving up/down through the results. This means:

- When a character is typed into the search box, screen readers now read out the first result
- When the up/down arrow key is used to navigate results, screen now should read the currently highlighted result

This has been tested in JAWS and NVDA, but not exhaustively (ie. only with multi-select boxes) so there may be cases where it doesn't work. Also, I'm not sure if it's a good idea to have a separate "results:speak" event, but it made sense at the time for reasons I've now forgotten ... let me know if there's a better place to change the active descendant.

See what you think and if there are any problems just let me know!

Jono