### PR TITLE
Fixes an issue of args === undefined and script terminates

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -357,6 +357,10 @@ define([
       'select': 'selecting',
       'unselect': 'unselecting'
     };
+    
+    if (args === undefined) {
+      args = {};
+    }
 
     if (name in preTriggerMap) {
       var preTriggerName = preTriggerMap[name];


### PR DESCRIPTION
I am returning `false` on `select2:opening` and I get this error for `args` being `undefined`. it terminates execution and breaks other things.

in this patch the functionality remains without breaking execution.

I tried being explicit in the code convention but this could also be a small footprint with
A:
```javascript
args || (args = {});
```
B:
```javascript
args === undefined && (args = {});
```