### PR TITLE
Stop bubbling up events when removing a choice

### DIFF
--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -46,6 +46,9 @@ define([
 
         var data = $selection.data('data');
 
+        // Stop bubbling up to selection
+        evt.stopPropagation();
+
         self.trigger('unselect', {
           originalEvent: evt,
           data: data


### PR DESCRIPTION
Fixes #3209 

I've tried also changing the original click event listener to exclude `.select2-selection__choice__remove` child, but I didn't figure how.

Anyway preventing event to bubble up to main container seems to be cleaner solution.

We are using Select2 as a filter in SPA when changing options triggers re-rendering view with filtered items. When options is removed, options container opens up and when view re-renders options container jumps out to upper left corner and detaches itself from main container.

By the way: what about a new release?