### PR TITLE
Add npm dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
       "lib": "dist"
     }
   },
+  "dependencies": {
+    "almond": "0.2.9",
+    "jquery.mousewheel": "3.1.9"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
I had an error doing `require('select2');` with browserify.
Adding these dependencies to package.json resolves it automatically.