### PR TITLE
Fix mousedown event when select2 is created from the context of another document

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -115,13 +115,16 @@ define([
 
   BaseSelection.prototype._attachCloseHandler = function (container) {
     var self = this;
+    var $body = container.$element ?
+      container.$element.closest('body') :
+      $(document.body);
 
-    $(document.body).on('mousedown.select2.' + container.id, function (e) {
+    $body.on('mousedown.select2.' + container.id, function (e) {
       var $target = $(e.target);
 
       var $select = $target.closest('.select2');
 
-      var $all = $('.select2.select2-container--open');
+      var $all = $('.select2.select2-container--open', $body);
 
       $all.each(function () {
         var $this = $(this);
@@ -138,7 +141,10 @@ define([
   };
 
   BaseSelection.prototype._detachCloseHandler = function (container) {
-    $(document.body).off('mousedown.select2.' + container.id);
+    var $body = container.$element ?
+      container.$element.closest('body') :
+      $(document.body);
+    $body.off('mousedown.select2.' + container.id);
   };
 
   BaseSelection.prototype.position = function ($selection, $container) {


### PR DESCRIPTION
I have an unusual scenario where I create an `iframe` (yeah...) and then initialize a select2 dropdown, _in the context of the parent document_. I'm aware there are ways around this, but I'd rather see this fixed here, too.

The select2 code has hardcoded references to `document.body` that break the `mousedown` handler that tries to close the dropdown when the user clicks somewhere else.
- Here's a link to a JS Fiddle that shows the problem: http://jsfiddle.net/rv56Latg/
- This Fiddle runs a version of `select2.js` that has this pull request applied: http://jsfiddle.net/k2x28jvn/

This pull request attempts to fix the issue querying for the correct `body`. However, I had to retain the `document.body` fallback for the tests to run. I suspect that it's an issue with the test environment, but not sure.
