### PR TITLE
Autocomplete should be false to stop the chrome autofill

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -10,7 +10,7 @@ define([
     var $search = $(
       '<span class="select2-search select2-search--dropdown">' +
         '<input class="select2-search__field" type="search" tabindex="-1"' +
-        ' autocomplete="off" autocorrect="off" autocapitalize="off"' +
+        ' autocomplete="false" autocorrect="off" autocapitalize="off"' +
         ' spellcheck="false" role="textbox" />' +
       '</span>'
     );

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -11,7 +11,7 @@ define([
     var $search = $(
       '<li class="select2-search select2-search--inline">' +
         '<input class="select2-search__field" type="search" tabindex="-1"' +
-        ' autocomplete="off" autocorrect="off" autocapitalize="off"' +
+        ' autocomplete="false" autocorrect="off" autocapitalize="off"' +
         ' spellcheck="false" role="textbox" />' +
       '</li>'
     );


### PR DESCRIPTION
I'm using Select-2 for a location auto-complete. Chrome likes to whip out its auto-fill box when I search for London ( part of my address ). The auto-fill box covers the select-2 suggestion list.

I tested my change in accordance with this answer on stack overflow -> http://stackoverflow.com/a/29582380

And it worked for me ( Version 43.0.2357.130 (64-bit) )
