### PR TITLE
clearing a user tag causes wrong selection in single mode

### DIFF
--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -60,6 +60,7 @@ define([
       }
     }
 
+    this.$element.find('option[data-select2-tag]').remove();
     this.$element.val(this.placeholder.id).trigger('change');
 
     this.trigger('toggle', {});


### PR DESCRIPTION
when clearing a user tag,

``` this.$element.val(this.placeholder.id).trigger('change');```
made the <select> selecting null, but then removing the tag option made the select default choose the first option and select2 in wrong state.
```
