### PR TITLE
Add sr-Cyrl language.

### DIFF
--- a/src/js/select2/i18n/hr.js
+++ b/src/js/select2/i18n/hr.js
@@ -15,6 +15,9 @@ define(function () {
   }
 
   return {
+    errorLoading: function () {
+      return 'Preuzimanje nije uspjelo.';
+    },
     inputTooLong: function (args) {
       var overChars = args.input.length - args.maximum;
 

--- a/src/js/select2/i18n/sr-Cyrl.js
+++ b/src/js/select2/i18n/sr-Cyrl.js
@@ -14,6 +14,9 @@ define(function () {
   }
 
   return {
+    errorLoading: function () {
+      return 'Преузимање није успело.';
+    },
     inputTooLong: function (args) {
       var overChars = args.input.length - args.maximum;
 

--- a/src/js/select2/i18n/sr-Cyrl.js
+++ b/src/js/select2/i18n/sr-Cyrl.js
@@ -1,0 +1,52 @@
+define(function () {
+  // Serbian Cyrilic
+  function ending (count, one, some, many) {
+    if (count % 10 == 1 && count % 100 != 11) {
+      return one;
+    }
+
+    if (count % 10 >= 2 && count % 10 <= 4 &&
+      (count % 100 < 12 || count % 100 > 14)) {
+        return some;
+    }
+
+    return many;
+  }
+
+  return {
+    inputTooLong: function (args) {
+      var overChars = args.input.length - args.maximum;
+
+      var message = 'Обришите ' + overChars + ' симбол';
+
+      message += ending(overChars, '', 'а', 'а');
+
+      return message;
+    },
+    inputTooShort: function (args) {
+      var remainingChars = args.minimum - args.input.length;
+
+      var message = 'Укуцајте бар још ' + remainingChars + ' симбол';
+
+      message += ending(remainingChars, '', 'а', 'а');
+
+      return message;
+    },
+    loadingMore: function () {
+      return 'Преузимање још резултата…';
+    },
+    maximumSelected: function (args) {
+      var message = 'Можете изабрати само ' + args.maximum + ' ставк';
+
+      message += ending(args.maximum, 'у', 'е', 'и');
+
+      return message;
+    },
+    noResults: function () {
+      return 'Ништа није пронађено';
+    },
+    searching: function () {
+      return 'Претрага…';
+    }
+  };
+});

--- a/src/js/select2/i18n/sr.js
+++ b/src/js/select2/i18n/sr.js
@@ -14,6 +14,9 @@ define(function () {
   }
 
   return {
+    errorLoading: function () {
+      return 'Preuzimanje nije uspelo.';
+    },
     inputTooLong: function (args) {
       var overChars = args.input.length - args.maximum;
 


### PR DESCRIPTION
As discussed in #3936 

>
>Select2 uses the ISO 639-1 language code to name the language file. In cases where there are variants for a language (pt-PT and pt-BR, for example), we keep the main language file as the dominant language (pt-PT becomes pt) when needed, or separate the two (zh-CN and zh-TW) when there is no dominant language.
>
>In this case, the ISO language code for Serbian is sr. The IANA Language Subtag Registry defines subtags for script variants (Latin is Latn and Cyrillic is Cyrl) which we can use to differentiate between the two. So the existing translation would be sr-Latn and the new translation would be sr-Cyrl. For backwards compatibility, I'd rather keep sr-Latn as sr, just so people don't have to change that on a minor update (even if it might not be the dominant or official script, backwards compatibility is important).