### PR TITLE
Fix bug with creation option item without "value" attribute if data.id is 0 (number)

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -170,7 +170,7 @@ define([
       }
     }
 
-    if (data.id) {
+    if (data.id !== undefined) {
       option.value = data.id;
     }
 


### PR DESCRIPTION
Fix `data.id` condition expression