### PR TITLE
Add missing png in jspm files declaration on 3.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "version": "3.5.4",
   "jspm": {
     "main": "select2",
-    "files": ["select2.js", "select2.png", "select2.css", "select2-spinner.gif"],
+    "files": ["select2.js", "select2.png", "select2x2.png", "select2.css", "select2-spinner.gif"],
     "shim": {
         "select2": {
             "imports": ["jquery", "./select2.css!"],


### PR DESCRIPTION
Fix #4094

This allows jspm to install the select2x2.png along with the other assets.