### PR TITLE
* Bootstrap Modal focus fight fix

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -39,7 +39,7 @@ define([
       self._detachPositioningHandler(container);
     });
 
-    this.$dropdownContainer.on('mousedown', function (evt) {
+    this.$dropdownContainer.on('mousedown focusin', function (evt) {
       evt.stopPropagation();
     });
   };


### PR DESCRIPTION
Fix focus fight between select2 search box and bootstrap modal.

Synopsis: can't focus to search box when select2 inside a boostrap modal dialog.
Demo: https://jsfiddle.net/5px1qg9e/
