### PR TITLE
Remove square brackets when generating id

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -94,7 +94,8 @@ define([
     if ($element.attr('id') != null) {
       id = $element.attr('id');
     } else if ($element.attr('name') != null) {
-      id = $element.attr('name') + '-' + Utils.generateChars(2);
+      id = $element.attr('name').replace(/\[|\]/g, '')
+      id =  id + '-' + Utils.generateChars(2);
     } else {
       id = Utils.generateChars(4);
     }

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -94,7 +94,7 @@ define([
     if ($element.attr('id') != null) {
       id = $element.attr('id');
     } else if ($element.attr('name') != null) {
-      id = $element.attr('name').replace(/\[|\]/g, '')
+      id = $element.attr('name').replace(/\[|\]/g, '');
       id =  id + '-' + Utils.generateChars(2);
     } else {
       id = Utils.generateChars(4);

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -94,12 +94,12 @@ define([
     if ($element.attr('id') != null) {
       id = $element.attr('id');
     } else if ($element.attr('name') != null) {
-      id = $element.attr('name').replace(/\[|\]/g, '');
-      id =  id + '-' + Utils.generateChars(2);
+      id = $element.attr('name') + '-' + Utils.generateChars(2);
     } else {
       id = Utils.generateChars(4);
     }
 
+    id = id.replace(/(:|\.|\[|\]|,)/g, '');
     id = 'select2-' + id;
 
     return id;


### PR DESCRIPTION
This fixes [issue 3618](https://github.com/select2/select2/issues/3618) by removing any square bracket when generating an id using the `name` attribute of the select element. The presence of square brackets, when used for namespacing events, seems to have been wreaking havoc with the regular expressions jQuery uses to match event names. This caused two sorts of errors:
 1.  If the name attribute contained inadvertently contained a malformed regular expression, it would cause errors. [Trying opening and closing the dropdown on thus fiddle to see error](https://jsfiddle.net/ogg1o102/1/)
 2. If the name attribute contained any sort of square bracket, it would cause event handlers to not be removed properly. [See fiddle for a general example](https://jsfiddle.net/vtojt4wo/1/).

While escaping the `name` attribute using the [guidelines here](https://learn.jquery.com/using-jquery-core/faq/how-do-i-select-an-element-by-an-id-that-has-characters-used-in-css-notation/) seems to fix the first case, it doesn't seem to fix the problem of event handlers not getting removed. [See this fiddle as another general example](https://jsfiddle.net/vtojt4wo/4/). For this reason, I've altered `_generateId` to remove any square brackets from the id entirely. 

As this is a small change, but one which fixes bugs in a different place, I wasn't sure where in the test suite, tests should be added. Any guidance on that and I would be happy to add them. 