### PR TITLE
Replaced protocol-relative URLs with HTTPS protocol

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -113,7 +113,7 @@ slug: home
     <p>
       Select2 is hosted on both the
       <a href="https://cdnjs.com/libraries/select2">cdnjs</a> and
-      <a href="http://www.jsdelivr.com/#!select2">jsDelivr</a> CDNs, allowing
+      <a href="https://www.jsdelivr.com/#!select2">jsDelivr</a> CDNs, allowing
       you to quickly include Select2 on your website.
     </p>
 
@@ -125,8 +125,8 @@ slug: home
         </p>
 
 <pre class="code prettyprint">
-&lt;link href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.1/css/select2.min.css" rel="stylesheet" /&gt;
-&lt;script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.1/js/select2.min.js"&gt;&lt;/script&gt;
+&lt;link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.1/css/select2.min.css" rel="stylesheet" /&gt;
+&lt;script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.1/js/select2.min.js"&gt;&lt;/script&gt;
 </pre>
 
         <div class="alert alert-info">


### PR DESCRIPTION
Use of protocol-relative URLs is now seen as an anti-pattern as it leaves the door open to attacks. As the CDNs serve over HTTPS it should be recommended that people use HTTPS rather than protocol-relative URLs. See Paul Irish's post on [Protocol-relative URLs](http://www.paulirish.com/2010/the-protocol-relative-url/) for more details.