### PR TITLE
params.term is initialy undefined when empty on first open.

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -88,7 +88,8 @@ define([
       self._request = $request;
     }
 
-    if (this.ajaxOptions.delay && params.term !== '') {
+    if (this.ajaxOptions.delay && 
+    	params.term !== undefined && params.term !== '') {
       if (this._queryTimeout) {
         window.clearTimeout(this._queryTimeout);
       }


### PR DESCRIPTION
See description in issue #4191.

params.term is undefined when initially opened; so the if statement does not work as expected. 
Left the !== '' in there in case there is another way it's defined but empty. 