### PR TITLE
Redirect the focus of original input to Select2

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2297,9 +2297,10 @@ the specific language governing permissions and limitations under the Apache Lic
             this.search.attr("id", this.focusser.attr('id') + '_search');
 
             this.search.prev()
-                .text($("label[for='" + this.focusser.attr('id') + "']").text())
-                .attr('for', this.search.attr('id'))
-                .on('click.select2', this.bind(function () { this.focus(); }));
+                .text(elementLabel.text())
+                .attr('for', this.search.attr('id'));
+            elementLabel.on('click.select2', this.bind(function () { this.focus(); }))
+            this.opts.element.on('focus.select2', this.bind(function () { this.focus(); }));
 
             this.search.on("keydown", this.bind(function (e) {
                 if (!this.isInterfaceEnabled()) return;

--- a/select2.js
+++ b/select2.js
@@ -2281,7 +2281,7 @@ the specific language governing permissions and limitations under the Apache Lic
             this.focusser.attr("id", "s2id_autogen"+idSuffix);
 
             elementLabel = $("label[for='" + this.opts.element.attr("id") + "']");
-            this.opts.element.on('focus.select2', this.bind(function () { this.focus(); }));
+            elementLabel.on('click.select2', this.bind(function () { this.focus(); }));
 
             this.focusser.prev()
                 .text(elementLabel.text())
@@ -2298,7 +2298,8 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.search.prev()
                 .text($("label[for='" + this.focusser.attr('id') + "']").text())
-                .attr('for', this.search.attr('id'));
+                .attr('for', this.search.attr('id'))
+                .on('click.select2', this.bind(function () { this.focus(); }));
 
             this.search.on("keydown", this.bind(function (e) {
                 if (!this.isInterfaceEnabled()) return;


### PR DESCRIPTION
Redirect the focus of original input to the `focus` event of Select2.
this way, we get back the accessible label for feature of previous Select2 versions.

The focus feature worked well in my previous version (3.4.8) without addition pieces of code
It's clearly a regression.
Le commit introducing the regression is there : https://github.com/select2/select2/commit/db7cd1b373f9a2a743a68ce32cc59dc8fc899eb8, and is due to the `input` becoming hidden instead of out of screen. An hidden input cannot get focus.

This is the second version of #2588
Tested on 3.5 head.