### PR TITLE
Fix delay not being applied to empty search term

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -88,7 +88,7 @@ define([
       self._request = $request;
     }
 
-    if (this.ajaxOptions.delay && params.term !== '') {
+    if (this.ajaxOptions.delay && params.term !== undefined) {
       if (this._queryTimeout) {
         window.clearTimeout(this._queryTimeout);
       }


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix

The following changes were made

There is an issue where if the search term is rapidly removed (By holding down the backspace key for example), an incorrect request will be sent at the end containing the first letter of the search term. This is due to the delay being ignored if an empty input is submitted. The input is originally `undefined` so I have changed it to that, which also fixes this bug.

![Demonstration of bug]
(http://i.imgur.com/MDimCHj.png)
