### PR TITLE
Fixed infinite scrolling issue using down key.

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -97,6 +97,25 @@ define([
     return sorter(data);
   };
 
+  Results.prototype.focusFirstItem = function () {
+
+    var $options = this.$results
+      .find('.select2-results__option[aria-selected]');
+
+    var $selected = $options.filter('[aria-selected=true]');
+
+    // Check if there are any selected options
+    if ($selected.length > 0) {
+      // If there are selected options, highlight the first
+      $selected.first().trigger('mouseenter');
+    } else {
+      // If there are no selected options, highlight the first option
+      // in the dropdown
+      $options.first().trigger('mouseenter');
+    }
+
+  };
+
   Results.prototype.setClasses = function () {
     var self = this;
 
@@ -124,17 +143,6 @@ define([
         }
       });
 
-      var $selected = $options.filter('[aria-selected=true]');
-
-      // Check if there are any selected options
-      if ($selected.length > 0) {
-        // If there are selected options, highlight the first
-        $selected.first().trigger('mouseenter');
-      } else {
-        // If there are no selected options, highlight the first option
-        // in the dropdown
-        $options.first().trigger('mouseenter');
-      }
     });
   };
 
@@ -245,6 +253,7 @@ define([
 
       if (container.isOpen()) {
         self.setClasses();
+        self.focusFirstItem();
       }
     });
 
@@ -267,6 +276,7 @@ define([
       }
 
       self.setClasses();
+      self.focusFirstItem();
     });
 
     container.on('unselect', function () {
@@ -275,6 +285,7 @@ define([
       }
 
       self.setClasses();
+      self.focusFirstItem();
     });
 
     container.on('open', function () {


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- setClasses has been split into two functions - focusFirstItem and setClasses itself;
- calls to focusFirstItem have been added after all but one calls to setClasses (not added in "results:append" event handler) - I just don't feel I've explored this code well enough so I preserved previous behavior as much as I could.

This is related to issue https://github.com/select2/select2/issues/3479.