### PR TITLE
Fixed preventing override scrolling event while using Select2 with ajax request

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -98,7 +98,7 @@ define([
 
     $watchers.on(scrollEvent, function (ev) {
       var position = $(this).data('select2-scroll-position');
-      $(this).scrollTop(position.y);
+      $(self).scrollTop(position.y);
     });
 
     $(window).on(scrollEvent + ' ' + resizeEvent + ' ' + orientationEvent,


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix

Problem story
  I'm using **ajax Select2** with Bootstrap3 Modal with scrolling modal. so when select2's dropdown opened, Bootstrap modal can't scroll.

The following changes were made
- change this to self 
-
-

If this is related to an existing ticket, include a link to it as well.

PS. this commit from @mahadoang's idea, all credit to him