### PR TITLE
fix scrolling to the highlighted results on first open

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -245,6 +245,7 @@ define([
 
       if (container.isOpen()) {
         self.setClasses();
+        self.ensureHighlightVisible();
       }
     });
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- added a call to ensureHighlightVisible() after the hightlight classes have been set

#3956 and #4204