### PR TITLE
Added missing Norwegian bokmaal label used for errors

### DIFF
--- a/src/js/select2/i18n/nb.js
+++ b/src/js/select2/i18n/nb.js
@@ -1,6 +1,9 @@
 define(function () {
   // Norwegian (Bokmål)
   return {
+    errorLoading: function () {
+      return 'Kunne ikke hente resultater.';
+    },
     inputTooLong: function (args) {
       var overChars = args.input.length - args.maximum;
 


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [x] Translation

The following changes were made

- Added a 'nb' translation for the 'errorLoading' text label 

If this is related to an existing ticket, include a link to it as well.

