### PR TITLE
Added the document.ready call to the multiple example section. Necess…

### DIFF
--- a/docs/_includes/examples/basics.html
+++ b/docs/_includes/examples/basics.html
@@ -50,7 +50,9 @@ $(document).ready(function() {
 
 {% highlight html linenos %}
 <script type="text/javascript">
-$(".js-example-basic-multiple").select2();
+$(document).ready(function() {
+  $(".js-example-basic-multiple").select2();
+});
 </script>
 
 <select class="js-example-basic-multiple" multiple="multiple">


### PR DESCRIPTION
This pull request includes a BUG FIX on:
https://select2.github.io/examples.html

The following changes were made:

I noticed on the examples page that the the basic example includes the document.ready() function necessary to make it work. However, on the "multiple" example, it does not. When I first came to select2 to use the tool, I was not very familiar with Javascript and it took me way too long to realize that was the one line I was missing. I made the changes and submitted a pull request because I think it is necessary to help users who may not be as familiar with JavaScript. 

Before: 

<script type="text/javascript">
$(".js-example-basic-multiple").select2();
</script>


After:

<script type="text/javascript">
$(document).ready(function() {
$(".js-example-basic-multiple").select2();
});
</script>


This was not related to a specific ticket. It is something I personally noticed and wanting to change.
