### PR TITLE
fix for formatResults not appending to container

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -1123,8 +1123,8 @@ the specific language governing permissions and limitations under the Apache Lic
                             formatted=opts.formatResult(result, label, query, self.opts.escapeMarkup);
                             if (formatted!==undefined) {
                                 label.html(formatted);
-                                node.append(label);
                             }
+                            node.append(label);
 
 
                             if (compound) {


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix

The following changes were made

- move node.append(label) outside of the formattedResult undefined evaluation

If this is related to an existing ticket, include a link to it as well.

Proposed fix for issue where results generated in user-defined formatResult function are not appearing in the select2 results.

Scenario: formatResult is being used with container parameter. A result is appended to the container but does not appear in the results.
Solution: node.append needs to be called regardless of formatResult return value