### PR TITLE
Allow the use of arrow keys when select2 is closed

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -329,7 +329,9 @@ define([
           evt.preventDefault();
         } else if (key === KEYS.DOWN || key === KEYS.UP) {
             var options = this.$element.find('option:selected');
-            options = key === KEYS.DOWN ? options.prevAll(":enabled") : options.prevAll(":enabled");
+            options = key === KEYS.DOWN ? 
+                options.nextAll(':enabled') :
+                options.prevAll(':enabled');
 
             var val = options.first.val();
             if (undefined !== val) {

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -327,6 +327,16 @@ define([
           self.open();
 
           evt.preventDefault();
+        } else if (key === KEYS.DOWN || key === KEYS.UP) {
+            var options = this.$element.find('option:selected');
+            options = key === KEYS.DOWN ? options.prevAll(":enabled") : options.prevAll(":enabled");
+
+            var val = options.first.val();
+            if (undefined !== val) {
+                this.$element.val(val);
+                this.$element.trigger('change');
+            }
+            evt.preventDefault();
         }
       }
     });

--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -87,6 +87,7 @@ define([
 
     $rendered.empty().append(formatted);
     $rendered.prop('title', selection.title || selection.text);
+    $rendered.attr('aria-live', 'assertive');
   };
 
   return SingleSelection;


### PR DESCRIPTION
This pull request includes a
- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made
- Allow the use of arrow keys when select2 is closed
- Set a 'aria-live' attribute so that SR read the new item

This is related to #3472 and #4068.

This commit add the possibilities to cycle through the
possible options even when select2 is closed.

I also added a 'aria-live' attribute on change so that
a screen reader will read the newly selected item upon
change.
