### PR TITLE
Removing the double event binding registration of "selection:update" …

### DIFF
--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -53,10 +53,6 @@ define([
     this.$selection.on('blur', function (evt) {
       // User exits the container
     });
-
-    container.on('selection:update', function (params) {
-      self.update(params.data);
-    });
   };
 
   SingleSelection.prototype.clear = function () {


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Removing the double registration of the listener binding on "selection:update" within SingleSelection.prototype.bind, as it already exists in BaseSelection.prototype.

If this is related to an existing ticket, include a link to it as well.
https://github.com/select2/select2/issues/3616
