### PR TITLE
Ability to hide currently selected value in dropdown as default option

### DIFF
--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -375,7 +375,8 @@ define([
         return selection.text;
       },
       theme: 'default',
-      width: 'resolve'
+      width: 'resolve',
+      hideOptionsWhenSelected: false
     };
   };
 

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -237,6 +237,13 @@ define([
 
     var id = container.id + '-results';
 
+    var getOptions = function() {
+      if (self.options.get('hideOptionsWhenSelected')) {
+        return self.$results.find('[aria-selected=false]');
+      }
+      return self.$results.find('[aria-selected]');
+    };
+
     this.$results.attr('id', id);
 
     container.on('results:all', function (params) {
@@ -245,6 +252,10 @@ define([
 
       if (container.isOpen()) {
         self.setClasses();
+      }
+
+      if (self.options.get('hideOptionsWhenSelected')) {
+        self.hideOptionsWhenSelected(); 
       }
     });
 
@@ -324,7 +335,7 @@ define([
     container.on('results:previous', function () {
       var $highlighted = self.getHighlightedResults();
 
-      var $options = self.$results.find('[aria-selected]');
+      var $options = getOptions();
 
       var currentIndex = $options.index($highlighted);
 
@@ -358,7 +369,7 @@ define([
     container.on('results:next', function () {
       var $highlighted = self.getHighlightedResults();
 
-      var $options = self.$results.find('[aria-selected]');
+      var $options = getOptions();
 
       var currentIndex = $options.index($highlighted);
 
@@ -506,6 +517,10 @@ define([
     } else {
       $(container).append(content);
     }
+  };
+
+  Results.prototype.hideOptionsWhenSelected = function() {
+    this.$results.find('[aria-selected=true]').css({'display': 'none'});
   };
 
   return Results;


### PR DESCRIPTION
This pull request includes a
- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made
- Adds a default option to be able to hide those elements that have been selected
- Prevents navigation by getting proper options, those with `[aria-selected=false]` when `hideOptionsWhenSelected: true` or  `[aria-selected]` for the default option `hideOptionsWhenSelected: false`

This issue was discussed in several issues, main issue listed below: 
- https://github.com/select2/select2/issues/1538

I hope it helps.
