### PR TITLE
Uses tabs for creating tags as a default feature

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -299,16 +299,15 @@ define([
       var key = evt.which;
 
       if (self.isOpen()) {
-        if (key === KEYS.ESC || key === KEYS.TAB ||
-            (key === KEYS.UP && evt.altKey)) {
+        if (key === KEYS.ESC || (key === KEYS.UP && evt.altKey)) {
           self.close();
 
           evt.preventDefault();
-        } else if (key === KEYS.ENTER) {
+        } else if (key === KEYS.ENTER || key === KEYS.TAB) {
           self.trigger('results:select', {});
 
           evt.preventDefault();
-        } else if ((key === KEYS.SPACE && evt.ctrlKey)) {
+        } else if (key === KEYS.SPACE && evt.ctrlKey) {
           self.trigger('results:toggle', {});
 
           evt.preventDefault();


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Allows the use of tabs to create tags by triggering the proper events, `results:select`

If this is related to an existing ticket, include a link to it as well.

https://github.com/select2/select2/issues/3359#issuecomment-214272255

I believe previous versions of Select2 added it as a default feature without the need of setting it via options. 

I run the tests and everything seems to be fine.

I hope it helps.