### PR TITLE
Fix for closing dropdown by clicking outside of it when $.select2 non-existent

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -132,7 +132,7 @@ define([
 
         var $element = $this.data('element');
 
-        $element.select2('close');
+        self.trigger('close');
       });
     });
   };


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Fixed the code that closes the dropdown, so that it works when Select2 is included as a module rather than attached to $.func

If this is related to an existing ticket, include a link to it as well.

Closes #4327
