### PR TITLE
reference the optgroup in the option's data-object

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -197,7 +197,7 @@ define([
     return $option;
   };
 
-  SelectAdapter.prototype.item = function ($option) {
+  SelectAdapter.prototype.item = function ($option, $optgroup) {
     var data = {};
 
     data = $.data($option[0], 'data');
@@ -214,6 +214,9 @@ define([
         selected: $option.prop('selected'),
         title: $option.prop('title')
       };
+      if ($optgroup && $optgroup.is('optgroup')) {
+        data.optgroup = $optgroup;
+      }
     } else if ($option.is('optgroup')) {
       data = {
         text: $option.prop('label'),
@@ -226,8 +229,7 @@ define([
 
       for (var c = 0; c < $children.length; c++) {
         var $child = $($children[c]);
-
-        var child = this.item($child);
+        var child = this.item($child, $option);
 
         children.push(child);
       }

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -97,6 +97,10 @@ define([
 
       $selection.data('data', selection);
 
+      if (selection.optgroup) {
+        $selection.data('optgroup-label', selection.optgroup.label);
+      }
+
       $selections.push($selection);
     }
 

--- a/tests/data/select-tests.js
+++ b/tests/data/select-tests.js
@@ -386,6 +386,19 @@ test('optgroup tags are marked with children', function (assert) {
   });
 });
 
+test('optgroup backreference in children', function (assert) {
+  var $select = $('#qunit-fixture .groups');
+
+  var data = new SelectData($select, selectOptions);
+
+  data.query({}, function (data) {
+    assert.ok(
+      'optgroup' in data.results[0].children[0],
+      'The option in a optgroup element should have a reference to its parent'
+    );
+  });
+});
+
 test('empty optgroups are still shown when queried', function (assert) {
   var $select = $('#qunit-fixture .groups');
 


### PR DESCRIPTION
To prevent parent()-lookups on the element, reference the optgroup directly in the option’s data-object when iterating the select elements children.

This pull request includes a

- [ x ] New feature

The following changes were made

- the item function now registers the `optgroup` as an attribute of the option, which  
- the label is added as a data-attribute to the listed option (maybe an unwanted extra?)
- test is added.