### PR TITLE
[BUGFIX] scrolling to the selected item in bottom of the long-size list on first open

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -245,6 +245,7 @@ define([
 
       if (container.isOpen()) {
         self.setClasses();
+        self.ensureHighlightVisible();
       }
     });
 
@@ -283,7 +284,6 @@ define([
       self.$results.attr('aria-hidden', 'false');
 
       self.setClasses();
-      self.ensureHighlightVisible();
     });
 
     container.on('close', function () {


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- scrolling to the selected item in bottom of the long-size list on first open

If this is related to an existing ticket, include a link to it as well.
#4254 #4204 #3956 

i can't scroll to the item in bottom of the list in 4.0.3
i fixed this bug related in #3956 (@zellerda comments)
i think it is correct. please comments. thank you