### PR TITLE
Fixes #4353. Does not jump the view to recently destroyed dropdown co…

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -81,8 +81,6 @@ define([
       self.$selection.removeAttr('aria-activedescendant');
       self.$selection.removeAttr('aria-owns');
 
-      self.$selection.focus();
-
       self._detachCloseHandler(container);
     });
 


### PR DESCRIPTION
This pull request includes a
- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Remove function call to focus view on destroyed dropdown upon clicking in another part of the screen.

Existing ticket #4353 
