### PR TITLE
perform deep merge for Defaults.set()

### DIFF
--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -387,7 +387,7 @@ define([
 
     var convertedData = Utils._convertData(data);
 
-    $.extend(this.defaults, convertedData);
+    $.extend(true, this.defaults, convertedData);
   };
 
   var defaults = new Defaults();

--- a/tests/options/ajax-tests.js
+++ b/tests/options/ajax-tests.js
@@ -34,7 +34,7 @@ test('options are merged recursively with default options', function (assert) {
 test('more than one default option can be changed via set()', function(assert) {
   var defaults = require('select2/defaults');
   var ajaxDelay = 123;
-  var dataDataType = 'xml'
+  var dataDataType = 'xml';
   defaults.set('ajax--delay', ajaxDelay);
   defaults.set('ajax--data-type', dataDataType);
 

--- a/tests/options/ajax-tests.js
+++ b/tests/options/ajax-tests.js
@@ -36,11 +36,11 @@ test('more than one default option can be changed via set()', function(assert) {
   var ajaxDelay = 123;
   var dataDataType = 'xml'
   defaults.set('ajax--delay', ajaxDelay);
-  defaults.set('ajax--dataType', dataDataType);
+  defaults.set('ajax--data-type', dataDataType);
 
   assert.equal(
       defaults.defaults.ajax.delay,
-      ajaxDelay
+      ajaxDelay,
       'Both ajax.delay and ajax.dataType present in defaults');
   assert.equal(
     defaults.defaults.ajax.dataType,

--- a/tests/options/ajax-tests.js
+++ b/tests/options/ajax-tests.js
@@ -30,3 +30,21 @@ test('options are merged recursively with default options', function (assert) {
 
   defaults.reset();
 });
+
+test('more than one default option can be changed via set()', function(assert) {
+  var defaults = require('select2/defaults');
+  var ajaxDelay = 123;
+  var dataDataType = 'xml'
+  defaults.set('ajax--delay', ajaxDelay);
+  defaults.set('ajax--dataType', dataDataType);
+
+  assert.equal(
+      defaults.defaults.ajax.delay,
+      ajaxDelay
+      'Both ajax.delay and ajax.dataType present in defaults');
+  assert.equal(
+    defaults.defaults.ajax.dataType,
+    dataDataType,
+    'Both ajax.delay and ajax.dataType present in defaults');
+  defaults.reset();
+});


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Changed Defaults.set() behavior to perform a "deep" merge,  so that it is possible, for example, to change multiple ajax defaults (e.g. "ajax.dataType"  and "ajax.delay")  without one call overwriting the other.
- Added test to assert new behavior
