### PR TITLE
Correct typo in "options" page

### DIFF
--- a/docs/_includes/options/data/array.html
+++ b/docs/_includes/options/data/array.html
@@ -38,7 +38,7 @@ $('select').select2({
   </h3>
 
   <p>
-    Because the <code>value</code> attributes on a <code>&gt;select&lt;</code>
+    Because the <code>value</code> attributes on a <code>&lt;select&gt;</code>
     tag must be strings, the <code>id</code> property on the data objects must
     also be strings. Select2 will attempt to convert anything that is not a
     string to a string, which will work for most situations, but it is


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Corrected a typo in the "options" page, "Data Adapters" section, "Do the id properties have to be strings?" part.

If this is related to an existing ticket, include a link to it as well.

Correct a typo in the "options" page, "Data Adapters" section, "Do the id properties have to be strings?" part.
"&gt;select&lt;" to "&lt;select&gt;"