### PR TITLE
Tabbing order after selecting single value

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -60,6 +60,7 @@ define([
       self.$search.attr('tabindex', -1);
 
       self.$search.val('');
+      this.$selection.focus();
     });
 
     container.on('focus', function () {


### PR DESCRIPTION
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Before dropdown removed from DOM focus redirected to $selection element

If this is related to an existing ticket, include a link to it as well.
https://github.com/select2/select2/issues/4384
