### PR TITLE
Doubled tags problem

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -436,15 +436,7 @@ define([
       var data = $this.data('data');
 
       if ($this.attr('aria-selected') === 'true') {
-        if (self.options.get('multiple')) {
-          self.trigger('unselect', {
-            originalEvent: evt,
-            data: data
-          });
-        } else {
-          self.trigger('close', {});
-        }
-
+        self.trigger('close', {});
         return;
       }
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix: https://github.com/select2/select2/issues/3975
- [ ] New feature
- [ ] Translation

With multiple tags option enabled:
- press enter when adding again an exiting tag will do nothing
- click on an exiting tag will remove the tag

This pull-request fix the behavior when clicking on a existing tag by doing nothing like pressing enter.