### PR TITLE
fix allowClear feature when placeholder is missing

### DIFF
--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -60,7 +60,7 @@ define([
       }
     }
 
-    this.$element.val(this.placeholder.id).trigger('change');
+    this.$element.val(this.placeholder ? this.placeholder.id : '').trigger('change');
 
     this.trigger('toggle', {});
   };


### PR DESCRIPTION
This pull request includes a bug fix.

The following changes were made:
- fix 'allowClear' feature when placeholder is missing - before fix "Uncaught TypeError: Cannot read property 'id' of undefined" occured
