### PR TITLE
Fixes #4419 - Switch to next form element does not work, because form focus is lost

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -63,7 +63,7 @@ define([
     });
 
     container.on('focus', function () {
-      if (container.isOpen()) {
+      if (!container.isOpen()) {
         self.$search.focus();
       }
     });


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Negated condition for focusing while select2 container is open

If this is related to an existing ticket, include a link to it as well.
 #4419
