### PR TITLE
Fix dropdown width

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -198,9 +198,10 @@ define([
   };
 
   AttachBody.prototype._resizeDropdown = function () {
-    var css = {
-      width: this.$container.outerWidth(false) + 'px'
-    };
+    var rect = this.$container.get(0).getBoundingClientRect(),
+      css = {
+        width: (rect.width ? rect.width : (rect.right - rect.left)) + 'px'
+      };
 
     if (this.options.get('dropdownAutoWidth')) {
       css.minWidth = css.width;


### PR DESCRIPTION
This pull request includes a bug fix for dropdown width #3481. $.outerWidth returns rounded pixel values so dropdown has got different width than select element.
The following changes were made
- use getBoundingClientRect() for calculate width of the dropdown.
