### PR TITLE
fix for bug #3512, ajax call with delay and quick search string removing

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -248,6 +248,10 @@ define([
     this.$results.attr('id', id);
 
     container.on('results:all', function (params) {
+      if (params.query && self.lastParams &&
+          params.query.term !== self.lastParams.term) {
+        return;
+      }
       self.clear();
       self.append(params.data);
 
@@ -266,6 +270,7 @@ define([
     });
 
     container.on('query', function (params) {
+      self.lastParams = params;
       self.hideMessages();
       self.showLoading(params);
     });


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made to fix bug #3512: 
Hitting backspace on select element showing the previous search results in case when delay in ajax call specified. Similar bug could be caught if we use ajax data adapter with minimum input length, if we type search string and remove it quickly we could see search results even if search string is less than minimum input length.

I've added checking if process results is run with the same term for which search with ajax call was called.

https://github.com/select2/select2/issues/3512
