### PR TITLE
New feature : New events can be added to EventRelay via the new optio…

### DIFF
--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -365,6 +365,7 @@ define([
       maximumSelectionLength: 0,
       minimumResultsForSearch: 0,
       selectOnClose: false,
+      relayablePluginsEvents: [],
       sorter: function (data) {
         return data;
       },

--- a/src/js/select2/selection/eventRelay.js
+++ b/src/js/select2/selection/eventRelay.js
@@ -10,7 +10,7 @@ define([
       'close', 'closing',
       'select', 'selecting',
       'unselect', 'unselecting'
-    ];
+    ].concat(this.options.get('relayablePluginsEvents'));
 
     var preventableEvents = ['opening', 'closing', 'selecting', 'unselecting'];
 


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- new Options: _relayablePluginsEvents_ [String]
- EventRelay : relayEvents is now extendable with _relayablePluginsEvents_ [String] 

### Why ?
  It give the possibility to add relayable custom plugins events without manually overriding EventRelay.

### Related to
 #4446

###  Example
 Example of usage with a plugin that trigger an event when the result search didn't found anything.
```javascript
// Can be improved by adding a method 'add' to Defaults.prototype.
$.fn.select2.defaults.set('relayablePluginsEvents', $.fn.select2.defaults.defaults.relayablePluginsEvents.concat('plugin:noresult'));
```

```javascript
$.fn.select2.amd.require([
    'select2/results',
  ], function(Results) {
    Results.prototype._bind = Results.prototype.bind;
    Results.prototype.bind = function(container, $container) {
      var self = this;
      this._bind.apply(this, arguments);
      // After results:select
      container.listeners['results:select'][1] = function(e) {
        var $highlighted = self.getHighlightedResults();

        if ($highlighted.length === 0) {
          self.trigger('plugin:noresult', {
            originalEvent: e,
            data: {}
          });
        }
      };
    };
  });
```
```javascript
 var select2 = $(".js-example-basic-single").select2();
 select2.on('select2:plugin:noresult', function() {
  console.log('no result found');
 });
```




