### PR TITLE
Better detection of aborted ajax queries

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -82,7 +82,7 @@ define([
       }, function () {
         // Attempt to detect if a request was aborted
         // Only works if the transport exposes a status property
-        if ($request.status && $request.status === '0') {
+        if ($request.status === 0 || $request.status === '0') {
           return;
         }
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made:

On Chrome 50, `$request.status` is a number, not a string thus the aborted query detection failed. For the end-user this resulted in seeing the 'The results could not be loaded.' message when he typed too fast for too long, instead of the correct 'Searching…' message.

This commit check `$request.status` both as a number and as a string, keeping backward compatibility while fixing the case for Chrome.