### PR TITLE
Fixes #3296 and fixes #4224 improving dropdown width calculation

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -129,7 +129,8 @@ define([
     }
 
     if (method == 'element') {
-      var elementWidth = $element.outerWidth(false);
+      var elementWidth = $element[0].getBoundingClientRect().width || 
+                         $element.outerWidth(false);
 
       if (elementWidth <= 0) {
         return 'auto';

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -198,8 +198,11 @@ define([
   };
 
   AttachBody.prototype._resizeDropdown = function () {
+    var containerWidth = this.$container[0].getBoundingClientRect().width ||
+                         this.$container.outerWidth(false);
+                         
     var css = {
-      width: this.$container.outerWidth(false) + 'px'
+      width: containerWidth + 'px'
     };
 
     if (this.options.get('dropdownAutoWidth')) {


### PR DESCRIPTION
This pull request includes a
- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Use getBoundingClientRect when available to calculate element widths

Fixes #3296 and it's duplicates (#4224)
