### PR TITLE
Fixing behavior in mobile touchscreen browsers

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -194,7 +194,7 @@ define([
         .addClass('select2-container--' + newDirection);
     }
 
-    this.$dropdownContainer.css(css);
+    this.$dropdownContainer.offset(css);
   };
 
   AttachBody.prototype._resizeDropdown = function () {


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

Dropdown element position jumps while scaling the page.
Thus you need to use _offset_ function to set position instead of direct _css_.
