### PR TITLE
Stop keyup event if keydown was handled

### DIFF
--- a/dist/js/select2.full.js
+++ b/dist/js/select2.full.js
@@ -1968,6 +1968,12 @@ S2.define('select2/selection/search',[
           return;
         }
 
+        // if the event was processed as 'keypress' (see 'keydown' handler) prevent it from leaving 
+		if (self._keyUpPrevented) {
+		  evt.stopPropagation();
+		  return;
+		}
+
         self.handleSearch(evt);
       }
     );
@@ -5378,7 +5384,17 @@ S2.define('select2/core',[
           evt.preventDefault();
         }
       }
+
+      self._keyUpPrevented = evt.isDefaultPrevented();
     });
+
+    this.on('keypress', function (evt) {
+      if (self._keyUpPrevented) {
+        evt.stopPropagation();
+        self._keyUpPrevented = false;
+      }
+    });
+
   };
 
   Select2.prototype._syncAttributes = function () {

--- a/dist/js/select2.full.js
+++ b/dist/js/select2.full.js
@@ -1944,6 +1944,16 @@ S2.define('select2/selection/search',[
       }
     );
 
+    this.$selection.on('keyup', 
+      function (evt) {
+        // if event was produced by handled 'keypress' prevent it from bubbling
+		if (self._keyUpPrevented) {
+		  evt.stopPropagation();
+		  return;
+		}
+      }
+    );
+
     this.$selection.on(
       'keyup.search input.search',
       '.select2-search--inline',
@@ -1968,7 +1978,7 @@ S2.define('select2/selection/search',[
           return;
         }
 
-        // if the event was processed as 'keypress' (see 'keydown' handler) prevent it from leaving 
+        // if event was produced by handled 'keypress' prevent it from bubbling
 		if (self._keyUpPrevented) {
 		  evt.stopPropagation();
 		  return;
@@ -5388,7 +5398,8 @@ S2.define('select2/core',[
       self._keyUpPrevented = evt.isDefaultPrevented();
     });
 
-    this.on('keypress', function (evt) {
+    this.on('keyup', function (evt) {
+      // if event was produced by handled 'keypress' prevent it from bubbling
       if (self._keyUpPrevented) {
         evt.stopPropagation();
         self._keyUpPrevented = false;

--- a/dist/js/select2.js
+++ b/dist/js/select2.js
@@ -1968,6 +1968,12 @@ S2.define('select2/selection/search',[
           return;
         }
 
+        // if the event was processed as 'keypress' (see 'keydown' handler) prevent it from leaving 
+		if (self._keyUpPrevented) {
+		  evt.stopPropagation();
+		  return;
+		}
+
         self.handleSearch(evt);
       }
     );
@@ -5378,7 +5384,17 @@ S2.define('select2/core',[
           evt.preventDefault();
         }
       }
+
+      self._keyUpPrevented = evt.isDefaultPrevented();
     });
+
+    this.on('keypress', function (evt) {
+      if (self._keyUpPrevented) {
+        evt.stopPropagation();
+        self._keyUpPrevented = false;
+      }
+    });
+
   };
 
   Select2.prototype._syncAttributes = function () {

--- a/dist/js/select2.js
+++ b/dist/js/select2.js
@@ -1944,6 +1944,16 @@ S2.define('select2/selection/search',[
       }
     );
 
+    this.$selection.on('keyup', 
+      function (evt) {
+        // if event was produced by handled 'keypress' prevent it from bubbling
+		if (self._keyUpPrevented) {
+		  evt.stopPropagation();
+		  return;
+		}
+      }
+    );
+
     this.$selection.on(
       'keyup.search input.search',
       '.select2-search--inline',
@@ -1968,7 +1978,7 @@ S2.define('select2/selection/search',[
           return;
         }
 
-        // if the event was processed as 'keypress' (see 'keydown' handler) prevent it from leaving 
+        // if event was produced by handled 'keypress' prevent it from bubbling
 		if (self._keyUpPrevented) {
 		  evt.stopPropagation();
 		  return;
@@ -5388,7 +5398,8 @@ S2.define('select2/core',[
       self._keyUpPrevented = evt.isDefaultPrevented();
     });
 
-    this.on('keypress', function (evt) {
+    this.on('keyup', function (evt) {
+      // if event was produced by handled 'keypress' prevent it from bubbling
       if (self._keyUpPrevented) {
         evt.stopPropagation();
         self._keyUpPrevented = false;

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -350,7 +350,18 @@ define([
           evt.preventDefault();
         }
       }
+
+      self._keyUpPrevented = evt.isDefaultPrevented();
     });
+
+    this.on('keyup', function (evt) {
+      // if event was produced by handled 'keypress' prevent it from bubbling
+      if (self._keyUpPrevented) {
+        evt.stopPropagation();
+        self._keyUpPrevented = false;
+      }
+    });
+
   };
 
   Select2.prototype._syncAttributes = function () {

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -118,6 +118,16 @@ define([
       }
     );
 
+    this.$selection.on('keyup', 
+      function (evt) {
+        // if event was produced by handled 'keypress' prevent it from bubbling
+		if (self._keyUpPrevented) {
+		  evt.stopPropagation();
+		  return;
+		}
+      }
+    );
+
     this.$selection.on(
       'keyup.search input.search',
       '.select2-search--inline',
@@ -141,6 +151,12 @@ define([
         if (key == KEYS.TAB) {
           return;
         }
+
+        // if event was produced by handled 'keypress' prevent it from bubbling
+		if (self._keyUpPrevented) {
+		  evt.stopPropagation();
+		  return;
+		}
 
         self.handleSearch(evt);
       }


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made:
- core.js: Select2: added 'keyup' handler to call `stopPropagation` if event was processed before in keypressed handler (uses `_keyUpPrevented` flag)
- selection.js: Search: added similar 'keyup' handler and the same logic added into existing handler 'keyup.search input.search'

Fixes #4495 Stop keyup event if keydown was handled

NOTE: 
why two handlers in Search are needed? I noticed that stopPropagation in 'keyup.search input.search' handler is not always enough. And also leaving only one for 'keyup' (a new one) is also not enough as `handleSearch` reset `keyUpPrevented` field.
