### PR TITLE
Add DOM placement 'insertBefore' option

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -106,8 +106,11 @@ define([
   };
 
   Select2.prototype._placeContainer = function ($container) {
-    if (this.options.get('insertBefore')) $container.insertBefore(this.$element);
-    else $container.insertAfter(this.$element);
+    if (this.options.get('insertBefore')) {
+      $container.insertBefore(this.$element);
+    } else {
+      $container.insertAfter(this.$element);
+    }
 
     var width = this._resolveWidth(this.$element, this.options.get('width'));
 

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -106,7 +106,8 @@ define([
   };
 
   Select2.prototype._placeContainer = function ($container) {
-    $container.insertAfter(this.$element);
+    if (this.options.get('insertBefore')) $container.insertBefore(this.$element);
+    else $container.insertAfter(this.$element);
 
     var width = this._resolveWidth(this.$element, this.options.get('width'));
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [x] New feature
- [ ] Translation

Add 'insertBefore' option to change DOM placement of Select2 generated items.

This is useful because various form validation libraries (including jqQuery Validation) put their validation messages immediately after the original form element. This means that such messages end up appearing before the visible form element instead of after it, once Select2 has been applied. (This is because the DOM order once Select2 has been applied is: the orginal input element (hidden by Select2), then any form validation messages, then the inserted Select2 elements.) Inserting the Select2 generated DOM items before the original element fixes this.

This pull request suggests implementing this as a new Select2 option called 'insertBefore', which if omitted defaults to the previous behaviour. E.g. $('#id').select2({ ... , insertBefore: true };

Addresses https://github.com/select2/select2/issues/4445