### PR TITLE
Resolved issue #4511 to reposition open dropdown when a selection is made

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -32,6 +32,15 @@ define([
           self._resizeDropdown();
         });
       }
+
+	  function repositionOnSelectionChange() {
+	    if (!this.options.get('closeOnSelect')) {
+		  self._positionDropdown();
+	    }
+	  };
+	  container.on("select", repositionOnSelectionChange);
+	  container.on("unselect", repositionOnSelectionChange);
+
     });
 
     container.on('close', function () {

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -37,9 +37,9 @@ define([
 	    if (!this.options.get('closeOnSelect')) {
 		  self._positionDropdown();
 	    }
-	  };
-	  container.on("select", repositionOnSelectionChange);
-	  container.on("unselect", repositionOnSelectionChange);
+	  }
+	  container.on('select', repositionOnSelectionChange);
+	  container.on('unselect', repositionOnSelectionChange);
 
     });
 


### PR DESCRIPTION
This pull request includes a
- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made:
- In AttachBody bind method, added handler to watch select and unselect events from container.  This allows the dropdown to reposition if the underlying selection object changes positions because it wraps onto another line, or if options are unselected, makes sure it snaps back up below selection object (so it doesn't float).

If this is related to an existing ticket, include a link to it as well.
#4511
