### PR TITLE
Fix for #4604 to support selecting an item with id=0 values (as number)

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -170,7 +170,7 @@ define([
       }
     }
 
-    if (data.id != null) {
+    if (data.id !== undefined) {
       option.value = data.id;
     }
 

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -170,7 +170,7 @@ define([
       }
     }
 
-    if (data.id) {
+    if (data.id != null) {
       option.value = data.id;
     }
 

--- a/tests/data/select-tests.js
+++ b/tests/data/select-tests.js
@@ -472,14 +472,15 @@ test('select option construction accepts id=0 (zero) value', function (assert) {
   // If was "Zero Value"", then it ignored id property
   assert.equal(
     optionElem[0].value,
-    "0",
+    '0',
     'Built option value should be "0" (zero as a string).'
   );
 });
 
 
 
-test('select option construction accepts id="" (empty string) value', function (assert) {
+test('select option construction accepts id="" (empty string) value',
+  function (assert) {
   var $select = $('#qunit-fixture .single');
 
   var selectOptions = [{ id: '', text: 'Empty String'}];
@@ -489,7 +490,7 @@ test('select option construction accepts id="" (empty string) value', function (
   
   assert.equal(
     optionElem[0].value,
-    "",
+    '',
     'Built option value should be an empty string.'
   );
 });

--- a/tests/data/select-tests.js
+++ b/tests/data/select-tests.js
@@ -455,3 +455,41 @@ test('data objects use the text of the option', function (assert) {
   assert.equal(item.id, '&');
   assert.equal(item.text, '&');
 });
+
+
+
+
+
+
+test('select option construction accepts id=0 (zero) value', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var selectOptions = [{ id: 0, text: 'Zero Value'}];
+  var data = new SelectData($select, selectOptions);
+
+  var optionElem = data.option(selectOptions[0]);
+  
+  // If was "Zero Value"", then it ignored id property
+  assert.equal(
+    optionElem[0].value,
+    "0",
+    'Built option value should be "0" (zero as a string).'
+  );
+});
+
+
+
+test('select option construction accepts id="" (empty string) value', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var selectOptions = [{ id: '', text: 'Empty String'}];
+  var data = new SelectData($select, selectOptions);
+
+  var optionElem = data.option(selectOptions[0]);
+  
+  assert.equal(
+    optionElem[0].value,
+    "",
+    'Built option value should be an empty string.'
+  );
+});


### PR DESCRIPTION
This pull request includes a
- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Changed `SelectAdapter.prototype.option` to check `if (data.id !== undefined)` instead of just `if (data.id)`

If this is related to an existing ticket, include a link to it as well. #4604 
