### PR TITLE
fix #3354 - adding options for select multiple backspace event

### DIFF
--- a/docs/_includes/options/selections/multiple.html
+++ b/docs/_includes/options/selections/multiple.html
@@ -14,4 +14,23 @@
   <p>
     Yes, Select2 will automatically map the value of the <code>multiple</code> attribute to the <code>multiple</code> option during initialization.
   </p>
+  
+  <h3 id="multipleOnBackspaceChoice">
+    Can I change the event produce on backspace hitting ?
+  </h3>
+
+  <p>
+    You could choice between this options :
+  </p>
+  <ul>
+    <li><code>text</code> : transform the tag option to text (by default)</li>
+    <li><code>unselect</code> : remove the tag which represent the option</li>
+    <li><code>none</code> : do nothing, ignore the event</li>
+  </ul>
+
+{% highlight js linenos %}
+$('select').select2({
+  multipleOnBackspaceChoice: 'none'
+});
+{% endhighlight %}
 </section>

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -364,6 +364,7 @@ define([
       maximumInputLength: 0,
       maximumSelectionLength: 0,
       minimumResultsForSearch: 0,
+      multipleOnBackspaceChoice : 'text',
       selectOnClose: false,
       sorter: function (data) {
         return data;

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -194,9 +194,19 @@ define([
   };
 
   Search.prototype.searchRemoveChoice = function (decorated, item) {
+    // if we do nothing
+    if (this.options.get('multipleOnBackspaceChoice') == 'none') {
+      return;
+    }
+    
     this.trigger('unselect', {
       data: item
     });
+    
+    // if we only unselect the option
+    if (this.options.get('multipleOnBackspaceChoice') == 'unselect') {
+      return;
+    }
 
     this.$search.val(item.text);
     this.handleSearch();


### PR DESCRIPTION
This pull request includes a
- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made :
- Add an option for choice what to do when backspace event is produce on multiple select (unselect (delete just the tag), none (do nothing), text (transform the tag to text like today)) (issues #3354)
