### PR TITLE
Fixed reinitialization of select2 in prog. example

### DIFF
--- a/docs/_includes/examples/programmatic-control.html
+++ b/docs/_includes/examples/programmatic-control.html
@@ -137,8 +137,8 @@ function log (name, evt) {
   <pre data-fill-from=".js-code-programmatic"></pre>
 
 <script type="text/javascript" class="js-code-programmatic">
-var $example = $(".js-example-programmatic").select2();
-var $exampleMulti = $(".js-example-programmatic-multi").select2();
+var $example = $(".js-example-programmatic");
+var $exampleMulti = $(".js-example-programmatic-multi");
 
 $(".js-programmatic-set-val").on("click", function () { $example.val("CA").trigger("change"); });
 


### PR DESCRIPTION
This pull request includes a
- [1] Bug fix in docs

The following changes were made
- deleted calling unwanted reinitialization of select2

The issue here was calling select2() on the input element which resulted in reinitialization. This was usually invisible but if theme or other options are introduced, the issue is very clear.
