### PR TITLE
load-grunt-tasks added in the project.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -324,20 +324,10 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-connect');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-qunit');
-  grunt.loadNpmTasks('grunt-contrib-requirejs');
-  grunt.loadNpmTasks('grunt-contrib-symlink');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-watch');
 
-  grunt.loadNpmTasks('grunt-gh-pages');
-  grunt.loadNpmTasks('grunt-jekyll');
-  grunt.loadNpmTasks('grunt-saucelabs');
-  grunt.loadNpmTasks('grunt-sass');
+  require('load-grunt-tasks')(grunt, {
+        scope: 'devDependencies'
+  });
 
   grunt.registerTask('default', ['compile', 'test', 'minify']);
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "grunt-gh-pages": "^0.9.1",
     "grunt-jekyll": "^0.4.2",
     "grunt-sass": "^1.0.0",
-    "grunt-saucelabs": "^8.6.0"
+    "grunt-saucelabs": "^8.6.0",
+    "load-grunt-tasks": "^3.5.0"
   },
   "dependencies": {
     "almond": "~0.3.1",


### PR DESCRIPTION
This pull request includes a
- [ x] New feature

The following changes were made
- make Gruntfile.js  a bit smaller, we saved a bit of lines.
- Very Easy now if someone install a dependency in the project from package.json, does not need to load this  in the Gruntfile.js
