### PR TITLE
attempt to fix closeOnSelect bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,5 +4,8 @@
     "main": ["select2.js", "select2.css", "select2.png", "select2x2.png", "select2-spinner.gif"],
     "dependencies": {
         "jquery": ">= 1.7.1"
-    }
+    },
+    "ignore": [
+        "tests"
+    ]
 }

--- a/select2.js
+++ b/select2.js
@@ -3183,7 +3183,6 @@ the specific language governing permissions and limitations under the Apache Lic
             // keep track of the search's value before it gets cleared
             this.lastSearchTerm = this.search.val();
 
-            this.clearSearch();
             this.updateResults();
 
             if (this.select || !this.opts.closeOnSelect) this.postprocessResults(data, false, this.opts.closeOnSelect===true);


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- removed `this.clearSearch()` of `onSelect` function (line 3186), as it was immediately closing the dropdown upon selection of an item when I wanted to select multiple items

fixes: https://github.com/select2/select2/issues/2264
