### PR TITLE
Fix remove click when multiselect box is higher than browser windows (#4642)

### DIFF
--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -26,8 +26,14 @@ define([
 
     MultipleSelection.__super__.bind.apply(this, arguments);
 
+    this.$selection.on('click', function (evt) {
+      self.trigger('toggle', {
+        originalEvent: evt
+      });
+    });
+
     this.$selection.on(
-      'click',
+      'mousedown',
       '.select2-selection__choice__remove',
       function (evt) {
         // Ignore the event if it is disabled
@@ -46,12 +52,6 @@ define([
         });
       }
     );
-
-    this.$selection.on('click', function (evt) {
-      self.trigger('toggle', {
-        originalEvent: evt
-      });
-    });
   };
 
   MultipleSelection.prototype.clear = function () {

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -26,12 +26,6 @@ define([
 
     MultipleSelection.__super__.bind.apply(this, arguments);
 
-    this.$selection.on('click', function (evt) {
-      self.trigger('toggle', {
-        originalEvent: evt
-      });
-    });
-
     this.$selection.on(
       'click',
       '.select2-selection__choice__remove',
@@ -52,6 +46,12 @@ define([
         });
       }
     );
+
+    this.$selection.on('click', function (evt) {
+      self.trigger('toggle', {
+        originalEvent: evt
+      });
+    });
   };
 
   MultipleSelection.prototype.clear = function () {


### PR DESCRIPTION
This pull request includes a
- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- I changed the event for the remove callback
- now removing an item is possible when the multiselect box is taller than the browser window (and the box is not yet active)

This fixes #4642 

_NOTE_:
This changes the following behaviour:
When you click on remove, the select dropdown will not open automatically. Which I personally think is better anyways.
