### PR TITLE
Add preselected option text as html property for span container.

### DIFF
--- a/dist/js/select2.js
+++ b/dist/js/select2.js
@@ -1560,7 +1560,8 @@ S2.define('select2/selection/single',[
     var formatted = this.display(selection, $rendered);
 
     $rendered.empty().append(formatted);
-    $rendered.prop('title', selection.title || selection.text);
+    $rendered.prop('title', selection.title || selection.text)
+        .html(selection.title || selection.text);
   };
 
   return SingleSelection;


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Add preselected option's text as html property for span container (http://bit.ly/2eDNJhI). In my case the span.select2-selection__rendered contains only title attribute with the name of preselected option (in the screenshot: LONDON), which isn't visible to the user.