### PR TITLE
Fix focus loss with closeOnSelect=false

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -493,9 +493,14 @@ define([
     var currentOffset = this.$results.offset().top;
     var nextTop = $highlighted.offset().top;
     var nextOffset = this.$results.scrollTop() + (nextTop - currentOffset);
+    var closeOnSelect = this.options.get('closeOnSelect');
 
     var offsetDelta = nextTop - currentOffset;
     nextOffset -= $highlighted.outerHeight(false) * 2;
+
+    if (!closeOnSelect) {
+      return;
+    }
 
     if (currentIndex <= 2) {
       this.$results.scrollTop(0);


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- I changed ensureHighlightVisible function
- Now select with closeOnSelect=false option not loses focus after selection

Fix for [3275](https://github.com/select2/select2/issues/3275)
