### PR TITLE
Add license to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
         "dist/js/select2.js",
         "src/scss/core.scss"
     ],
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "git@github.com:select2/select2.git"


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix

The following changes were made

- Added license info to bower.json

