### PR TITLE
Add native event dispatching

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,8 @@
     "QUnit": false,
     "require": false,
     "test": false,
-    "window": false
+    "window": false,
+    "CustomEvent": false
   },
   "indent": 2,
   "maxlen": 80,

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -448,10 +448,14 @@ define([
         return;
       }
 
-      self.trigger('select', {
+      var payload = {
         originalEvent: evt,
         data: data
-      });
+      };
+      
+      self.$element[0].dispatchEvent(new CustomEvent('change', { detail: payload }));
+      
+      self.trigger('select', payload);
     });
 
     this.$results.on('mouseenter', '.select2-results__option[aria-selected]',

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -453,7 +453,8 @@ define([
         data: data
       };
       
-      self.$element[0].dispatchEvent(new CustomEvent('change', { detail: payload }));
+      self.$element[0].dispatchEvent(
+        new CustomEvent('change', { detail: payload }));
       
       self.trigger('select', payload);
     });


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Add native dispatcher event support for change events
- Add support to angular 2 event binding syntax

``` html 
<select 
    #select 
    class="select2"
    (change)="onSelectChange($event)">. . . </select> 
```
Event changed for listen nativately with the DOM