### PR TITLE
Add reference section to documentation

### DIFF
--- a/docs/_includes/nav/reference.html
+++ b/docs/_includes/nav/reference.html
@@ -1,0 +1,9 @@
+<nav class="s2-docs-sidebar hidden-print hidden-xs hidden-sm">
+  <ul class="nav s2-docs-sidenav">
+    <li><a href="#options">Options</a></li>
+    <li><a href="#events">Events</a></li>
+  </ul>
+  <a class="back-to-top" href="#top">
+    Back to top
+  </a>
+</nav>

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -18,6 +18,9 @@
         <li{% if page.slug == "options" %} class="active"{% endif %}>
           <a href="./options.html">Options</a>
         </li>
+        <li{% if page.slug == "reference" %} class="active"{% endif %}>
+          <a href="./reference.html">Reference</a>
+        </li>
         <li class="dropdown{% if page.slug == "announcements-4.0" %} active{% endif %}">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             Topics

--- a/docs/_includes/reference/options.html
+++ b/docs/_includes/reference/options.html
@@ -1,0 +1,297 @@
+<section>
+  <h2 id="options">Options</h2>
+
+  <p>Select2 has the following options available. Note that this page is a work
+  in progress. The <a href="http://select2.github.io/select2/#documentation">previous
+  release's documentation</a> should cover the gaps here for the time being.</p>
+
+  <table class="table table-bordered table-striped">
+  	<thead>
+  		<tr>
+  			<th>Option</th>
+  			<th>Type</th>
+  			<th>Description</th>
+  		</tr>
+  	</thead>
+  	<tbody>
+      <tr id="adaptContainerCssClass">
+        <td>adaptContainerCssClass</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="adaptDropdownCssClass">
+        <td>adaptDropdownCssClass</td>
+        <td></td>
+        <td></td>
+      </tr>
+  		<tr id="ajax">
+  			<td>ajax</td>
+  			<td></td>
+  			<td></td>
+  		</tr>
+  		<tr id="allowClear">
+  			<td>allowClear</td>
+  			<td>boolean</td>
+  			<td>
+  				<p>When set to <strong>true</strong>, causes a clear button to appear on the select box
+          when a value is selected. Clicking the clear button will clear the selected value,
+          effectively resetting the select box back to its placeholder value.</p>
+
+  				<p>Default value: <strong>false</strong></p>
+  			</td>
+  		</tr>
+      <tr id="amdBase">
+        <td>amdBase</td>
+        <td>string</td>
+        <td>
+          <p>The base AMD loader path to be used for select2 dependency resolution. This option
+          typically doesn't need to be changed, but is available for situations where module names
+          may change as a result of certain build environments.</p>
+
+          <p>Default value: <strong>&quot;./&quot;</strong></p>
+        </td>
+      </tr>
+      <tr id="amdLanguageBase">
+        <td>amdLanguageBase</td>
+        <td>string</td>
+        <td>
+          <p>The base AMD loader language path to be used for select2 language file resolution. This
+          option typically doesn't need to be changed, but is available for situations where module
+          names may change as a result of certain build environments.</p>
+
+          <p>Default value: <strong>&quot;./i18n/&quot;</strong></p>
+        </td>
+      </tr>
+  		<tr id="closeOnSelect">
+  			<td>closeOnSelect</td>
+  			<td>boolean</td>
+  			<td>
+  				<p>When set to <strong>false</strong>, keeps the dropdown open upon selecting an option,
+          making it easy to quickly select multiple items. <em>Note that this option is only
+          applicable to multi-select controls</em>.</p>
+
+  				<p>Default value: <strong>true</strong></p>
+  			</td>
+  		</tr>
+      <tr id="containerCss">
+        <td>containerCss</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="containerCssClass">
+        <td>containerCssClass</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="dataAdapter">
+        <td>dataAdapter</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="debug">
+        <td>debug</td>
+        <td>boolean</td>
+        <td></td>
+      </tr>
+   		<tr id="dir">
+  			<td>dir</td>
+  			<td></td>
+  			<td></td>
+  		</tr>
+  		<tr id="disabled">
+  			<td>disabled</td>
+  			<td>boolean</td>
+  			<td>
+  				<p>When set to <strong>true</strong>, the select control will be disabled.</p>
+
+  				<p>Default value: <strong>false</strong></p>
+  			</td>
+  		</tr>
+      <tr id="dropdownAdapter">
+        <td>dropdownAdapter</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="dropdownAutoWidth">
+        <td>dropdownAutoWidth</td>
+        <td>boolean</td>
+        <td></td>
+      </tr>
+      <tr id="dropdownCss">
+        <td>dropdownCss</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="dropdownCssClass">
+        <td>dropdownCssClass</td>
+        <td></td>
+        <td></td>
+      </tr>
+  		<tr id="dropdownParent">
+  			<td>dropdownParent</td>
+  			<td></td>
+  			<td></td>
+  		</tr>
+      <tr id="escapeMarkup">
+        <td>escapeMarkup</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="initSelection">
+        <td>initSelection</td>
+        <td></td>
+        <td></td>
+      </tr>
+  		<tr id="language">
+  			<td>language</td>
+  			<td></td>
+  			<td></td>
+  		</tr>
+      <tr id="matcher">
+        <td>matcher</td>
+        <td></td>
+        <td></td>
+      </tr>
+  		<tr id="maximumInputLength">
+  			<td>maximumInputLength</td>
+  			<td>integer</td>
+  			<td>
+          <p>Maximum number of characters that may be provided for a search term.</p>
+
+          <p>Default value: <strong>0</strong></p>   
+        </td>
+  		</tr>
+  		<tr id="maximumSelectionLength">
+  			<td>maximumSelectionLength</td>
+  			<td>integer</td>
+  			<td>
+          <p>The maximum number of items that may be selected in a multi-select control. If the
+          value of this option is less than 1, the number of selected items will not be limited.</p>
+
+          <p>Default value: <strong>0</strong></p>
+        </td>
+  		</tr>
+  		<tr id="minimumInputLength">
+  			<td>minimumInputLength</td>
+  			<td>integer</td>
+  			<td>
+  				<p>Minimum number of characters required to start a search. This options is primarily
+          useful in cases where data is loaded via the <code>ajax</code> option.</p>
+
+          <p>Default value: <strong>0</strong></p>
+  			</td>
+  		</tr>
+  		<tr id="minimumResultsForSearch">
+  			<td>minimumResultsForSearch</td>
+  			<td>integer</td>
+  			<td>
+  				<p>The minimum number of results required in the initial population of the dropdown to
+          keep the search box. This option is useful for cases where local data is used with a small
+          result set, and the search box would simply be a waste of screen real estate. Set this
+          value to -1 to permanently hide the search box.</p>
+
+          <p>Default value: <strong>0</strong></p>
+  			</td>
+  		</tr>
+      <tr id="multiple">
+        <td>multiple</td>
+        <td></td>
+        <td></td>
+      </tr>
+  		<tr id="placeholder">
+  			<td>placeholder</td>
+  			<td></td>
+  			<td></td>
+  		</tr>
+      <tr id="query">
+        <td>query</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="resultsAdapter">
+        <td>resultsAdapter</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="selectionAdapter">
+        <td>selectionAdapter</td>
+        <td></td>
+        <td></td>
+      </tr>
+  		<tr id="selectOnClose">
+  			<td>selectOnClose</td>
+  			<td>boolean</td>
+  			<td>
+          <p>Default value: <strong>false</strong></p>
+        </td>
+  		</tr>
+      <tr id="sorter">
+        <td>sorter</td>
+        <td>function</td>
+        <td></td>
+      </tr>
+  		<tr id="tags">
+  			<td>tags</td>
+  			<td></td>
+  			<td></td>
+  		</tr>
+  		<tr id="templateResult">
+  			<td>templateResult</td>
+  			<td>function</td>
+  			<td></td>
+  		</tr>
+  		<tr id="templateSelection">
+  			<td>templateSelection</td>
+  			<td>function</td>
+  			<td></td>
+  		</tr>
+  		<tr id="theme">
+  			<td>theme</td>
+  			<td>string</td>
+  			<td>
+          <p>Default value: <strong>default</strong></p>
+        </td>
+  		</tr>
+      <tr id="tokenizer">
+        <td>tokenizer</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr id="tokenSeparators">
+        <td>tokenSeparators</td>
+        <td></td>
+        <td></td>
+      </tr>
+  		<tr id="width">
+  			<td>width</td>
+  			<td>string</td>
+  			<td>
+  				<p>Specifies the <code>width</code> style attribute of the select2 container. The
+          following values are supported:</p>
+
+  				<dl class="dl-horizontal">
+  					<dt>element</dt>
+  					<dd>Uses the computed element width from any applicable CSS rules.</dd>
+
+  					<dt>resolve</dt>
+  					<dd>Uses the <code>style</code> attribute value if available, falling
+            back to the computed element width as necessary.</dd>
+
+  					<dt>style</dt>
+  					<dd>Width is determined from the <code>select</code> element's <code>style</code>
+            attribute. If no <code>style</code> attribute is found, null is returned as the
+            width.</dd>
+
+  					<dt><em>{width_value}</em></dt>
+  					<dd>Valid CSS values can be passed as a string (i.e. <code>80%</code>).</dd>
+  				</dl>
+
+  				<p>Default value: <strong>resolve</strong></p>
+  			</td>
+  		</tr>
+  	</tbody>
+  </table>
+
+  <h2 id="events">Events</h2>
+  <p>TODO</p>
+</section>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1,0 +1,240 @@
+---
+layout: default
+title: Reference - Select2
+slug: reference
+---
+
+<script type="text/javascript" src="vendor/js/placeholders.jquery.min.js"></script>
+<script type="text/javascript" src="dist/js/i18n/es.js"></script>
+
+<style type="text/css">
+  .img-flag {
+    height: 15px;
+    width: 18px;
+  }
+</style>
+
+<section class="jumbotron">
+  <div class="container">
+    <h1>Technical Reference</h1>
+  </div>
+</section>
+
+<div class="container s2-docs-container">
+  <div class="row">
+    <div class="col-md-9" role="main">
+      {% include reference/options.html %}
+    </div>
+    <div class="col-md-3" role="complementary">
+
+      {% include nav/reference.html %}
+
+    </div>
+  </div>
+</div>
+
+{% include js-source-states.html %}
+
+<script type="text/javascript">
+  var $states = $(".js-source-states");
+  var statesOptions = $states.html();
+  $states.remove();
+
+  $(".js-states").append(statesOptions);
+
+  $("[data-fill-from]").each(function () {
+    var $this = $(this);
+
+    var codeContainer = $this.data("fill-from");
+    var $container = $(codeContainer);
+
+    var code = $.trim($container.html());
+
+    $this.text(code);
+    $this.addClass("prettyprint linenums");
+  });
+
+  prettyPrint();
+
+  $.fn.select2.amd.require([
+    "select2/core",
+    "select2/utils",
+    "select2/compat/matcher"
+  ], function (Select2, Utils, oldMatcher) {
+    var $basicSingle = $(".js-example-basic-single");
+    var $basicMultiple = $(".js-example-basic-multiple");
+    var $limitMultiple = $(".js-example-basic-multiple-limit");
+
+    var $dataArray = $(".js-example-data-array");
+    var $dataArraySelected = $(".js-example-data-array-selected");
+
+    var data = [
+      { id: 0, text: 'enhancement' },
+      { id: 1, text: 'bug' },
+      { id: 2, text: 'duplicate' },
+      { id: 3, text: 'invalid' },
+      { id: 4, text: 'wontfix' }
+    ];
+
+    var $ajax = $(".js-example-data-ajax");
+
+    var $disabledResults = $(".js-example-disabled-results");
+
+    var $tags = $(".js-example-tags");
+
+    var $matcherStart = $('.js-example-matcher-start');
+
+    var $diacritics = $(".js-example-diacritics");
+    var $language = $(".js-example-language");
+
+    $.fn.select2.defaults.set("width", "100%");
+
+    $basicSingle.select2();
+    $basicMultiple.select2();
+    $limitMultiple.select2({
+      maximumSelectionLength: 2
+    });
+
+    function formatState (state) {
+      if (!state.id) {
+        return state.text;
+      }
+      var $state = $(
+        '<span>' +
+          '<img src="vendor/images/flags/' +
+            state.element.value.toLowerCase() +
+          '.png" class="img-flag" /> ' +
+          state.text +
+        '</span>'
+      );
+      return $state;
+    };
+
+    $(".js-example-templating").select2({
+      templateResult: formatState,
+      templateSelection: formatState
+    });
+
+    $dataArray.select2({
+      data: data
+    });
+
+    $dataArraySelected.select2({
+      data: data
+    });
+
+    function formatRepo (repo) {
+      if (repo.loading) return repo.text;
+
+      var markup = "<div class='select2-result-repository clearfix'>" +
+        "<div class='select2-result-repository__avatar'><img src='" + repo.owner.avatar_url + "' /></div>" +
+        "<div class='select2-result-repository__meta'>" +
+          "<div class='select2-result-repository__title'>" + repo.full_name + "</div>";
+
+      if (repo.description) {
+        markup += "<div class='select2-result-repository__description'>" + repo.description + "</div>";
+      }
+
+      markup += "<div class='select2-result-repository__statistics'>" +
+        "<div class='select2-result-repository__forks'><i class='fa fa-flash'></i> " + repo.forks_count + " Forks</div>" +
+        "<div class='select2-result-repository__stargazers'><i class='fa fa-star'></i> " + repo.stargazers_count + " Stars</div>" +
+        "<div class='select2-result-repository__watchers'><i class='fa fa-eye'></i> " + repo.watchers_count + " Watchers</div>" +
+      "</div>" +
+      "</div></div>";
+
+      return markup;
+    }
+
+    function formatRepoSelection (repo) {
+      return repo.full_name || repo.text;
+    }
+
+    $ajax.select2({
+      ajax: {
+        url: "https://api.github.com/search/repositories",
+        dataType: 'json',
+        delay: 250,
+        data: function (params) {
+          return {
+            q: params.term, // search term
+            page: params.page
+          };
+        },
+        processResults: function (data, params) {
+          // parse the results into the format expected by Select2
+          // since we are using custom formatting functions we do not need to
+          // alter the remote JSON data, except to indicate that infinite
+          // scrolling can be used
+          params.page = params.page || 1;
+
+          return {
+            results: data.items,
+            pagination: {
+              more: (params.page * 30) < data.total_count
+            }
+          };
+        },
+        cache: true
+      },
+      escapeMarkup: function (markup) { return markup; },
+      minimumInputLength: 1,
+      templateResult: formatRepo,
+      templateSelection: formatRepoSelection
+    });
+
+    $(".js-example-disabled").select2();
+    $(".js-example-disabled-multi").select2();
+
+    $(".js-example-responsive").select2({
+        width: 'resolve' // need to override the changed default
+    });
+
+    $disabledResults.select2();
+
+    $(".js-example-programmatic").select2();
+    $(".js-example-programmatic-multi").select2();
+
+    $eventSelect.select2();
+
+    $tags.select2({
+      tags: ['red', 'blue', 'green']
+    });
+
+    $(".js-example-tokenizer").select2({
+      tags: true,
+      tokenSeparators: [',', ' ']
+    });
+
+    function matchStart (term, text) {
+      if (text.toUpperCase().indexOf(term.toUpperCase()) == 0) {
+        return true;
+      }
+
+      return false;
+    }
+
+    $matcherStart.select2({
+      matcher: oldMatcher(matchStart)
+    });
+
+    $(".js-example-basic-hide-search").select2({
+      minimumResultsForSearch: Infinity
+    });
+
+    $diacritics.select2();
+
+    $language.select2({
+      language: "es"
+    });
+
+    $(".js-example-theme-single").select2({
+      theme: "classic"
+    });
+
+    $(".js-example-theme-multiple").select2({
+      theme: "classic"
+    });
+
+    $(".js-example-rtl").select2();
+  });
+</script>


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Added a reference guide (skeleton) to the documentation.

Let's add a reference section to the documentation to at least have a list of the available options. This should (to a point) resolve issue #3948 and #4687. I know it's incomplete, but I've been sitting on this for months and haven't had a chance to move it forward any further. At least making it available might spur someone else to contribute.

I also hope to add to it as I am able.