### PR TITLE
Simplify plugin integration

### DIFF
--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -67,6 +67,11 @@ define([
         AdapterClass = chains.shift();
       }
 
+      var decorator = options[type + 'Decorator'];
+      if (decorator != null) {
+        chains.push(decorator);
+      }
+
       $.each(chains, function (i, DecoratorClass) {
         AdapterClass = Utils.Decorate(AdapterClass, DecoratorClass);
       });


### PR DESCRIPTION
This pull request includes a

- [x] New feature

The following changes were made

- Support decorator options: dataDecorator, resultsDecorator, dropdownDecorator and selectionDecorator

It will simplify third-party plugin integration. User can specify decorator which will decorate the default adapter. Don't need to use $.fn.select2.amd.require and construct adapter manually using Utils.Decorate.
