### PR TITLE
Adds an option to pass a global function to templateResult

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -505,10 +505,15 @@ define([
   };
 
   Results.prototype.template = function (result, container) {
+    var content;
     var template = this.options.get('templateResult');
     var escapeMarkup = this.options.get('escapeMarkup');
 
-    var content = template(result, container);
+    if (typeof window[template] == 'function') {
+        content = window[template](result, container);
+    } else {
+        content = template(result, container);
+    }
 
     if (content == null) {
       container.style.display = 'none';


### PR DESCRIPTION
Hello there,

Small improvement I made so we'll be able to pass global functions into templateResult option.
That way I will be able to pass a string to the templateResult, and if a global function exists in that name, it would be fired instead of returning an error.

Now we can just add a data attribute to a certain element like this:
`data-template-result="foo"`
and it will try to find a function with that name:
```
function foo(data) {
    // Do your stuff
    return data.text;
}
```

But of course things may be even more convenient for large projects. Like this for example:
```
var Main = function () {
    window.foo = bar

    var bar = function (data) {
        // Do more stuff here
        return data.text;
    }
}

$(function () {
    Main();
});
```

Let me know what you think.