### PR TITLE
Added an option that disables scrolling to the parent item when a child is highlighted

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "select2",
-    "version": "3.5.3",
+    "version": "3.5.4",
     "main": ["select2.js", "select2.css", "select2.png", "select2x2.png", "select2-spinner.gif"],
     "dependencies": {
         "jquery": ">= 1.7.1"

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "select2",
   "repo": "ivaynberg/select2",
   "description": "Select2 is a jQuery based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results.",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "demo": "http://ivaynberg.github.io/select2/",
   "keywords": [
     "jquery"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name":
   "ivaynberg/select2",
   "description": "Select2 is a jQuery based replacement for select boxes.",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "type": "component",
   "homepage": "http://ivaynberg.github.io/select2/",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Igor Vaynberg",
   "repository": {"type": "git", "url": "git://github.com/ivaynberg/select2.git"},
   "main": "select2.js",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "jspm": {
     "main": "select2",
     "files": ["select2.js", "select2.png", "select2.css", "select2-spinner.gif"],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "version": "3.5.4",
   "jspm": {
     "main": "select2",
-    "files": ["select2.js", "select2.png", "select2.css", "select2-spinner.gif"],
+    "files": ["select2.js", "select2.png", "select2x2.png", "select2.css", "select2-spinner.gif"],
     "shim": {
         "select2": {
             "imports": ["jquery", "./select2.css!"],

--- a/select2.jquery.json
+++ b/select2.jquery.json
@@ -11,7 +11,7 @@
         "tag",
         "tagging"
     ],
-    "version": "3.5.3",
+    "version": "3.5.4",
     "author": {
         "name": "Igor Vaynberg",
         "url": "https://github.com/ivaynberg"

--- a/select2.js
+++ b/select2.js
@@ -2745,7 +2745,7 @@ the specific language governing permissions and limitations under the Apache Lic
                 if (data == undefined) data = null;
                 return data;
             } else {
-                if (opts.debug && console && console.warn) {
+                if (this.opts.debug && console && console.warn) {
                     console.warn(
                         'Select2: The `select2("data")` method can no longer set selected values in 4.0.0, ' +
                         'consider using the `.val()` method instead.'

--- a/select2.js
+++ b/select2.js
@@ -1698,6 +1698,8 @@ the specific language governing permissions and limitations under the Apache Lic
                 return;
             }
 
+            if (!this.opts.scrollToParentWhenChildHighlighted) return;
+
             children = this.findHighlightableChoices().find('.select2-result-label');
 
             child = $(children[index]);
@@ -3619,6 +3621,7 @@ the specific language governing permissions and limitations under the Apache Lic
         dropdownCss: {},
         containerCssClass: "",
         dropdownCssClass: "",
+        scrollToParentWhenChildHighlighted: true,
         formatResult: function(result, container, query, escapeMarkup) {
             var markup=[];
             markMatch(this.text(result), query.term, markup, escapeMarkup);


### PR DESCRIPTION
Fix is in 1d45ed0b38e195ce4b4ba873fa96edea70584b32.

I was experiencing an odd issue occurring when child options were highlighted, especially in cases where there were many children. The highlight code was constantly causing a scroll to occur, disabling from actually reaching elements toward the bottom of the list.

This highlights the bug (using select2/stable/3.5): https://jsfiddle.net/shfs7s8e/3/
This highlights the fix (using tzellman/stable/3.5) https://jsfiddle.net/22rzn48g/3/

Apologies for not making the pull request sooner - slipped off my radar. Thanks!