### PR TITLE
Dropdown list width shouldn’t round

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -129,7 +129,7 @@ define([
     }
 
     if (method == 'element') {
-      var elementWidth = $element.outerWidth(false);
+      var elementWidth = $element[0].getBoundingClientRect().width;
 
       if (elementWidth <= 0) {
         return 'auto';

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -199,7 +199,7 @@ define([
 
   AttachBody.prototype._resizeDropdown = function () {
     var css = {
-      width: this.$container.outerWidth(false) + 'px'
+      width: this.$container[0].getBoundingClientRect().width + 'px'
     };
 
     if (this.options.get('dropdownAutoWidth')) {

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -398,6 +398,7 @@ define([
 
     container.on('results:focus', function (params) {
       params.element.addClass('select2-results__option--highlighted');
+      params.element.css('width', this.$container[0].getBoundingClientRect().width + 'px');
     });
 
     container.on('results:message', function (params) {


### PR DESCRIPTION
When main dropdown box width is not round,  the dropdown width list is round since using jQuery outerWidth function always return round value, and the result of dropdown box and dropdown list is not exact same width.
