### PR TITLE
Show same options in example as used in demo

### DIFF
--- a/docs/_includes/examples/themes-templating-responsive-design.html
+++ b/docs/_includes/examples/themes-templating-responsive-design.html
@@ -69,7 +69,8 @@ function formatState (state) {
 };
 
 $(".js-example-templating").select2({
-  templateResult: formatState
+  templateResult: formatState,
+  templateSelection: formatState
 });
 {% endhighlight %}
 


### PR DESCRIPTION
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- The templateSelection option was used in the demo, but was not shown in the example code.
This commit fixes it, so that copy&pasting works as expected.