### PR TITLE
Clear tooltip bug fix

### DIFF
--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -66,7 +66,9 @@ define([
   };
 
   SingleSelection.prototype.clear = function () {
+
     this.$selection.find('.select2-selection__rendered').empty();
+    this.$selection.find('.select2-selection__rendered').attr('title',''); // clear tooltip on empty
   };
 
   SingleSelection.prototype.display = function (data, container) {

--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -67,8 +67,9 @@ define([
 
   SingleSelection.prototype.clear = function () {
 
-    this.$selection.find('.select2-selection__rendered').empty();
-    this.$selection.find('.select2-selection__rendered').attr('title',''); // clear tooltip on empty
+    var $rendered = this.$selection.find('.select2-selection__rendered');
+    $rendered.empty();
+    $rendered.attr('title',''); // clear tooltip on empty
   };
 
   SingleSelection.prototype.display = function (data, container) {


### PR DESCRIPTION
This pull request includes a

- [ + ] Bug fix

The following changes were made

-  when placeholder present [ and allowClear true ], select a value 
-  clear it
- Placeholder on hover shows last selected value


If this is related to an existing ticket, include a link to it as well.
#4700