### PR TITLE
Fix ajax.abort() detection to handle transport.status code as integer

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -82,7 +82,7 @@ define([
       }, function () {
         // Attempt to detect if a request was aborted
         // Only works if the transport exposes a status property
-        if ($request.status && $request.status === '0') {
+        if ($request.hasOwnProperty('status') && $request.status == '0') {
           return;
         }
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Actually the transport.status property is handled as string but it fails when this property comes as as integer. Tested on OSX - Chrome 55.0.2883.95

Original commit cfb66f5