### PR TITLE
Fix bug which favours upwards version of Dropdown

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -176,7 +176,7 @@ define([
 
     if (!enoughRoomBelow && enoughRoomAbove && !isCurrentlyAbove) {
       newDirection = 'above';
-    } else if (!enoughRoomAbove && enoughRoomBelow && isCurrentlyAbove) {
+    } else if (enoughRoomBelow && isCurrentlyAbove) {
       newDirection = 'below';
     }
 


### PR DESCRIPTION
This pull request includes a

- [ x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Amended the logic which decides which way round to display the dropdown because previously if it showed a dropdown as upwards it would only then show that dropdown downwards if there ceased to be enough room upwards. I think preferred behaviour (and more usual) would be for it to always display downwards if there is room and only display upwards if it has to.

If this is related to an existing ticket, include a link to it as well.
