### PR TITLE
Fix disabled option not updating when property changes

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -175,8 +175,8 @@ define([
       'aria-selected': 'false'
     };
 
-    if ((data.element != null && data.element.disabled)
-        || (data.element == null && data.disabled)) {
+    if ((data.element != null && data.element.disabled) ||
+        (data.element == null && data.disabled)) {
       delete attrs['aria-selected'];
       attrs['aria-disabled'] = 'true';
     }

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -175,7 +175,8 @@ define([
       'aria-selected': 'false'
     };
 
-    if (data.disabled) {
+    if ((data.element != null && data.element.disabled)
+        || (data.element == null && data.disabled)) {
       delete attrs['aria-selected'];
       attrs['aria-disabled'] = 'true';
     }


### PR DESCRIPTION
 This fixes the problem where disabled options couldn't be re-enabled.

This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Modified condition to consider the element's current disabled state instead of the cached one for disabled elements. If no element exists the cached value will be used.

Fix for #3347