### PR TITLE
Correct the inputTooShort message

### DIFF
--- a/src/js/select2/i18n/fr.js
+++ b/src/js/select2/i18n/fr.js
@@ -24,6 +24,8 @@ define(function () {
         message += 's';
       }
 
+      message += ' ou plus';
+
       return message;
     },
     loadingMore: function () {


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [x] Translation

The following changes were made

- The french translation for the `inputTooShort` message give the false idea that this limit is strict. Add the 'or more' equivalent that was missing.
