### PR TITLE
Adds a `select2:blur` event back to select2

### DIFF
--- a/src/js/select2/selection/eventRelay.js
+++ b/src/js/select2/selection/eventRelay.js
@@ -9,7 +9,8 @@ define([
       'open', 'opening',
       'close', 'closing',
       'select', 'selecting',
-      'unselect', 'unselecting'
+      'unselect', 'unselecting',
+      'blur'
     ];
 
     var preventableEvents = ['opening', 'closing', 'selecting', 'unselecting'];


### PR DESCRIPTION
Following from the discussion in https://github.com/select2/select2/issues/1908 this PR adds the `blur` event at the `EventRelay` list.