### PR TITLE
Adding sample JSON object to Ajax documentation

### DIFF
--- a/docs/_includes/options/data/ajax.html
+++ b/docs/_includes/options/data/ajax.html
@@ -19,7 +19,28 @@
     What should the results returned to Select2 look like?
   </h3>
 
-  {% include options/not-written.html %}
+  <p>
+    A result object with two select options and more available via pagination would look like this:
+  </p>
+
+{% highlight json linenos %}
+{
+  "results": [
+    {
+      "id": "1",
+      "text": "Option 1"
+    },
+    {
+      "id": "2",
+      "text": "Option 2"
+    }
+  ],
+  "pagination": {
+    "more": true
+  },
+  "status" : 200
+}
+{% endhighlight %}
 
   <h3>
     Is there a way to modify the response before passing it back to Select2?


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

Hi, I'm just trying to add a sample JSON object to the Ajax documentation - it would have saved me a little time when I was looking for it. The change is in docs\_includes\options\data\ajax.html. Please take a look and let me know what you think.

