### PR TITLE
Prevent Scroll to First Selection on Select/Unselect

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -112,6 +112,8 @@ define([
       // in the dropdown
       $options.first().trigger('mouseenter');
     }
+
+    this.ensureHighlightVisible();
   };
 
   Results.prototype.setClasses = function () {

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -112,8 +112,6 @@ define([
       // in the dropdown
       $options.first().trigger('mouseenter');
     }
-
-    this.ensureHighlightVisible();
   };
 
   Results.prototype.setClasses = function () {

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -276,7 +276,6 @@ define([
       }
 
       self.setClasses();
-      self.highlightFirstItem();
     });
 
     container.on('unselect', function () {
@@ -285,7 +284,6 @@ define([
       }
 
       self.setClasses();
-      self.highlightFirstItem();
     });
 
     container.on('open', function () {


### PR DESCRIPTION
Resolves issue for multiselects using `closeOnSelect: false` that caused the list of results to scroll to the first selection after each select/unselect

This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Removed behavior for scrolling to first selection after each selection/unselection
-
-

If this is related to an existing ticket, include a link to it as well.
https://github.com/select2/select2/issues/1513