### PR TITLE
Fix : #4876 - optgroup cannot be disabled

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -197,7 +197,7 @@ define([
     return $option;
   };
 
-  SelectAdapter.prototype.item = function ($option) {
+  SelectAdapter.prototype.item = function ($option, disabledParent) {
     var data = {};
 
     data = $.data($option[0], 'data');
@@ -205,12 +205,14 @@ define([
     if (data != null) {
       return data;
     }
+    
+    var disabled = disabledParent || $option.prop('disabled');
 
     if ($option.is('option')) {
       data = {
         id: $option.val(),
         text: $option.text(),
-        disabled: $option.prop('disabled'),
+        disabled: disabled,
         selected: $option.prop('selected'),
         title: $option.prop('title')
       };
@@ -218,6 +220,7 @@ define([
       data = {
         text: $option.prop('label'),
         children: [],
+        disabled: disabled,
         title: $option.prop('title')
       };
 
@@ -227,7 +230,7 @@ define([
       for (var c = 0; c < $children.length; c++) {
         var $child = $($children[c]);
 
-        var child = this.item($child);
+        var child = this.item($child, disabled);
 
         children.push(child);
       }


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Optgroup can now be disabled and disabled their children (fix #4876)

If this is related to an existing ticket, include a link to it as well.
