### PR TITLE
Set defaults recursively

### DIFF
--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -387,7 +387,7 @@ define([
 
     var convertedData = Utils._convertData(data);
 
-    $.extend(this.defaults, convertedData);
+    $.extend(true, this.defaults, convertedData);
   };
 
   var defaults = new Defaults();


### PR DESCRIPTION
Without the patch, when you set defaults like this:

```
$.fn.select2.defaults.set("ajax--delay", 250)
$.fn.select2.defaults.set("ajax--minimumResultsForSearch", 2)
```

you get defaults == `ajax: { minimumResultsForSearch: 2 }` (`delay` is dismissed).

This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Set default options recursively (so that you can set `ajax` defaults)
