### PR TITLE
Fix cleanup of scroll positioning handler

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -87,9 +87,12 @@ define([
     var scrollEvent = 'scroll.select2.' + container.id;
     var resizeEvent = 'resize.select2.' + container.id;
     var orientationEvent = 'orientationchange.select2.' + container.id;
+    
+    if (!this.attached_containers) this.attached_containers = [];
 
     var $watchers = this.$container.parents().filter(Utils.hasScroll);
     $watchers.each(function () {
+      self.attached_containers.push(this);
       $(this).data('select2-scroll-position', {
         x: $(this).scrollLeft(),
         y: $(this).scrollTop()
@@ -114,8 +117,8 @@ define([
     var resizeEvent = 'resize.select2.' + container.id;
     var orientationEvent = 'orientationchange.select2.' + container.id;
 
-    var $watchers = this.$container.parents().filter(Utils.hasScroll);
-    $watchers.off(scrollEvent);
+    if (this.attached_containers) $(this.attached_containers).off(scrollEvent);
+    this.attached_containers = null;
 
     $(window).off(scrollEvent + ' ' + resizeEvent + ' ' + orientationEvent);
   };

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -88,11 +88,13 @@ define([
     var resizeEvent = 'resize.select2.' + container.id;
     var orientationEvent = 'orientationchange.select2.' + container.id;
     
-    if (!this.attached_containers) this.attached_containers = [];
+    if (!this.attachedContainers) {
+      this.attachedContainers = [];
+    }
 
     var $watchers = this.$container.parents().filter(Utils.hasScroll);
     $watchers.each(function () {
-      self.attached_containers.push(this);
+      self.attachedContainers.push(this);
       $(this).data('select2-scroll-position', {
         x: $(this).scrollLeft(),
         y: $(this).scrollTop()
@@ -117,8 +119,10 @@ define([
     var resizeEvent = 'resize.select2.' + container.id;
     var orientationEvent = 'orientationchange.select2.' + container.id;
 
-    if (this.attached_containers) $(this.attached_containers).off(scrollEvent);
-    this.attached_containers = null;
+    if (this.attachedContainers) {
+      $(this.attachedContainers).off(scrollEvent);
+    }
+    this.attachedContainers = null;
 
     $(window).off(scrollEvent + ' ' + resizeEvent + ' ' + orientationEvent);
   };


### PR DESCRIPTION
If the Select2 DOM elements are removed from the DOM or moved to another parent element while the select2 dropdown is open, the scroll event would not get detached from the correct elements. This breaks scrolling and causes a memory leak. This patch fixes the problem by storing the elements to which event handlers were bound.

This pull request includes a

- [x] Bug fix