### PR TITLE
fix($tag-input): Fix tag input on IE11

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -82,6 +82,10 @@ define([
       self.$selection.removeAttr('aria-owns');
 
       self.$selection.focus();
+      // fix Chrome bug - lost focus after selecting a value
+      window.setTimeout(function () {
+        self.$selection.focus();
+      }, 0);
 
       self._detachCloseHandler(container);
     });

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -174,8 +174,13 @@ define([
                    .append(this.$searchContainer);
 
     this.resizeSearch();
-    if (searchHadFocus) {
+    var isTagInput = this.$element.find('[data-select2-tag]').length;
+
+    if (!isTagInput && searchHadFocus) {
       this.$search.focus();
+    } else if (isTagInput && searchHadFocus) {
+      // fix IE11 bug where tag input lost focus
+      this.$element.focus();
     }
   };
 


### PR DESCRIPTION
#4398 #4570

This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fix bug with tag input in IE11 and Chrome
