### PR TITLE
add enableMousewheel property

### DIFF
--- a/dist/js/select2.full.js
+++ b/dist/js/select2.full.js
@@ -1177,7 +1177,7 @@ S2.define('select2/results',[
       self.displayMessage(params);
     });
 
-    if ($.fn.mousewheel) {
+    if (this.options.get('enableMousewheel') && $.fn.mousewheel) {
       this.$results.on('mousewheel', function (e) {
         var top = self.$results.scrollTop();
 
@@ -4900,7 +4900,8 @@ S2.define('select2/defaults',[
         return selection.text;
       },
       theme: 'default',
-      width: 'resolve'
+      width: 'resolve',
+      enableMousewheel: true
     };
   };
 

--- a/dist/js/select2.js
+++ b/dist/js/select2.js
@@ -1177,7 +1177,7 @@ S2.define('select2/results',[
       self.displayMessage(params);
     });
 
-    if ($.fn.mousewheel) {
+    if (this.options.get('enableMousewheel') && $.fn.mousewheel) {
       this.$results.on('mousewheel', function (e) {
         var top = self.$results.scrollTop();
 
@@ -4900,7 +4900,8 @@ S2.define('select2/defaults',[
         return selection.text;
       },
       theme: 'default',
-      width: 'resolve'
+      width: 'resolve',
+      enableMousewheel: true
     };
   };
 

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -375,7 +375,8 @@ define([
         return selection.text;
       },
       theme: 'default',
-      width: 'resolve'
+      width: 'resolve',
+      enableMousewheel: true
     };
   };
 

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -404,7 +404,7 @@ define([
       self.displayMessage(params);
     });
 
-    if ($.fn.mousewheel) {
+    if (this.options.get('enableMousewheel') && $.fn.mousewheel) {
       this.$results.on('mousewheel', function (e) {
         var top = self.$results.scrollTop();
 


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- enableMousewheel means to use $.fn.mousewheel.
- If you don't use $.fn.mousewheel, you can not use mouse scroll in select2 body.

If this is related to an existing ticket, include a link to it as well.
