### PR TITLE
fixed typo (missing space)

### DIFF
--- a/src/js/select2/i18n/ro.js
+++ b/src/js/select2/i18n/ro.js
@@ -19,7 +19,7 @@ define(function () {
       var remainingChars = args.minimum - args.input.length;
 
       var message = 'Vă rugăm să introduceți ' + remainingChars +
-        'sau mai multe caractere';
+        ' sau mai multe caractere';
 
       return message;
     },


### PR DESCRIPTION
Added a missing space on `inputTooShort` message.

This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [X] Translation

The following changes were made

- added missing space on `inputTooShort` message.
