### PR TITLE
Add style property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   ],
   "license": "MIT",
   "main": "dist/js/select2.js",
+  "style": "dist/css/select2.css",
   "files": [
     "src",
     "dist"
   ],
-  "style": "dist/css/select2.css",
   "version": "4.0.3",
   "jspm": {
     "main": "js/select2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "src",
     "dist"
   ],
+  "style": "dist/css/select2.css",
   "version": "4.0.3",
   "jspm": {
     "main": "js/select2",


### PR DESCRIPTION
By adding a reference to the main dist CSS, `gulp` tools such as [`sass-module-importer`](https://www.npmjs.com/package/sass-module-importer) can automatically import the stylesheet.