### PR TITLE
Updates disabled state when changed after initialisation.

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -141,6 +141,12 @@ define([
         } else {
           $option.attr('aria-selected', 'false');
         }
+        
+        if (item.element != null && item.element.disabled) {
+          $option.attr('aria-disabled', 'true');
+        } else {
+          $option.attr('aria-disabled', 'false');
+        }
       });
 
     });


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix

The following changes were made

- adds a check within `setClasses` to set "aria-disabled" attribute based on state of `option.disabled`.

Fixes #3347 
