### PR TITLE
fix issue with select2 input focus on tag deletion

### DIFF
--- a/dist/js/select2.js
+++ b/dist/js/select2.js
@@ -1924,7 +1924,7 @@ S2.define('select2/selection/search',[
           var item = $previousChoice.data('data');
 
           self.searchRemoveChoice(item);
-
+          self.$search.val("").blur().focus();
           evt.preventDefault();
         }
       }


### PR DESCRIPTION
This pull request includes a

- Bug fix

The following changes were made

The focus from select2 input was lost to body tag on deleting an option from multiple select list due to which the browser page was navigated to previous page on further backspace key hits. 

The changes were made to keep the focus on select list on deletion of options from multiple select list.