### PR TITLE
Update select2.js

### DIFF
--- a/dist/js/select2.js
+++ b/dist/js/select2.js
@@ -5,7 +5,7 @@
  * Released under the MIT license
  * https://github.com/select2/select2/blob/master/LICENSE.md
  */
-(function (factory) {
+;(function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['jquery'], factory);


### PR DESCRIPTION
Adding ending statement at the start of the code as absence of that causes console error while concatenating files.

This pull request includes a

- Bug fix

The following changes were made

- Added semi column at the starting of the code to avoid concatenation issue with Grunt

If this is related to an existing ticket, include a link to it as well. - NO
