### PR TITLE
easier build from the command line.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist/js/i18n/build.txt
 .sass-cache
+*.log

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-connect": "^0.9.0",
-    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-nodeunit": "~0.3.3",
     "grunt-contrib-qunit": "~0.4.0",
     "grunt-contrib-requirejs": "^0.4.4",
@@ -69,5 +69,13 @@
   "dependencies": {
     "almond": "~0.3.1",
     "jquery-mousewheel": "~3.1.13"
+  },
+  "scripts": {
+    "_comment": "Use 'npm run <scriptName> to run a script. 'npm run grunt <cmd>' will run that grunt command with the prescribed version of grunt, not your global grunt installation.",
+    "clean": "rm -rf dist",
+    "compile": "npm install && grunt compile",
+    "build": "npm run clean && npm run compile && grunt test && grunt minify",
+    "hostDocs": "npm run compile && grunt docs",
+    "grunt": "grunt"
   }
 }


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made
- Added a single build script for development. Run it with `npm run build`. This uses the prescribed version of Grunt installed with `npm install` rather than whatever the user has globally installed at the time.
- Also added a script to run any arbitrary grunt task using the prescribed version of grunt with `npm run grunt <task>'.

If this is related to an existing ticket, include a link to it as well.
#5117
