### PR TITLE
Fix up arrow error when there is no options

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -340,7 +340,8 @@ define([
       var currentIndex = $options.index($highlighted);
 
       // If we are already at te top, don't move further
-      if (currentIndex === 0) {
+      // If no options, currentIndex will be -1
+      if (currentIndex <= 0) {
         return;
       }
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Select2 throws an error when user presses up arrow key and there is no options. I saw that in this case currentIndex in results.js is -1. So I just changed the function exit condition.
- This error is in select2 since 2015 and is causing more than 1k errors per week in our logs. If this is not the correct fix. Please fix it.

https://github.com/select2/select2/issues/3523