### PR TITLE
Fixes #5137 - Switch to select2 inside label tag loses focus

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -63,7 +63,7 @@ define([
     });
 
     container.on('focus', function () {
-      if (!container.isOpen()) {
+      if (!container.hasFocus()) {
         self.$search.focus();
       }
     });


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Focus container only if container does not have focus yet

If this is related to an existing ticket, include a link to it as well.
[#5137](https://github.com/select2/select2/issues/5137)