### PR TITLE
Add scrollAfterSelect as a configurable option for multiselect dropdowns to allow toggling of highlightFirstItem() behaviour

### DIFF
--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -365,7 +365,7 @@ define([
       maximumSelectionLength: 0,
       minimumResultsForSearch: 0,
       selectOnClose: false,
-      scrollOnSelect: true,
+      scrollAfterSelect: true,
       sorter: function (data) {
         return data;
       },

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -365,6 +365,7 @@ define([
       maximumSelectionLength: 0,
       minimumResultsForSearch: 0,
       selectOnClose: false,
+      scrollOnSelect: true,
       sorter: function (data) {
         return data;
       },

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -276,7 +276,10 @@ define([
       }
 
       self.setClasses();
-      self.highlightFirstItem();
+
+      if (self.options.get('scrollAfterSelect')) {
+        self.highlightFirstItem();
+      }
     });
 
     container.on('unselect', function () {
@@ -285,7 +288,10 @@ define([
       }
 
       self.setClasses();
-      self.highlightFirstItem();
+
+      if (self.options.get('scrollAfterSelect')) {
+        self.highlightFirstItem();
+      }
     });
 
     container.on('open', function () {

--- a/tests/results/focusing-tests.js
+++ b/tests/results/focusing-tests.js
@@ -136,3 +136,106 @@ test('results:append does not trigger results:focus', function (assert) {
     }
   });
 });
+
+test('scrollAfterSelect triggers results:focus by default', function (assert) {
+  assert.expect(3);
+
+  var $ = require('jquery');
+
+  var $select = $('<select></select>');
+  var $parent = $('<div></div>');
+
+  var $container = $('<span></span>');
+  var container = new MockContainer();
+
+  $parent.appendTo($('#qunit-fixture'));
+  $select.appendTo($parent);
+
+  var Utils = require('select2/utils');
+  var Options = require('select2/options');
+
+  var Results = require('select2/results');
+
+  var options = new Options({});
+  var results = new Results($select, options);
+
+  // Fake the data adapter for the `setClasses` method
+  results.data = {};
+  results.data.current = function (callback) {
+    callback([{ id: 'test' }]);
+  };
+
+  results.render();
+
+  results.bind(container, $container);
+
+  // check that default for scrollAfterSelect is true
+  assert.equal(options.get('scrollAfterSelect'), true);
+
+  results.append({
+    results: [
+      {
+        id: 'test',
+        text: 'Test'
+      }
+    ]
+  });
+
+  results.on('results:focus', function (params) {
+    assert.equal(params.data.id, 'test');
+    assert.equal(params.data.text, 'Test');
+  });
+
+  container.trigger('select', {});
+});
+
+test('!scrollAfterSelect does not trigger results:focus', function (assert) {
+  assert.expect(1);
+
+  var $ = require('jquery');
+
+  var $select = $('<select></select>');
+  var $parent = $('<div></div>');
+
+  var $container = $('<span></span>');
+  var container = new MockContainer();
+
+  $parent.appendTo($('#qunit-fixture'));
+  $select.appendTo($parent);
+
+  var Utils = require('select2/utils');
+  var Options = require('select2/options');
+
+  var Results = require('select2/results');
+
+  var options = new Options({ scrollAfterSelect: false });
+  var results = new Results($select, options);
+
+  // Fake the data adapter for the `setClasses` method
+  results.data = {};
+  results.data.current = function (callback) {
+    callback([{ id: 'test' }]);
+  };
+
+  results.render();
+
+  results.bind(container, $container);
+
+  // check that default for scrollAfterSelect is false
+  assert.equal(options.get('scrollAfterSelect'), false);
+
+  results.append({
+    results: [
+      {
+        id: 'test',
+        text: 'Test'
+      }
+    ]
+  });
+
+  results.on('results:focus', function () {
+    assert.ok(false, 'The results:focus event was triggered');
+  });
+
+  container.trigger('select', {});
+});


### PR DESCRIPTION
Resolves issue for multiselects using closeOnSelect: false that caused the list of results to scroll to the first selection after each select/unselect. This behaviour was intentional to deal with infinite scroll UI issues but it created an issue with multiselect dropdown boxes of fixed length. This pull request adds a configurable option to toggle between these two desirable behaviours.

This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Added configurable option "scrollOnSelect"
- If set to TRUE multiselect dropdowns will scroll to the first item on the list after "select" or "unselect" events (i.e. for infinite scroll case)
- If set to FALSE highlight will remain on selected item.

I ran into this issue when implementing select2 multiselect dropdowns with a fixed item length. It was confusing to have the focus move to the first item after each select/unselect event.

If this is related to an existing ticket, include a link to it as well.
https://github.com/select2/select2/pull/4869 - is tagged needs more work. I noticed it hasn't been touched for a while so I'm following up on this.
https://github.com/select2/select2/issues/4417 - discussion for where this problem originated. (this particular commit - https://github.com/select2/select2/commit/9f581285d88128b29a01fc1e5fd2d445d610b553)