### PR TITLE
Fix #3320 - Prevent select2:open when clearing selection

### DIFF
--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -30,6 +30,8 @@ define([
   };
 
   AllowClear.prototype._handleClear = function (_, evt) {
+    evt.stopPropagation();
+
     // Ignore the event if it is disabled
     if (this.options.get('disabled')) {
       return;
@@ -42,14 +44,13 @@ define([
       return;
     }
 
-    evt.stopPropagation();
-
     var data = Utils.GetData($clear[0], 'data');
 
     var previousVal = this.$element.val();
     this.$element.val(this.placeholder.id);
 
     var unselectData = {
+      originalEvent: evt,
       data: data
     };
     this.trigger('clear', unselectData);
@@ -75,8 +76,6 @@ define([
     }
 
     this.$element.trigger('change');
-
-    this.trigger('toggle', {});
   };
 
   AllowClear.prototype._handleKeyboardClear = function (_, evt, container) {

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -36,6 +36,8 @@ define([
       'click',
       '.select2-selection__choice__remove',
       function (evt) {
+        evt.stopPropagation();
+
         // Ignore the event if it is disabled
         if (self.options.get('disabled')) {
           return;


### PR DESCRIPTION
This pull request includes a

- [x ] Bug fix

The following changes were made

- Prevent select2:open when clearing selection.
- Include originalEvent in ```clear``` event, the same as it has been included in ```unselect``` event in ```multiple.js``` file

Link to the issue ticket: https://github.com/select2/select2/issues/3320
