### PR TITLE
fix typo in ajax--url

### DIFF
--- a/src/js/select2/options.js
+++ b/src/js/select2/options.js
@@ -78,7 +78,7 @@ define([
       }
 
       $e.attr('ajax--url', Utils.GetData($e[0], 'ajaxUrl'));
-      Utils.StoreData($e[0], 'ajax-Url', Utils.GetData($e[0], 'ajaxUrl'));
+      Utils.StoreData($e[0], 'ajax--url', Utils.GetData($e[0], 'ajaxUrl'));
 	  
     }
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fixed a typo for data-ajax--url 

Made a comment on the offending commit, https://github.com/select2/select2/commit/a1dc7f23d1d5b0913e3954d824e03e4c5e5cdcbc#r26352956

This seems to break custom ajax urls such as for django-select2 when used. 

Version 4.0.5
![4 0 5](https://user-images.githubusercontent.com/2067277/34132940-17975f7c-e407-11e7-9d6f-35925ffcc94b.png)

Version 4.0.6-rc.1
![4 0 6-rc 1](https://user-images.githubusercontent.com/2067277/34132943-19c86e1c-e407-11e7-94e6-cc123b605802.png)

