### PR TITLE
Removing highlightFirstItem calls to fix scroll

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -276,7 +276,6 @@ define([
       }
 
       self.setClasses();
-      self.highlightFirstItem();
     });
 
     container.on('unselect', function () {
@@ -285,7 +284,6 @@ define([
       }
 
       self.setClasses();
-      self.highlightFirstItem();
     });
 
     container.on('open', function () {


### PR DESCRIPTION
Hello,

i'm proposing this change to correct the scroll bug when selecting and unselecting, the scrollbar always return to the first selected item.

it's related to issue : https://github.com/select2/select2/issues/5022

i have removed the calls to highlightFirstItem in select and unselect events in results.js
these calls where added after in v 4.0.0
i have left the call in results:all because it seems it cause a problem with the enter key i don't know why.

tell me what you think of it.

thanks.
  
  
  