### PR TITLE
IE11: seach input on multiselect looses focus on list update from ajax

### DIFF
--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -175,7 +175,10 @@ define([
 
     this.resizeSearch();
     if (searchHadFocus) {
-      this.$search.focus();
+       var searchEl = this.$search
+     	  setTimeout(function() {
+     	        searchEl.focus();
+     	  },0)
     }
   };
 

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -175,10 +175,10 @@ define([
 
     this.resizeSearch();
     if (searchHadFocus) {
-       var searchEl = this.$search
-     	  setTimeout(function() {
+       var searchEl = this.$search;
+     	  window.setTimeout(function() {
      	        searchEl.focus();
-     	  },0)
+     	  },0);
     }
   };
 

--- a/tests/selection/search-tests.js
+++ b/tests/selection/search-tests.js
@@ -132,14 +132,14 @@ test('updating selection does not shift the focus', function (assert) {
 
   assert.equal($search.length, 1, 'The search box disappeared');
 
-  setTimeout(function(){
-  assert.equal(
+  window.setTimeout(function(){
+    assert.equal(
       document.activeElement,
       $search[0],
       'The search did not have focus after the selection was updated'
     );
-    done()
- }, 20)
+    done();
+ }, 20);
   
 });
 

--- a/tests/selection/search-tests.js
+++ b/tests/selection/search-tests.js
@@ -91,6 +91,7 @@ test('backspace will set the search text', function (assert) {
 });
 
 test('updating selection does not shift the focus', function (assert) {
+  var done = assert.async();
   // Check for IE 8, which triggers a false negative during testing
   if (window.attachEvent && !window.addEventListener) {
     // We must expect 0 assertions or the test will fail
@@ -131,11 +132,15 @@ test('updating selection does not shift the focus', function (assert) {
 
   assert.equal($search.length, 1, 'The search box disappeared');
 
+  setTimeout(function(){
   assert.equal(
-    document.activeElement,
-    $search[0],
-    'The search did not have focus after the selection was updated'
-  );
+      document.activeElement,
+      $search[0],
+      'The search did not have focus after the selection was updated'
+    );
+    done()
+ }, 20)
+  
 });
 
 test('the focus event shifts the focus', function (assert) {


### PR DESCRIPTION
This pull request includes a

- [ X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- refocusing of the search input defered in a setTimeout function
- related unit test fixed (added async assertion)

I opened an issue on this:
https://github.com/select2/select2/issues/5193