### PR TITLE
[Fix] attachBody - reposition dropdown on message display

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -31,6 +31,11 @@ define([
           self._positionDropdown();
           self._resizeDropdown();
         });
+
+        container.on('results:message', function () {
+          self._positionDropdown();
+          self._resizeDropdown();
+        });
       }
     });
 


### PR DESCRIPTION
Resolves: https://github.com/select2/select2/issues/4614  
Link to master branch PR (https://github.com/select2/select2/pull/5186)

- Previous behavior: whenever a message is displayed, results are cleared out, but dropdown is not repositioned, resulting in a floating search box based off of last position.   
- Fixed behavior: when a message is displayed, reposition the dropdown
accordingly

This pull request includes a

- [x] Bug fix
- New feature
- Translation

The following changes were made

- Added an event listener on the container for whenever a message is displayed (using the `results:message` event) we reposition/resize the dropdown (due to messages clearing out results, but not taking into account new dropdown height).


  