### PR TITLE
fix: undefined validation, jquery3 compatible

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -161,7 +161,7 @@ define([
 
     // For statically positoned elements, we need to get the element
     // that is determining the offset
-    if ($offsetParent.css('position') === 'static') {
+    if ($offsetParent.css('position') === 'static' && $offsetParent[0].nodeName !== 'BODY') {
       $offsetParent = $offsetParent.offsetParent();
     }
 

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -161,7 +161,8 @@ define([
 
     // For statically positoned elements, we need to get the element
     // that is determining the offset
-    if ($offsetParent.css('position') === 'static' && $offsetParent[0].nodeName !== 'BODY') {
+    if ($offsetParent.css('position') === 'static' && 
+      $offsetParent[0].nodeName !== 'BODY') {
       $offsetParent = $offsetParent.offsetParent();
     }
 

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -121,7 +121,7 @@ define([
 
     this.data.current(function (selected) {
       var selectedIds = $.map(selected, function (s) {
-        return s.id.toString();
+        return s && s.id && s.id.toString() || '';
       });
 
       var $options = self.$results


### PR DESCRIPTION
This pull request includes a

- [X ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

-  fix: Cannot read property 'toString' of undefined
- fix: error JQMIGRATE: jQuery.fn.offset() requires an element connected to a document for jQuery3
-

If this is related to an existing ticket, include a link to it as well.
