### PR TITLE
Fix #4743

### DIFF
--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -83,14 +83,16 @@ define([
       return;
     }
 
-    var $remove = $(
-      '<span class="select2-selection__clear">' +
-        '&times;' +
-      '</span>'
-    );
+    var $remove = this.$selection.find('.select2-selection__clear');
+    if ($remove.length === 0) {
+      $remove = $(
+        '<span class="select2-selection__clear">' +
+          '&times;' +
+        '</span>'
+      );
+      this.$selection.find('.select2-selection__rendered').prepend($remove);
+    }
     $remove.data('data', data);
-
-    this.$selection.find('.select2-selection__rendered').prepend($remove);
   };
 
   return AllowClear;

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -55,7 +55,7 @@ define([
   };
 
   MultipleSelection.prototype.clear = function () {
-    this.$selection.find('.select2-selection__rendered').empty();
+    this.$selection.find('.select2-selection__rendered .select2-selection__choice').remove();
   };
 
   MultipleSelection.prototype.display = function (data, container) {
@@ -102,7 +102,7 @@ define([
 
     var $rendered = this.$selection.find('.select2-selection__rendered');
 
-    Utils.appendMany($rendered, $selections);
+    Utils.prependMany($rendered, $selections);
   };
 
   return MultipleSelection;

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -55,7 +55,8 @@ define([
   };
 
   MultipleSelection.prototype.clear = function () {
-    this.$selection.find('.select2-selection__rendered .select2-selection__choice').remove();
+    this.$selection.find(
+      '.select2-selection__rendered .select2-selection__choice').remove();
   };
 
   MultipleSelection.prototype.display = function (data, container) {

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -170,8 +170,10 @@ define([
 
     decorated.call(this, data);
 
-    if (!$.contains(document.body, this.$searchContainer[0]))
-      this.$selection.find('.select2-selection__rendered').append(this.$searchContainer);
+    if (!$.contains(document.body, this.$searchContainer[0])) {
+      var $rendered = this.$selection.find('.select2-selection__rendered');
+      $rendered.append(this.$searchContainer);
+    }
 
     this.resizeSearch();
     if (searchHadFocus) {

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -170,8 +170,8 @@ define([
 
     decorated.call(this, data);
 
-    this.$selection.find('.select2-selection__rendered')
-                   .append(this.$searchContainer);
+    if (!$.contains(document.body, this.$searchContainer[0]))
+      this.$selection.find('.select2-selection__rendered').append(this.$searchContainer);
 
     this.resizeSearch();
     if (searchHadFocus) {

--- a/src/js/select2/utils.js
+++ b/src/js/select2/utils.js
@@ -272,5 +272,22 @@ define([
     $element.append($nodes);
   };
 
+  // Prepend an array of jQuery nodes to a given element.
+  Utils.prependMany = function ($element, $nodes) {
+    // jQuery 1.7.x does not support $.fn.prepend() with an array
+    // Fall back to a jQuery object collection using $.fn.add()
+    if ($.fn.jquery.substr(0, 3) === '1.7') {
+      var $jqNodes = $();
+
+      $.map($nodes, function (node) {
+        $jqNodes = $jqNodes.add(node);
+      });
+
+      $nodes = $jqNodes;
+    }
+
+    $element.prepend($nodes);
+  };
+
   return Utils;
 });

--- a/tests/selection/multiple-tests.js
+++ b/tests/selection/multiple-tests.js
@@ -70,9 +70,7 @@ test('empty update clears the selection', function (assert) {
 
   var $selection = selection.render();
   var $rendered = $selection.find('.select2-selection__rendered');
-
-  $rendered.text('testing');
-
+  selection.update([{ text: 'testing' }]);
   selection.update([]);
 
   assert.equal($rendered.text(), '');


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- `MultipleSelection.update` removes only `.select2-selection__choice` elements to keep the `<input>` of `Search` on the DOM tree
- `AllowClear.update` appends only once the element, because `MultipleSelection` no longer removes that

Link to the issue ticket: #4743 