### PR TITLE
Do not close on select if Ctrl or Meta (Cmd) keys are being held

### DIFF
--- a/src/js/select2/dropdown/closeOnSelect.js
+++ b/src/js/select2/dropdown/closeOnSelect.js
@@ -21,7 +21,7 @@ define([
     var originalEvent = evt.originalEvent;
 
     // Don't close if the control key is being held
-    if (originalEvent && originalEvent.ctrlKey) {
+    if (originalEvent && (originalEvent.ctrlKey || originalEvent.metaKey)) {
       return;
     }
 


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Handle Meta (Cmd) key the same way as Ctrl when closing select, as described in #3400. Useful for MacOS users.

