### PR TITLE
Replace Deprecated .blur() and .focus() Calls

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -60,7 +60,7 @@ define([
       self.$search.attr('tabindex', -1);
 
       self.$search.val('');
-      self.$search.blur();
+      self.$search.trigger('blur');
     });
 
     container.on('focus', function () {

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -49,10 +49,10 @@ define([
     container.on('open', function () {
       self.$search.attr('tabindex', 0);
 
-      self.$search.focus();
+      self.$search.trigger('focus');
 
       window.setTimeout(function () {
-        self.$search.focus();
+        self.$search.trigger('focus');
       }, 0);
     });
 
@@ -65,7 +65,7 @@ define([
 
     container.on('focus', function () {
       if (!container.isOpen()) {
-        self.$search.focus();
+        self.$search.trigger('focus');
       }
     });
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

All event shorthand methods have been deprecated as of jQuery 3.3.0 ([#3214](https://github.com/jquery/jquery/issues/3214), [022b69a4](https://github.com/jquery/jquery/commit/022b69a44e42684bdd0029dd456bedb3b495cc24))

- Replaced calls to `.blur()` with `.trigger('blur')`
- Replaced calls to `.focus()` with `.trigger('focus')`

The change is fully backwards compatible across all versions of jQuery