### PR TITLE
Changing the close event from body to document

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -116,7 +116,7 @@ define([
   BaseSelection.prototype._attachCloseHandler = function (container) {
     var self = this;
 
-    $(document.body).on('mousedown.select2.' + container.id, function (e) {
+    $(document).on('mousedown.select2.' + container.id, function (e) {
       var $target = $(e.target);
 
       var $select = $target.closest('.select2');
@@ -138,7 +138,7 @@ define([
   };
 
   BaseSelection.prototype._detachCloseHandler = function (container) {
-    $(document.body).off('mousedown.select2.' + container.id);
+    $(document).off('mousedown.select2.' + container.id);
   };
 
   BaseSelection.prototype.position = function ($selection, $container) {


### PR DESCRIPTION
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fixing issue #5249 by changing the close event from document.body to document
