### PR TITLE
add "computedstyle" option for calculating the select width

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -162,6 +162,12 @@ define([
       return null;
     }
 
+    if (method == 'computedstyle') {
+      var computedStyle = window.getComputedStyle($element[0]);
+
+      return computedStyle.width;
+    }
+
     return method;
   };
 

--- a/tests/options/width-tests.js
+++ b/tests/options/width-tests.js
@@ -64,3 +64,39 @@ test('resolve falls back to element if there is no style', function (assert) {
 
   assert.equal(width, '500px');
 });
+
+test('resolve fails if parent element is invisible', function (assert) {
+  var $style = $(
+    '<style type="text/css">.css-set-width { width: 500px; }</style>'
+  );
+  var $test = $(
+    '<div style="display:none;">' +
+      '<select class="css-set-width"></select>' +
+    '</div>'
+  );
+
+  $('#qunit-fixture').append($style);
+  $('#qunit-fixture').append($test);
+
+  var width = select._resolveWidth($test.find('select'), 'resolve');
+
+  assert.notEqual(width, '500px');
+});
+
+test('computedstyle gets the style if parent is invisible', function (assert) {
+  var $style = $(
+    '<style type="text/css">.css-set-width { width: 500px; }</style>'
+  );
+  var $test = $(
+    '<div style="display:none;">' +
+      '<select class="css-set-width"></select>' +
+    '</div>'
+  );
+
+  $('#qunit-fixture').append($style);
+  $('#qunit-fixture').append($test);
+
+  var width = select._resolveWidth($test.find('select'), 'computedstyle');
+
+  assert.equal(width, '500px');
+});


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- add new "computedstyle" option for calculating the select width
- added test
- also added test to demonstrate that "resolve" does not work if parent is invisible

If this is related to an existing ticket, include a link to it as well.
fixes #3278