### PR TITLE
Fix pluralization

### DIFF
--- a/src/js/select2/i18n/fr.js
+++ b/src/js/select2/i18n/fr.js
@@ -8,20 +8,20 @@ define(function () {
       var overChars = args.input.length - args.maximum;
 
       return 'Supprimez ' + overChars + ' caractère' +
-        (overChars > 1) ? 's' : '';
+        ((overChars > 1) ? 's' : '');
     },
     inputTooShort: function (args) {
       var remainingChars = args.minimum - args.input.length;
 
       return 'Saisissez au moins ' + remainingChars + ' caractère' +
-        (remainingChars > 1) ? 's' : '';
+        ((remainingChars > 1) ? 's' : '');
     },
     loadingMore: function () {
       return 'Chargement de résultats supplémentaires…';
     },
     maximumSelected: function (args) {
       return 'Vous pouvez seulement sélectionner ' + args.maximum +
-        ' élément' + (args.maximum > 1) ? 's' : '';
+        ' élément' + ((args.maximum > 1) ? 's' : '');
     },
     noResults: function () {
       return 'Aucun résultat trouvé';


### PR DESCRIPTION
The test return always 's' in translations : inputTooLong, inputTooShort, maximumSelected

This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [x] Translation

The following changes were made
- fix the test for pluralization

If this is related to an existing ticket, include a link to it as well.
