### PR TITLE
When the select2 instance is multiple with ajax and you click with mouse twice or more in the field, the focus stay in this field forever.

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -82,10 +82,7 @@ define([
       self.$selection.removeAttr('aria-owns');
 
       self.$selection.focus();
-      window.setTimeout(function () {
-        self.$selection.focus();
-      }, 0);
-
+    
       self._detachCloseHandler(container);
     });
 


### PR DESCRIPTION
@ivaynberg @alexweissman 

When the select2 instance is multiple with ajax and you click with mouse twice or more in the field, the focus stay in this field forever.