### PR TITLE
Fix up arrow error when there are no options

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -339,8 +339,8 @@ define([
 
       var currentIndex = $options.index($highlighted);
 
-      // If we are already at te top, don't move further
-      if (currentIndex === 0) {
+      // If we are already at the top, don't move further
+      if (currentIndex <= 0) {
         return;
       }
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Also escape results:previous event if currentIndex is less than 0.

If this is related to an existing ticket, include a link to it as well.
