### PR TITLE
Update Vietnamese (vi) translation

### DIFF
--- a/src/js/select2/i18n/vi.js
+++ b/src/js/select2/i18n/vi.js
@@ -4,18 +4,15 @@ define(function () {
     inputTooLong: function (args) {
       var overChars = args.input.length - args.maximum;
 
-      var message = 'Vui lòng nhập ít hơn ' + overChars + ' ký tự';
-
-      if (overChars != 1) {
-        message += 's';
-      }
+      var message = 'Vui lòng xóa bớt ' + overChars + ' ký tự';
 
       return message;
     },
     inputTooShort: function (args) {
       var remainingChars = args.minimum - args.input.length;
 
-      var message = 'Vui lòng nhập nhiều hơn ' + remainingChars + ' ký tự';
+      var message = 'Vui lòng nhập thêm từ ' + remainingChars +
+                    ' ký tự trở lên';
 
       return message;
     },
@@ -33,7 +30,7 @@ define(function () {
     searching: function () {
       return 'Đang tìm…';
     },
-    removeAllItems: function () {     
+    removeAllItems: function () {
       return 'Xóa tất cả các mục';
     }
   };


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [x] Translation

The following changes were made

- Removed the plural logic adding `s` in `inputTooLong` function
- Update the message for minimum input length: The original translation can be misunderstood as `Please enter more than {overChars} characters` a.k.a `Minimum {overChars} characters`, not `Please enter more {overChars} characters to satisfy the minimum length requirement`
- Update the message for maximum input length: The original translation can be misunderstood as `Please enter less than {overChars} characters` a.k.a `Maximum {overChars} characters`, not `Please enter less {overChars} characters to satisfy the maximum length requirement`

If this is related to an existing ticket, include a link to it as well.
