### PR TITLE
Ensure data.id is a string in SelectAdapter unselect

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -90,7 +90,7 @@ define([
       for (var d = 0; d < currentData.length; d++) {
         var id = currentData[d].id;
 
-        if (id !== data.id && $.inArray(id, val) === -1) {
+        if (id !== data.id.toString() && $.inArray(id, val) === -1) {
           val.push(id);
         }
       }


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- We ensure that `data.id` is a string in `SelectAdapter.prototype.unselect`. This fixes an issue where `currentData[d].id` (previously normalized as a _string_) was not properly compared to an ajax-backed `data.id` (often an _integer_ from a JSON result).

Fixes #4845.