### PR TITLE
Fix aborting ajax request

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -79,11 +79,11 @@ define([
         }
 
         callback(results);
-      }, function () {
+      }, function ($req) {
         // Attempt to detect if a request was aborted
         // Only works if the transport exposes a status property
-        if ('status' in $request &&
-            ($request.status === 0 || $request.status === '0')) {
+        if ('status' in $req &&
+            ($req.status === 0 || $req.status === '0')) {
           return;
         }
 


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix

The following changes were made

- Handle abortion of ajax request

If this is related to an existing ticket https://github.com/select2/select2/issues/4205 and commit https://github.com/select2/select2/commit/cfb66f5e4f71a56c46a6890c5dde4b7f24f11fa8

# Description

I am not able to abort a second ajax request. In my case I want the list of options to be asynchronously loaded. As the user may not use the dropdown, I dont want the sever to retrieve the whole list on each page load. As I only need the list to be loaded once, I need to abort the second ajax request.

# Error

Reproducible on Select2 4.0.6-rc.1.
https://jsfiddle.net/h704wejy/1/

In Firefox (OSX), when I open the dropdown the first time, the options are loaded. When I open the options in the second time, I'm expecting the ajax request to be aborted. But instead I get this error in the console:

```
TypeError: right-hand side of 'in' should be an object, got undefined[Learn More] select2.js:3581:1
request/$request<
http://localhost/js/select2/js/select2.js:3581:1
k
http://localhost/js/jquery-1.8.2.min.js:2:16915
add
http://localhost/js/jquery-1.8.2.min.js:2:17234
transport
http://localhost/js/select2/js/select2.js:3525:9
request
http://localhost/js/select2/js/select2.js:3564:22
S2</</AjaxAdapter.prototype.query
http://localhost/js/select2/js/select2.js:3601:7
S2</</Select2.prototype._registerEvents/<
http://localhost/js/select2/js/select2.js:5448:7
S2</</Observable.prototype.invoke
http://localhost/js/select2/js/select2.js:655:7
S2</</Observable.prototype.trigger
http://localhost/js/select2/js/select2.js:645:7
S2</</Select2.prototype.trigger
http://localhost/js/select2/js/select2.js:5591:5
S2</</Select2.prototype.open
http://localhost/js/select2/js/select2.js:5611:5
S2</</Select2.prototype.toggleDropdown
http://localhost/js/select2/js/select2.js:5602:7
S2</</Select2.prototype._registerSelectionEvents/<
http://localhost/js/select2/js/select2.js:5388:7
S2</</Observable.prototype.invoke
http://localhost/js/select2/js/select2.js:655:7
S2</</Observable.prototype.trigger
http://localhost/js/select2/js/select2.js:645:7
S2</</SingleSelection.prototype.bind/<
http://localhost/js/select2/js/select2.js:1598:7
dispatch
http://localhost/js/jquery-1.8.2.min.js:2:37955
h
http://localhost/js/jquery-1.8.2.min.js:2:33851
```

# In the code

When I look at https://github.com/select2/select2/commit/cfb66f5e4f71a56c46a6890c5dde4b7f24f11fa8:
```
var $request = options.transport(options, function (data) {
  ...
}, function () {
  // Attempt to detect if a request was aborted
  // Only works if the transport exposes a status property
  if ('status' in $request &&
      ($request.status === 0 || $request.status === '0')) {
    return;
  }

  ...
});
```
I dont see how `$request` can be set in the error handler. This PR solves this issue in my case.