### PR TITLE
More suitable spelling `ещё` instead of `еще`

### DIFF
--- a/src/js/select2/i18n/ru.js
+++ b/src/js/select2/i18n/ru.js
@@ -31,7 +31,7 @@ define(function () {
     inputTooShort: function (args) {
       var remainingChars = args.minimum - args.input.length;
 
-      var message = 'Пожалуйста, введите еще хотя бы ' + remainingChars +
+      var message = 'Пожалуйста, введите ещё хотя бы ' + remainingChars +
         ' символ';
 
       message += ending(remainingChars, '', 'a', 'ов');


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [x] Translation

The following changes were made:

- More suitable spelling `ещё` instead of `еще` in Russian translation.

