### PR TITLE
fix page scroll when used inside a jquery ui dialog

### DIFF
--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -47,6 +47,9 @@ define([
       self.trigger('toggle', {
         originalEvent: evt
       });
+
+      // Stop propagation of event
+      return false;
     });
 
     this.$selection.on('focus', function (evt) {


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
Fix issue #5408 

This commit fixes the page scrolling when the select2 element is clicked or a selection is made. It does *not* fix the scrolling when the user clicks outside the select2 element to close the dropdown, because both select2 and dialog listen on the mousedown event on the body element. The dialog's callback is executed first because it's registered first, so it cannot be cancelled.