### PR TITLE
fix result option highlighting for screenreaders

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -308,6 +308,9 @@ define([
       self.$results.attr('aria-expanded', 'false');
       self.$results.attr('aria-hidden', 'true');
       self.$results.removeAttr('aria-activedescendant');
+
+      // remove aria-activedescendant from the search input for screen readers
+      this.dropdown.$search.removeAttr('aria-activedescendant');
     });
 
     container.on('results:toggle', function () {
@@ -360,6 +363,9 @@ define([
 
       var $next = $options.eq(nextIndex);
 
+      // update the search input's aria-activedescendant for screen readers
+	  this.dropdown.$search.attr('aria-activedescendant', $next.attr('id'));
+
       $next.trigger('mouseenter');
 
       var currentOffset = self.$results.offset().top;
@@ -388,6 +394,9 @@ define([
       }
 
       var $next = $options.eq(nextIndex);
+
+      // update the search input's aria-activedescendant for screen readers
+      this.dropdown.$search.attr('aria-activedescendant', $next.attr('id'));
 
       $next.trigger('mouseenter');
 


### PR DESCRIPTION
Addresses #3735 and pull request [#3821](https://github.com/select2/select2/pull/3821)

Not very familiar with the codebase and didn't have much time. Hope this helps move the accessibility improvements in the right direction.

From what I can deduce from various examples`aria-activedescendent` should be updated to the id of the current highlighted result. Also, `aria-activedescendent` is on the `input` in the examples.

Examples:
- http://oaa-accessibility.org/example/11/
- https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html