### PR TITLE
Multiselect unselect by enter

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -276,7 +276,7 @@ define([
 
   Select2.prototype._registerEvents = function () {
     var self = this;
-    
+
     this.on('focus', function () {
       self.$container.addClass('select2-container--focus');
 
@@ -346,7 +346,12 @@ define([
 
           evt.preventDefault();
         } else if (key === KEYS.ENTER) {
-          self.trigger('results:select', {});
+
+          if (self.options.get('unselectByEnter')) {
+            self.trigger('results:toggle', {});
+          } else {
+            self.trigger('results:select', {});
+          }
 
           evt.preventDefault();
         } else if ((key === KEYS.SPACE && evt.ctrlKey)) {

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -366,7 +366,7 @@ define([
       minimumResultsForSearch: 0,
       selectOnClose: false,
       scrollAfterSelect: false,
-      unselectByEnter: true,
+      unselectByEnter: false,
       sorter: function (data) {
         return data;
       },

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -366,6 +366,7 @@ define([
       minimumResultsForSearch: 0,
       selectOnClose: false,
       scrollAfterSelect: false,
+      unselectByEnter: true,
       sorter: function (data) {
         return data;
       },


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Added configurable option "unselectByEnter"
- If set to TRUE it is possible to unselect options by pressing the Enter key

If this is related to an existing ticket, include a link to it as well.
#4048 - Multiselect unselect by ENTER