### PR TITLE
don't cache optgroup data

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -238,7 +238,10 @@ define([
     data = this._normalizeItem(data);
     data.element = $option[0];
 
-    Utils.StoreData($option[0], 'data', data);
+    // don't cache optgroups data, we need to catch changes inside its children
+    if($option.is('option')) {
+      Utils.StoreData($option[0], 'data', data);
+    }
 
     return data;
   };


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix

The following changes were made

data optgroups is not cached anymore

Fixing issue #3604: