### PR TITLE
Move almond and jquery-mousewheel to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     }
   },
   "devDependencies": {
+    "almond": "~0.3.1",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.4.0",
@@ -57,10 +58,9 @@
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.0",
     "grunt-sass": "^1.0.0",
+    "jquery-mousewheel": "~3.1.13",
     "node-sass": "^4.5.3"
   },
   "dependencies": {
-    "almond": "~0.3.1",
-    "jquery-mousewheel": "~3.1.13"
   }
 }


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation
- [x] Miscellaneous

The following changes were made

These two are required at build time to generate the full builds
of Select2 (for jQuery Mousewheel) and to inject the AMD loader
(for Almond.js). They are not required for anyone who depends on
Select2, since jQuery Mousewheel is an optional dependency.

This may result in some people needing to add jQuery Mousewheel to
their projects as a required dependency, if they were expecting
it to be added by Select2 before.

Fixes #5450. Closes #5475.