### PR TITLE
Fix width becoming fixed to 0 if initialized when hidden by parent element

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -135,7 +135,9 @@ define([
       var elementWidth = $element.outerWidth(false);
 
       if (elementWidth <= 0) {
-        return 'auto';
+
+        //May happen if the element is hidden, due to its parent.
+        return '100%';
       }
 
       return elementWidth + 'px';

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -214,7 +214,9 @@ define([
     var width = '';
 
     if (this.$search.attr('placeholder') !== '') {
-      width = this.$selection.find('.select2-selection__rendered').innerWidth();
+
+      //Default to 100% if the width is 0, which may happen if the element is hidden due to its parent.
+      width = this.$selection.find('.select2-selection__rendered').innerWidth() || "100%";
     } else {
       var minimumWidth = this.$search.val().length + 1;
 


### PR DESCRIPTION
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fixed resizeSearch() setting width to 0 due to innerWidth() returning 0 when the element is hidden due to its parent element being hidden. If innerWidth() returns 0, then resizeSearch() shall return "100%" to default to the maximum possible width.
- Changed _resolveWidth() returning "auto" to "100%", so that it will retain its default behaviour of utilizing all maximum width.

If this is related to an existing ticket, include a link to it as well.
Related to #3292, #3817, #3278, #291, plus other duplicates.

Credit for the fix to resizeSearch() goes to @Brandonhall of #3292.

I know that this may not give exactly the same result as when select2 is initialized while it is visible, but I really cannot tell what is a betterchoice than defaulting to 100% width. This is already 7 years old, so I hope it'll be fixed someday.

Between some offered solutions like #3292 and #4898, jQuery used to have a bug that resulted in width becoming 100px.

Originally posted by me in #3817:

> As for why: up to this jQuery Github PR, jQuery had a problem with computing the width of elements under specific conditions. In this example, it fails to compute the width of the element because the jQuery outerWidth (similar for innerHeight, innerWidth, height, width, outerHeight and outerWidth) function will call the width cssHook, which in turn calls getWidthOrHeight(). getWidthOrHeight() may obtain a width in %, which is then returned as it is. The width function does not check what was returned and passes it through parseFloat, which results in the 100% becoming just 100.
In newer jQuery versions, this bug was solved, but the width of such a hidden element becomes 0.
>
> Perhaps this was why #3292 could have worked, while yet the author of #4898 disagreed (the jQuery PR was still recent back then).

As for test cases: I don't know how to test for this because it is faulty behaviour, not that the logic was wrong.
#5259 contains a test case that will exhibit this bug. You can refer to this fiddle as well: https://jsfiddle.net/NozomiTypeR/6pLzy1ak/44/