### PR TITLE
removed select2-selection__placeholder from _multiple.scss

### DIFF
--- a/src/scss/theme/default/_multiple.scss
+++ b/src/scss/theme/default/_multiple.scss
@@ -16,14 +16,6 @@
     }
   }
 
-  .select2-selection__placeholder {
-    color: #999;
-
-    margin-top: 5px;
-
-    float: left;
-  }
-
   .select2-selection__clear {
     cursor: pointer;
     float: right;
@@ -63,7 +55,7 @@
 
 &[dir="rtl"] {
   .select2-selection--multiple {
-    .select2-selection__choice, .select2-selection__placeholder, .select2-search--inline {
+    .select2-selection__choice, .select2-search--inline {
       float: right;
     }
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
1. removed select2-selection__placeholder from _multiple.scss

If this is related to an existing ticket, include a link to it as well.
fixes issue: #5094 