### PR TITLE
Update base.js

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -80,10 +80,6 @@ define([
       self.$selection.attr('aria-expanded', 'false');
       self.$selection.removeAttr('aria-activedescendant');
       self.$selection.removeAttr('aria-owns');
-
-      window.setTimeout(function () {
-        self.$selection.focus();
-      }, 0);
     
       self._detachCloseHandler(container);
     });


### PR DESCRIPTION
allow focus to other input box when the select2 opened.
（Originally, two clicks were needed to focus on the new input box.）

