### PR TITLE
Prevent too many items.

### DIFF
--- a/src/js/select2/selection/eventRelay.js
+++ b/src/js/select2/selection/eventRelay.js
@@ -41,6 +41,26 @@ define([
       }
 
       params.prevented = evt.isDefaultPrevented();
+
+      /*
+       * Display the corresponding message when maximumSelectionLength is
+       * reached. This will prevent the user from adding too many items by
+       * holding the ctrl key or when closeOnSelect is false.
+       * This fixes #3514 and #3860.
+       */
+      var maximumSelectionLength = self.options.get('maximumSelectionLength');
+      var values = self.$element.val() || [];
+  
+      if (!params.prevented && name === 'selecting' &&
+        maximumSelectionLength > 0 &&
+        values.length+1 >= maximumSelectionLength) {
+          self.trigger('results:message', {
+            message: 'maximumSelected',
+            args: {
+              maximum: maximumSelectionLength
+            }
+        });
+      }
     });
   };
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- When selecting a new item, the eventRelay will trigger the maximumSelected message if the maximumSelectionLength is reached. This will prevent the user from adding more than maximumSelectionLength items, in case he is holding ctrl or closeOnSelect is false.

This will fix these issues:
#3514  
#3860 