### PR TITLE
Add createTagOnMatch option to create a tag even if there is a matching item

### DIFF
--- a/src/js/select2/data/tags.js
+++ b/src/js/select2/data/tags.js
@@ -10,6 +10,14 @@ define([
       this.createTag = createTag;
     }
 
+    this.createTagOnMatch = false;
+
+    var createTagOnMatch = options.get('createTagOnMatch');
+
+    if (createTagOnMatch !== undefined) {
+        this.createTagOnMatch = !!createTagOnMatch;
+    }
+
     var insertTag = options.get('insertTag');
 
     if (insertTag !== undefined) {
@@ -60,13 +68,17 @@ define([
 
         if (checkText || checkChildren) {
           if (child) {
-            return false;
+            if (!self.createTagOnMatch) {
+              return false;
+            }
           }
 
           obj.data = data;
           callback(obj);
 
-          return;
+          if (!self.createTagOnMatch) {
+            return;
+          }
         }
       }
 

--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -82,7 +82,20 @@ test('does not create option if text is same but lowercase', function (assert) {
 test('creates option if text is same but createTagOnMatch is true', function (assert) {
   var options = new Options({
     tags: true,
-    createTagOnMatch: true
+    createTagOnMatch: 1,
+    createTag: function (params) {
+      var term = $.trim(params.term);
+
+      if (term === '') {
+        return null;
+      }
+
+      return {
+        id: '_' + term + '_',
+        text: '*' + term + '*',
+        newTag: true
+      }
+    }
   });
   var data = new SelectTags($('#qunit-fixture .single'), options);
 
@@ -93,7 +106,7 @@ test('creates option if text is same but createTagOnMatch is true', function (as
     console.log('data.results.length');
     console.log(data.results.length);
 
-    assert.equal(data.results.length, 2);
+    assert.equal(data.results.length, 1);
 
     var item0 = data.results[0],
         item1 = data.results[1];
@@ -108,8 +121,8 @@ test('creates option if text is same but createTagOnMatch is true', function (as
       console.log('item1[' + k + ']', item1[k]);
     }
         
-    assert.equal(item.id, 'one');
-    assert.equal(item.text, 'one');
+    assert.equal(item0.id, 'one');
+    assert.equal(item0.text, 'one');
   });
 });
 

--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -80,7 +80,8 @@ test('does not create option if text is same but lowercase', function (assert) {
 });
 
 test('creates option if text is same but createTagOnMatch is true', function (assert) {
-  var options = new Options({
+  console.log('=== inside test ===');
+  var options_createTagOnMatch = new Options({
     tags: true,
     createTagOnMatch: 1,
     createTag: function (params) {
@@ -97,12 +98,12 @@ test('creates option if text is same but createTagOnMatch is true', function (as
       }
     }
   });
-  var data = new SelectTags($('#qunit-fixture .single'), options);
+  var data = new SelectTags($('#qunit-fixture .single'), options_createTagOnMatch);
 
   data.query({
     term: 'one'
   }, function (data) {
-    console.log('inside test');
+    console.log('=== inside query results ===');
     console.log('data.results.length');
     console.log(data.results.length);
 

--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -90,14 +90,24 @@ test('creates option if text is same but createTagOnMatch is true', function (as
     term: 'one'
   }, function (data) {
     console.log('inside test');
-    console.log('data.results');
-    console.log(data.results);
     console.log('data.results.length');
     console.log(data.results.length);
-    assert.equal(data.results.length, 1);
 
-    var item = data.results[0];
+    assert.equal(data.results.length, 2);
 
+    var item0 = data.results[0],
+        item1 = data.results[1];
+    console.log('item0');
+    console.log(item0);
+    for ( var k in item0 ) {
+      console.log('item0[' + k + ']', item0[k]);
+    }
+    console.log('item1');
+    console.log(item1);
+    for ( var k in item1 ) {
+      console.log('item1[' + k + ']', item1[k]);
+    }
+        
     assert.equal(item.id, 'one');
     assert.equal(item.text, 'one');
   });

--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -82,7 +82,7 @@ test('does not create option if text is same but lowercase', function (assert) {
 test('creates option if createTagOnMatch is true', function (assert) {
   assert.expect(8);
 
-  var optionsCreateTagOnMatch = new Options({
+  var newOptions = new Options({
     tags: true,
     createTagOnMatch: 1,
     createTag: function (params) {
@@ -96,26 +96,26 @@ test('creates option if createTagOnMatch is true', function (assert) {
         id: '_' + term + '_',
         text: '*' + term + '*',
         newTag: true
-      }
+      };
     }
   });
 
-  var data = new SelectTags($('#qunit-fixture .single'), optionsCreateTagOnMatch);
+  var data = new SelectTags($('#qunit-fixture .single'), newOptions);
 
-  var num_query_answers = 0;
+  var numQueryAnswers = 0;
 
   data.query({
     term: 'One'
   }, function (data) {
-    num_query_answers += 1;
+    numQueryAnswers += 1;
 
-    if ( num_query_answers == 1 ) {
+    if ( numQueryAnswers == 1 ) {
       assert.equal(data.results.length, 1);
       return;
-    } else if ( num_query_answers == 2 ) {
+    } else if ( numQueryAnswers == 2 ) {
       assert.equal(data.results.length, 2);
     } else {
-      assert.equal(true, false, 'The query should never return more than 2 answers.');
+      assert.equal(true, false, "Query should't return more than 2 answers.");
     }
 
     var item0 = data.results[0];

--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -80,6 +80,8 @@ test('does not create option if text is same but lowercase', function (assert) {
 });
 
 test('creates option if text is same but createTagOnMatch is true', function (assert) {
+  assert.expect(8);
+
   console.log('=== inside test ===');
   var options_createTagOnMatch = new Options({
     tags: true,
@@ -100,34 +102,24 @@ test('creates option if text is same but createTagOnMatch is true', function (as
   });
   var data = new SelectTags($('#qunit-fixture .single'), options_createTagOnMatch);
 
+  var num_query_answers = 0;
   data.query({
     term: 'One'
-  }, function (data, bbb, ccc, ddd, eee) {
+  }, function (data) {
+    num_query_answers += 1;
+
     console.log('=== inside query results ===');
-    if ( typeof bbb !== 'undefined' ) {
-      console.log('typeof bbb', typeof bbb);
-      console.log('bbb');
-      console.log(bbb);
-    }
-    if ( typeof ccc !== 'undefined' ) {
-      console.log('typeof ccc', typeof ccc);
-      console.log('ccc');
-      console.log(ccc);
-    }
-    if ( typeof ddd !== 'undefined' ) {
-      console.log('typeof ddd', typeof ddd);
-      console.log('ddd');
-      console.log(ddd);
-    }
-    if ( typeof eee !== 'undefined' ) {
-      console.log('typeof eee', typeof eee);
-      console.log('eee');
-      console.log(eee);
-    }
     console.log('data.results.length');
     console.log(data.results.length);
 
-    assert.equal(data.results.length, 1);
+    if ( num_query_answers == 1 ) {
+      assert.equal(data.results.length, 1);
+      return;
+    } else if ( num_query_answers == 2 ) {
+      assert.equal(data.results.length, 2);
+    } else {
+      assert.equal(true, false);
+    }
 
     var item0 = data.results[0],
         item1 = data.results[1];
@@ -141,9 +133,13 @@ test('creates option if text is same but createTagOnMatch is true', function (as
     for ( var k in item1 ) {
       console.log('item1[' + k + ']', item1[k]);
     }
-        
-    assert.equal(item0.id, 'one');
-    assert.equal(item0.text, 'one');
+    
+    assert.equal(item0.id, '_One_');
+    assert.equal(item0.text, '*One*');
+    assert.equal(item0.newTag, true);
+    assert.equal(item1.id, 'One');
+    assert.equal(item1.text, 'One');
+    assert.equal(typeof item1.newTag, 'undefined');
   });
 });
 

--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -79,6 +79,30 @@ test('does not create option if text is same but lowercase', function (assert) {
   });
 });
 
+test('creates option if text is same but createTagOnMatch is true', function (assert) {
+  var options = new Options({
+    tags: true,
+    createTagOnMatch: true
+  });
+  var data = new SelectTags($('#qunit-fixture .single'), options);
+
+  data.query({
+    term: 'one'
+  }, function (data) {
+    console.log('inside test');
+    console.log('data.results');
+    console.log(data.results);
+    console.log('data.results.length');
+    console.log(data.results.length);
+    assert.equal(data.results.length, 1);
+
+    var item = data.results[0];
+
+    assert.equal(item.id, 'one');
+    assert.equal(item.text, 'one');
+  });
+});
+
 test('does not trigger for additional pages', function (assert) {
   var data = new SelectTags($('#qunit-fixture .single'), options);
 

--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -101,9 +101,29 @@ test('creates option if text is same but createTagOnMatch is true', function (as
   var data = new SelectTags($('#qunit-fixture .single'), options_createTagOnMatch);
 
   data.query({
-    term: 'one'
-  }, function (data) {
+    term: 'One'
+  }, function (data, bbb, ccc, ddd, eee) {
     console.log('=== inside query results ===');
+    if ( typeof bbb !== 'undefined' ) {
+      console.log('typeof bbb', typeof bbb);
+      console.log('bbb');
+      console.log(bbb);
+    }
+    if ( typeof ccc !== 'undefined' ) {
+      console.log('typeof ccc', typeof ccc);
+      console.log('ccc');
+      console.log(ccc);
+    }
+    if ( typeof ddd !== 'undefined' ) {
+      console.log('typeof ddd', typeof ddd);
+      console.log('ddd');
+      console.log(ddd);
+    }
+    if ( typeof eee !== 'undefined' ) {
+      console.log('typeof eee', typeof eee);
+      console.log('eee');
+      console.log(eee);
+    }
     console.log('data.results.length');
     console.log(data.results.length);
 

--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -79,11 +79,10 @@ test('does not create option if text is same but lowercase', function (assert) {
   });
 });
 
-test('creates option if text is same but createTagOnMatch is true', function (assert) {
+test('creates option if createTagOnMatch is true', function (assert) {
   assert.expect(8);
 
-  console.log('=== inside test ===');
-  var options_createTagOnMatch = new Options({
+  var optionsCreateTagOnMatch = new Options({
     tags: true,
     createTagOnMatch: 1,
     createTag: function (params) {
@@ -100,17 +99,15 @@ test('creates option if text is same but createTagOnMatch is true', function (as
       }
     }
   });
-  var data = new SelectTags($('#qunit-fixture .single'), options_createTagOnMatch);
+
+  var data = new SelectTags($('#qunit-fixture .single'), optionsCreateTagOnMatch);
 
   var num_query_answers = 0;
+
   data.query({
     term: 'One'
   }, function (data) {
     num_query_answers += 1;
-
-    console.log('=== inside query results ===');
-    console.log('data.results.length');
-    console.log(data.results.length);
 
     if ( num_query_answers == 1 ) {
       assert.equal(data.results.length, 1);
@@ -118,25 +115,15 @@ test('creates option if text is same but createTagOnMatch is true', function (as
     } else if ( num_query_answers == 2 ) {
       assert.equal(data.results.length, 2);
     } else {
-      assert.equal(true, false);
+      assert.equal(true, false, 'The query should never return more than 2 answers.');
     }
 
-    var item0 = data.results[0],
-        item1 = data.results[1];
-    console.log('item0');
-    console.log(item0);
-    for ( var k in item0 ) {
-      console.log('item0[' + k + ']', item0[k]);
-    }
-    console.log('item1');
-    console.log(item1);
-    for ( var k in item1 ) {
-      console.log('item1[' + k + ']', item1[k]);
-    }
-    
+    var item0 = data.results[0];
     assert.equal(item0.id, '_One_');
     assert.equal(item0.text, '*One*');
     assert.equal(item0.newTag, true);
+    
+    var item1 = data.results[1];
     assert.equal(item1.id, 'One');
     assert.equal(item1.text, 'One');
     assert.equal(typeof item1.newTag, 'undefined');

--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -115,7 +115,7 @@ test('creates option if createTagOnMatch is true', function (assert) {
     } else if ( numQueryAnswers == 2 ) {
       assert.equal(data.results.length, 2);
     } else {
-      assert.equal(true, false, "Query should't return more than 2 answers.");
+      assert.equal(true, false, 'Query must return 2 answers.');
     }
 
     var item0 = data.results[0];


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Added option `createTagOnMatch`, which defaults to `false`.

Before returning from the query wrapper when an item matches the query, it checks that `createTagOnMatch` is not `true`.

- Added a test to make sure that when not existing everything is still the same and when existing, the new tag is returned.
