### PR TITLE
 Fix lost of input focus when searching tags entries 

### DIFF
--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -178,7 +178,7 @@ define([
       var isTagInput = this.$element.find('[data-select2-tag]').length;
       if (isTagInput) {
         // fix IE11 bug where tag input lost focus
-        this.$element.focus();
+        this.$element[0].focus();
       } else {
         this.$search.focus();
       }

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -255,3 +255,34 @@ test('removing a selected option changes the value', function (assert) {
 
   syncDone();
 });
+
+test('searching tags does not loose focus', function (assert) {
+  assert.expect(1);
+
+  var asyncDone = assert.async();
+  var $ = require('jquery');
+  var Options = require('select2/options');
+  var Select2 = require('select2/core');
+
+  var $select = $(
+    '<select multiple="multiple">' +
+    '  <option value="1">Text1</option>' +
+    ' <option value="2">Text2</option>' +
+    '</select>'
+  );
+
+  $('#qunit-fixture').append($select);
+
+  var select = new Select2($select, {tags: true});
+
+  var inputEl = select.selection.$search[0];
+  inputEl.focus();
+
+  select.on('selection:update', function() {
+    assert.equal(document.activeElement, inputEl);
+    asyncDone();
+  });
+
+  select.selection.trigger('query', {term: 'f'});
+  select.selection.trigger('query', {term: 'ff'});
+});


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Uses native focus method instead of jquery one in Search adapter
- Add a test that fails without the fix

If this is related to an existing ticket, include a link to it as well.

Fixes #5485 #5516