### PR TITLE
Set focus to selection synchronously when closing

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -81,10 +81,8 @@ define([
       self.$selection.removeAttr('aria-activedescendant');
       self.$selection.removeAttr('aria-owns');
 
-      window.setTimeout(function () {
-        self.$selection.focus();
-      }, 0);
-    
+      self.$selection[0].focus();
+
       self._detachCloseHandler(container);
     });
 

--- a/tests/selection/close-tests.js
+++ b/tests/selection/close-tests.js
@@ -1,0 +1,30 @@
+module('Selection containers - Close');
+
+var SingleSelection = require('select2/selection/single');
+
+var $ = require('jquery');
+var Options = require('select2/options');
+
+var options = new Options({});
+
+test('close set the focus to the selection', function (assert) {
+  var $container = $('#qunit-fixture .event-container');
+  var container = new MockContainer();
+  var selection = new SingleSelection(
+    $('#qunit-fixture .single'),
+    options
+  );
+
+  var $selection = selection.render();
+  selection.bind(container, $container);
+  selection.update([]);
+  $container.append($selection);
+
+  container.trigger('close');
+
+  assert.equal(
+    document.activeElement, 
+    $selection[0], 
+    'After close, focus must be set to selection'
+  );
+});

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -84,6 +84,7 @@
     <script src="results/focusing-tests.js" type="text/javascript"></script>
 
     <script src="selection/allowClear-tests.js" type="text/javascript"></script>
+    <script src="selection/close-tests.js" type="text/javascript"></script>
     <script src="selection/containerCss-tests.js" type="text/javascript"></script>
     <script src="selection/multiple-tests.js" type="text/javascript"></script>
     <script src="selection/placeholder-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -84,6 +84,7 @@
     <script src="results/focusing-tests.js" type="text/javascript"></script>
 
     <script src="selection/allowClear-tests.js" type="text/javascript"></script>
+    <script src="selection/close-tests.js" type="text/javascript"></script>
     <script src="selection/containerCss-tests.js" type="text/javascript"></script>
     <script src="selection/multiple-tests.js" type="text/javascript"></script>
     <script src="selection/placeholder-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -84,6 +84,7 @@
     <script src="results/focusing-tests.js" type="text/javascript"></script>
 
     <script src="selection/allowClear-tests.js" type="text/javascript"></script>
+    <script src="selection/close-tests.js" type="text/javascript"></script>
     <script src="selection/containerCss-tests.js" type="text/javascript"></script>
     <script src="selection/multiple-tests.js" type="text/javascript"></script>
     <script src="selection/placeholder-tests.js" type="text/javascript"></script>


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Set focus to selection synchronously in close event (remove setTimeout call)
- Call native focus method instead of jquery one because the later fails with jquery v1

If this is related to an existing ticket, include a link to it as well.

Fixes #5532 