### PR TITLE
Add `computedstyle` option for calculating the width

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -162,6 +162,12 @@ define([
       return null;
     }
 
+    if (method == 'computedstyle') {
+      var computedStyle = window.getComputedStyle($element[0]);
+
+      return computedStyle.width;
+    }
+
     return method;
   };
 

--- a/tests/options/width-tests.js
+++ b/tests/options/width-tests.js
@@ -64,3 +64,21 @@ test('resolve falls back to element if there is no style', function (assert) {
 
   assert.equal(width, '500px');
 });
+
+test('computedstyle gets the style if parent is invisible', function (assert) {
+  var $style = $(
+    '<style type="text/css">.css-set-width { width: 500px; }</style>'
+  );
+  var $test = $(
+    '<div style="display:none;">' +
+      '<select class="css-set-width"></select>' +
+    '</div>'
+  );
+
+  $('#qunit-fixture').append($style);
+  $('#qunit-fixture').append($test);
+
+  var width = select._resolveWidth($test.find('select'), 'computedstyle');
+
+  assert.equal(width, '500px');
+});


### PR DESCRIPTION
This allows for more accurate resolution of the width when compared
to the `resolve` method. This is more relevant for jQuery 1.x, where
the `resolve` method cannot find the width of a hidden select box,
but it also applies to newer versions of jQuery where the `width()`
method provided by jQuery doesn't fully match `getComputedStyle()`.

Fixes #3278
Fixes #5502
Closes #5259

This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Added `computedstyle` option
- Added tests to make sure that it works across all jQuery versions