### PR TITLE
remove deprecated jQuery shorthand

### DIFF
--- a/src/js/select2/data/tokenizer.js
+++ b/src/js/select2/data/tokenizer.js
@@ -58,7 +58,7 @@ define([
       // Replace the search term if we have the search box
       if (this.$search.length) {
         this.$search.val(tokenData.term);
-        this.$search.focus();
+        this.$search.trigger('focus');
       }
 
       params.term = tokenData.term;

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -49,10 +49,10 @@ define([
     container.on('open', function () {
       self.$search.attr('tabindex', 0);
 
-      self.$search.focus();
+      self.$search.trigger('focus');
 
       window.setTimeout(function () {
-        self.$search.focus();
+        self.$search.trigger('focus');
       }, 0);
     });
 
@@ -60,12 +60,12 @@ define([
       self.$search.attr('tabindex', -1);
 
       self.$search.val('');
-      self.$search.blur();
+      self.$search.trigger('blur');
     });
 
     container.on('focus', function () {
       if (!container.isOpen()) {
-        self.$search.focus();
+        self.$search.trigger('focus');
       }
     });
 

--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -82,7 +82,7 @@ define([
       self.$selection.removeAttr('aria-owns');
 
       window.setTimeout(function () {
-        self.$selection.focus();
+        self.$selection.trigger('focus');
       }, 0);
     
       self._detachCloseHandler(container);

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -175,7 +175,7 @@ define([
 
     this.resizeSearch();
     if (searchHadFocus) {
-      this.$search.focus();
+      this.$search.trigger('focus');
     }
   };
 

--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -59,7 +59,7 @@ define([
 
     container.on('focus', function (evt) {
       if (!container.isOpen()) {
-        self.$selection.focus();
+        self.$selection.trigger('focus');
       }
     });
   };


### PR DESCRIPTION
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Replaced calls to .blur() with .trigger('blur')
- Replaced calls to .focus() with .trigger('focus')

These functions have been deprecated.

This is related to #5228
