### PR TITLE
Revert change to focusing behaviour in 4.0.6

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -81,10 +81,8 @@ define([
       self.$selection.removeAttr('aria-activedescendant');
       self.$selection.removeAttr('aria-owns');
 
-      window.setTimeout(function () {
-        self.$selection.trigger('focus');
-      }, 0);
-    
+      self.$selection.trigger('focus');
+
       self._detachCloseHandler(container);
     });
 

--- a/tests/selection/focusing-tests.js
+++ b/tests/selection/focusing-tests.js
@@ -1,0 +1,41 @@
+module('Selection containers - Managing focus');
+
+var SingleSelection = require('select2/selection/single');
+
+var $ = require('jquery');
+var Options = require('select2/options');
+
+var options = new Options({});
+
+test('close sets the focus to the selection', function (assert) {
+  var $container = $('#qunit-fixture .event-container');
+  var container = new MockContainer();
+  var selection = new SingleSelection(
+    $('#qunit-fixture .single'),
+    options
+  );
+
+  var $selection = selection.render();
+  selection.bind(container, $container);
+
+  selection.update([{
+    id: 'test',
+    text: 'test'
+  }]);
+
+  $container.append($selection);
+
+  assert.notEqual(
+    document.activeElement,
+    $selection[0],
+    'The selection had focus originally'
+  );
+
+  container.trigger('close');
+
+  assert.equal(
+    document.activeElement,
+    $selection[0],
+    'After close, focus must be set to selection'
+  );
+});

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -87,6 +87,7 @@
 
     <script src="selection/allowClear-tests.js" type="text/javascript"></script>
     <script src="selection/containerCss-tests.js" type="text/javascript"></script>
+    <script src="selection/focusing-tests.js" type="text/javascript"></script>
     <script src="selection/multiple-tests.js" type="text/javascript"></script>
     <script src="selection/placeholder-tests.js" type="text/javascript"></script>
     <script src="selection/search-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -87,6 +87,7 @@
 
     <script src="selection/allowClear-tests.js" type="text/javascript"></script>
     <script src="selection/containerCss-tests.js" type="text/javascript"></script>
+    <script src="selection/focusing-tests.js" type="text/javascript"></script>
     <script src="selection/multiple-tests.js" type="text/javascript"></script>
     <script src="selection/placeholder-tests.js" type="text/javascript"></script>
     <script src="selection/search-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -87,6 +87,7 @@
 
     <script src="selection/allowClear-tests.js" type="text/javascript"></script>
     <script src="selection/containerCss-tests.js" type="text/javascript"></script>
+    <script src="selection/focusing-tests.js" type="text/javascript"></script>
     <script src="selection/multiple-tests.js" type="text/javascript"></script>
     <script src="selection/placeholder-tests.js" type="text/javascript"></script>
     <script src="selection/search-tests.js" type="text/javascript"></script>


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Revert 933189b92 
- Add test to ensure the focus is transferred properly when the dropdown closes

If this is related to an existing ticket, include a link to it as well.

Fixes #5532
Fixes #5185
Closes #5552