### PR TITLE
Fix `maximumSelectionLength` being ignored by `closeOnSelect`

### DIFF
--- a/src/js/select2/data/maximumSelectionLength.js
+++ b/src/js/select2/data/maximumSelectionLength.js
@@ -7,8 +7,28 @@ define([
     decorated.call(this, $e, options);
   }
 
+  MaximumSelectionLength.prototype.bind =
+    function (decorated, container, $container) {
+      var self = this;
+
+      decorated.call(this, container, $container);
+
+      container.on('select', function () {
+        self._checkIfMaximumSelected();
+      });
+  };
+
   MaximumSelectionLength.prototype.query =
     function (decorated, params, callback) {
+      var self = this;
+
+      this._checkIfMaximumSelected(function () {
+        decorated.call(self, params, callback);
+      });
+  };
+
+  MaximumSelectionLength.prototype._checkIfMaximumSelected =
+    function (_, successCallback) {
       var self = this;
 
       this.current(function (currentData) {
@@ -23,7 +43,10 @@ define([
           });
           return;
         }
-        decorated.call(self, params, callback);
+
+        if (successCallback) {
+          successCallback();
+        }
       });
   };
 

--- a/tests/data/maximumSelectionLength-tests.js
+++ b/tests/data/maximumSelectionLength-tests.js
@@ -1,202 +1,127 @@
 module('Data adapters - Maximum selection length');
 
+var SelectData = require('select2/data/select');
 var MaximumSelectionLength = require('select2/data/maximumSelectionLength');
 
 var $ = require('jquery');
 var Options = require('select2/options');
 var Utils = require('select2/utils');
 
-function MaximumSelectionStub () {
-  this.called = false;
-  this.currentData = [];
-}
-
-MaximumSelectionStub.prototype.current = function (callback) {
-  callback(this.currentData);
-};
-
-MaximumSelectionStub.prototype.val = function (val) {
-  this.currentData.push(val);
-};
-
-MaximumSelectionStub.prototype.query = function (params, callback) {
-  this.called = true;
-};
-
-var MaximumSelectionData = Utils.Decorate(
-  MaximumSelectionStub,
-  MaximumSelectionLength
-);
+var MaximumSelectionData = Utils.Decorate(SelectData, MaximumSelectionLength);
 
 test('0 never displays the notice', function (assert) {
+  assert.expect(3);
+
+  var $select = $('#qunit-fixture .multiple');
+
   var zeroOptions = new Options({
     maximumSelectionLength: 0
   });
 
-  var data = new MaximumSelectionData(null, zeroOptions);
+  var container = new MockContainer();
+  var data = new MaximumSelectionData($select, zeroOptions);
 
-  data.trigger = function () {
-    assert.ok(false, 'No events should be triggered');
-  };
+  data.bind(container, null);
+
+  data.on('results:message', function () {
+    assert.ok(false, 'The message should not be displayed');
+  });
 
   data.query({
     term: ''
+  }, function () {
+    assert.ok(true, 'The results should be queried');
   });
 
-  assert.ok(data.called);
-
-  data = new MaximumSelectionData(null, zeroOptions);
-
-  data.trigger = function () {
-    assert.ok(false, 'No events should be triggered');
-  };
-
-  data.val('1');
+  $select.val(['One']);
 
   data.query({
     term: ''
+  }, function () {
+    assert.ok(true, 'The results should be queried');
   });
 
-  assert.ok(data.called);
-
-  data = new MaximumSelectionData(null, zeroOptions);
-
-  data.trigger = function () {
-    assert.ok(false, 'No events should be triggered');
-  };
-
-  data.val('1');
-  data.val('2');
+  $select.val(['One', 'Two']);
 
   data.query({
     term: ''
+  }, function () {
+    assert.ok(true, 'The results should be queried');
   });
-
-  assert.ok(data.called);
 });
 
 test('< 0 never displays the notice', function (assert) {
+  assert.expect(3);
+
+  var $select = $('#qunit-fixture .multiple');
+
   var negativeOptions = new Options({
     maximumSelectionLength: -1
   });
 
-  var data = new MaximumSelectionData(null, negativeOptions);
+  var container = new MockContainer();
+  var data = new MaximumSelectionData($select, negativeOptions);
 
-  data.trigger = function () {
-    assert.ok(false, 'No events should be triggered');
-  };
+  data.bind(container, null);
+
+  data.on('results:message', function () {
+    assert.ok(false, 'The message should not be displayed');
+  });
 
   data.query({
     term: ''
+  }, function () {
+    assert.ok(true, 'The results should be queried');
   });
 
-  assert.ok(data.called);
-
-  data = new MaximumSelectionData(null, negativeOptions);
-
-  data.trigger = function () {
-    assert.ok(false, 'No events should be triggered');
-  };
-
-  data.val('1');
+  $select.val(['One']);
 
   data.query({
     term: ''
+  }, function () {
+    assert.ok(true, 'The results should be queried');
   });
 
-  assert.ok(data.called);
-
-  data = new MaximumSelectionData(null, negativeOptions);
-
-  data.trigger = function () {
-    assert.ok(false, 'No events should be triggered');
-  };
-
-  data.val('1');
-  data.val('2');
+  $select.val(['One', 'Two']);
 
   data.query({
     term: ''
+  }, function () {
+    assert.ok(true, 'The results should be queried');
   });
-
-  assert.ok(data.called);
 });
 
 test('triggers when >= 1 selection' , function (assert) {
+  assert.expect(2);
+
+  var $select = $('#qunit-fixture .multiple');
+
   var maxOfOneOptions = new Options({
     maximumSelectionLength: 1
   });
-  var data = new MaximumSelectionData(null, maxOfOneOptions);
 
-  data.trigger = function () {
-    assert.ok(false, 'No events should be triggered');
-  };
+  var container = new MockContainer();
+  var data = new MaximumSelectionData($select, maxOfOneOptions);
+
+  data.bind(container, null);
+
+  data.on('results:message', function () {
+    assert.ok(true, 'The message should be displayed');
+  });
+
+  $select.val(['One']);
 
   data.query({
     term: ''
+  }, function () {
+    assert.ok(false, 'The results should not be queried');
   });
 
-  assert.ok(data.called);
-
-  data = new MaximumSelectionData(null, maxOfOneOptions);
-
-  data.trigger = function () {
-    assert.ok(true, 'The event should be triggered.');
-  };
-
-  data.val('1');
+  $select.val(['One', 'Two']);
 
   data.query({
     term: ''
+  }, function () {
+    assert.ok(false, 'The results should not be queried');
   });
-
-  assert.ok(!data.called);
-
-});
-
-test('triggers when >= 2 selections' , function (assert) {
-  var maxOfTwoOptions = new Options({
-    maximumSelectionLength: 2
-  });
-  var data = new MaximumSelectionData(null, maxOfTwoOptions);
-
-  data.trigger = function () {
-    assert.ok(false, 'No events should be triggered');
-  };
-
-  data.query({
-    term: ''
-  });
-
-  assert.ok(data.called);
-
-  data = new MaximumSelectionData(null, maxOfTwoOptions);
-
-  data.trigger = function () {
-    assert.ok(false, 'No events should be triggered');
-  };
-
-  data.val('1');
-
-  data.query({
-    term: ''
-  });
-
-  assert.ok(data.called);
-
-  data = new MaximumSelectionData(null, maxOfTwoOptions);
-
-  data.trigger = function () {
-    assert.ok(true, 'The event should be triggered.');
-  };
-
-  data.val('1');
-  data.val('2');
-
-  data.query({
-    term: ''
-  });
-
-  assert.ok(!data.called);
-
 });

--- a/tests/data/maximumSelectionLength-tests.js
+++ b/tests/data/maximumSelectionLength-tests.js
@@ -125,3 +125,28 @@ test('triggers when >= 1 selection' , function (assert) {
     assert.ok(false, 'The results should not be queried');
   });
 });
+
+test('triggers after selection' , function (assert) {
+  assert.expect(1);
+
+  var $select = $('#qunit-fixture .multiple');
+
+  var maxOfOneOptions = new Options({
+    maximumSelectionLength: 1
+  });
+
+  var container = new MockContainer();
+  var data = new MaximumSelectionData($select, maxOfOneOptions);
+
+  data.bind(container, null);
+
+  data.on('results:message', function () {
+    assert.ok(true, 'The message should be displayed');
+  });
+
+  $select.val(['One']);
+
+  container.trigger('select', {
+    data: {}
+  });
+});


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fix maximumSelectionLength being ignored by closeOnSelect
- Rewrote tests to match other unit tests for Select2
- Added new test to ensure the select event is listened to

If this is related to an existing ticket, include a link to it as well.

Fixes #3514
Fixes #3860
Closes #5333