### PR TITLE
Set the main ARIA 1.1 roles and properties for comboboxes

### DIFF
--- a/src/js/select2/dropdown/infiniteScroll.js
+++ b/src/js/select2/dropdown/infiniteScroll.js
@@ -78,7 +78,7 @@ define([
     var $option = $(
       '<li ' +
       'class="select2-results__option select2-results__option--load-more"' +
-      'role="treeitem" aria-disabled="true"></li>'
+      'role="option" aria-disabled="true"></li>'
     );
 
     var message = this.options.get('translations').get('loadingMore');

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -11,7 +11,7 @@ define([
       '<span class="select2-search select2-search--dropdown">' +
         '<input class="select2-search__field" type="search" tabindex="-1"' +
         ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
-        ' spellcheck="false" role="textbox" />' +
+        ' spellcheck="false" role="textbox" aria-autocomplete="list" />' +
       '</span>'
     );
 
@@ -25,6 +25,8 @@ define([
 
   Search.prototype.bind = function (decorated, container, $container) {
     var self = this;
+
+    var resultsId = container.id + '-results';
 
     decorated.call(this, container, $container);
 
@@ -48,6 +50,7 @@ define([
 
     container.on('open', function () {
       self.$search.attr('tabindex', 0);
+      self.$search.attr('aria-owns', resultsId);
 
       self.$search.trigger('focus');
 
@@ -58,6 +61,8 @@ define([
 
     container.on('close', function () {
       self.$search.attr('tabindex', -1);
+      self.$search.removeAttr('aria-owns');
+      self.$search.removeAttr('aria-activedescendant');
 
       self.$search.val('');
       self.$search.trigger('blur');
@@ -78,6 +83,14 @@ define([
         } else {
           self.$searchContainer.addClass('select2-search--hide');
         }
+      }
+    });
+
+    container.on('results:focus', function (params) {
+      if (params.data._resultId) {
+        self.$search.attr('aria-activedescendant', params.data._resultId);
+      } else {
+        self.$search.removeAttr('aria-activedescendant');
       }
     });
   };

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -50,7 +50,7 @@ define([
 
     container.on('open', function () {
       self.$search.attr('tabindex', 0);
-      self.$search.attr('aria-owns', resultsId);
+      self.$search.attr('aria-controls', resultsId);
 
       self.$search.trigger('focus');
 
@@ -61,7 +61,7 @@ define([
 
     container.on('close', function () {
       self.$search.attr('tabindex', -1);
-      self.$search.removeAttr('aria-owns');
+      self.$search.removeAttr('aria-controls');
       self.$search.removeAttr('aria-activedescendant');
 
       self.$search.val('');

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -11,7 +11,7 @@ define([
       '<span class="select2-search select2-search--dropdown">' +
         '<input class="select2-search__field" type="search" tabindex="-1"' +
         ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
-        ' spellcheck="false" role="textbox" aria-autocomplete="list" />' +
+        ' spellcheck="false" role="searchbox" aria-autocomplete="list" />' +
       '</span>'
     );
 

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -14,7 +14,7 @@ define([
 
   Results.prototype.render = function () {
     var $results = $(
-      '<ul class="select2-results__options" role="tree"></ul>'
+      '<ul class="select2-results__options" role="listbox"></ul>'
     );
 
     if (this.options.get('multiple')) {
@@ -37,7 +37,7 @@ define([
     this.hideLoading();
 
     var $message = $(
-      '<li role="treeitem" aria-live="assertive"' +
+      '<li role="alert" aria-live="assertive"' +
       ' class="select2-results__option"></li>'
     );
 
@@ -171,7 +171,7 @@ define([
     option.className = 'select2-results__option';
 
     var attrs = {
-      'role': 'treeitem',
+      'role': 'option',
       'aria-selected': 'false'
     };
 

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -12,7 +12,7 @@ define([
       '<li class="select2-search select2-search--inline">' +
         '<input class="select2-search__field" type="search" tabindex="-1"' +
         ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
-        ' spellcheck="false" role="textbox" aria-autocomplete="list" />' +
+        ' spellcheck="false" role="searchbox" aria-autocomplete="list" />' +
       '</li>'
     );
 

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -29,14 +29,18 @@ define([
   Search.prototype.bind = function (decorated, container, $container) {
     var self = this;
 
+    var resultsId = container.id + '-results';
+
     decorated.call(this, container, $container);
 
     container.on('open', function () {
+      self.$search.attr('aria-owns', resultsId);
       self.$search.trigger('focus');
     });
 
     container.on('close', function () {
       self.$search.val('');
+      self.$search.removeAttr('aria-owns');
       self.$search.removeAttr('aria-activedescendant');
       self.$search.trigger('focus');
     });
@@ -56,7 +60,11 @@ define([
     });
 
     container.on('results:focus', function (params) {
-      self.$search.attr('aria-activedescendant', params.id);
+      if (params.data._resultId) {
+        self.$search.attr('aria-activedescendant', params.data._resultId);
+      } else {
+        self.$search.removeAttr('aria-activedescendant');
+      }
     });
 
     this.$selection.on('focusin', '.select2-search--inline', function (evt) {

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -34,13 +34,13 @@ define([
     decorated.call(this, container, $container);
 
     container.on('open', function () {
-      self.$search.attr('aria-owns', resultsId);
+      self.$search.attr('aria-controls', resultsId);
       self.$search.trigger('focus');
     });
 
     container.on('close', function () {
       self.$search.val('');
-      self.$search.removeAttr('aria-owns');
+      self.$search.removeAttr('aria-controls');
       self.$search.removeAttr('aria-activedescendant');
       self.$search.trigger('focus');
     });

--- a/tests/dropdown/search-a11y-tests.js
+++ b/tests/dropdown/search-a11y-tests.js
@@ -1,0 +1,169 @@
+module('Dropdown - Search - Accessibility');
+
+var Utils = require('select2/utils');
+
+var Dropdown = require('select2/dropdown');
+var DropdownSearch = Utils.Decorate(
+  Dropdown,
+  require('select2/dropdown/search')
+);
+
+var $ = require('jquery');
+
+var Options = require('select2/options');
+var options = new Options({});
+
+test('aria-autocomplete attribute is present', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  assert.equal(
+    $dropdown.find('input').attr('aria-autocomplete'),
+    'list',
+    'The search box is marked as autocomplete'
+  );
+});
+
+test('aria-activedescendant should not be set initiailly', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  var $search = $dropdown.find('input');
+
+  assert.ok(
+    !$search.attr('aria-activedescendant'),
+    'The search box should not point to anything when it is first rendered'
+  );
+});
+
+test('aria-activedescendant should be set after highlight', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  container.trigger('results:focus', {
+    data: {
+      _resultId: 'test'
+    }
+  });
+
+  var $search = $dropdown.find('input');
+
+  assert.equal(
+    $search.attr('aria-activedescendant'),
+    'test',
+    'The search is pointing to the focused result'
+  );
+});
+
+test('activedescendant should remove if there is no ID', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  var $search = $dropdown.find('input');
+  $search.attr('aria-activedescendant', 'test');
+
+  container.trigger('results:focus', {
+    data: {}
+  });
+
+  assert.ok(
+    !$search.attr('aria-activedescendant'),
+    'There is no result for the search to be pointing to'
+  );
+});
+
+test('aria-activedescendant should be removed when closed', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  var $search = $dropdown.find('input');
+  $search.attr('aria-activedescendant', 'something');
+
+  container.trigger('close');
+
+  assert.ok(
+    !$search.attr('aria-activedescendant'),
+    'There is no active descendant when the dropdown is closed'
+  );
+});
+
+test('aria-owns should not be set initiailly', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  var $search = $dropdown.find('input');
+
+  assert.ok(
+    !$search.attr('aria-owns'),
+    'The search box should not point to the results when it is first rendered'
+  );
+});
+
+test('aria-owns should be set when opened', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  var $search = $dropdown.find('input');
+
+  container.trigger('open');
+
+  assert.ok(
+    $search.attr('aria-owns'),
+    'The search should point to the results when it is opened'
+  );
+});
+
+test('aria-owns should be removed when closed', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  var $search = $dropdown.find('input');
+  $search.attr('aria-owns', 'something');
+
+  container.trigger('close');
+
+  assert.ok(
+    !$search.attr('aria-owns'),
+    'There are no results for the search box to point to when it is closed'
+  );
+});

--- a/tests/dropdown/search-a11y-tests.js
+++ b/tests/dropdown/search-a11y-tests.js
@@ -13,6 +13,22 @@ var $ = require('jquery');
 var Options = require('select2/options');
 var options = new Options({});
 
+test('role attribute is set to searchbox', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  assert.equal(
+    $dropdown.find('input').attr('role'),
+    'searchbox',
+    'The search box is marked as a search box'
+  );
+});
+
 test('aria-autocomplete attribute is present', function (assert) {
   var $select = $('#qunit-fixture .single');
 

--- a/tests/dropdown/search-a11y-tests.js
+++ b/tests/dropdown/search-a11y-tests.js
@@ -128,7 +128,7 @@ test('aria-activedescendant should be removed when closed', function (assert) {
   );
 });
 
-test('aria-owns should not be set initiailly', function (assert) {
+test('aria-controls should not be set initiailly', function (assert) {
   var $select = $('#qunit-fixture .single');
 
   var dropdown = new DropdownSearch($select, options);
@@ -140,12 +140,12 @@ test('aria-owns should not be set initiailly', function (assert) {
   var $search = $dropdown.find('input');
 
   assert.ok(
-    !$search.attr('aria-owns'),
+    !$search.attr('aria-controls'),
     'The search box should not point to the results when it is first rendered'
   );
 });
 
-test('aria-owns should be set when opened', function (assert) {
+test('aria-controls should be set when opened', function (assert) {
   var $select = $('#qunit-fixture .single');
 
   var dropdown = new DropdownSearch($select, options);
@@ -159,12 +159,12 @@ test('aria-owns should be set when opened', function (assert) {
   container.trigger('open');
 
   assert.ok(
-    $search.attr('aria-owns'),
+    $search.attr('aria-controls'),
     'The search should point to the results when it is opened'
   );
 });
 
-test('aria-owns should be removed when closed', function (assert) {
+test('aria-controls should be removed when closed', function (assert) {
   var $select = $('#qunit-fixture .single');
 
   var dropdown = new DropdownSearch($select, options);
@@ -174,12 +174,12 @@ test('aria-owns should be removed when closed', function (assert) {
   dropdown.bind(container, $('<span></span>'));
 
   var $search = $dropdown.find('input');
-  $search.attr('aria-owns', 'something');
+  $search.attr('aria-controls', 'something');
 
   container.trigger('close');
 
   assert.ok(
-    !$search.attr('aria-owns'),
+    !$search.attr('aria-controls'),
     'There are no results for the search box to point to when it is closed'
   );
 });

--- a/tests/results/a11y-tests.js
+++ b/tests/results/a11y-tests.js
@@ -1,0 +1,25 @@
+module('Results - Accessibility');
+
+var $ = require('jquery');
+
+var Options = require('select2/options');
+
+var Results = require('select2/results');
+
+test('role of results should be a listbox', function (assert) {
+  var results = new Results($('<select></select>'), new Options({}));
+
+  var $results = results.render();
+
+  assert.equal($results.attr('role'), 'listbox');
+});
+
+test('multiple select should have aria-multiselectable', function (assert) {
+  var results = new Results($('<select></select>'), new Options({
+    multiple: true
+  }));
+
+  var $results = results.render();
+
+  assert.equal($results.attr('aria-multiselectable'), 'true');
+});

--- a/tests/results/option-tests.js
+++ b/tests/results/option-tests.js
@@ -61,3 +61,56 @@ test('option in disabled optgroup is disabled', function (assert) {
 
   assert.equal(option.getAttribute('aria-disabled'), 'true');
 });
+
+test('options are not selected by default', function (assert) {
+  var results = new Results($('<select></select>'), new Options({}));
+
+  var $option = $('<option></option>');
+  var option = results.option({
+    id: 'test',
+    element: $option[0]
+  });
+
+  assert.equal(option.getAttribute('aria-selected'), 'false');
+});
+
+test('options with children are given the group role', function(assert) {
+  var results = new Results($('<select></select>'), new Options({}));
+
+  var $option = $('<optgroup></optgroup>');
+  var option = results.option({
+    children: [{
+      id: 'test'
+    }],
+    element: $option[0]
+  });
+
+  assert.equal(option.getAttribute('role'), 'group');
+});
+
+test('options with children have the aria-label set', function (assert) {
+  var results = new Results($('<select></select>'), new Options({}));
+
+  var $option = $('<optgroup></optgroup>');
+  var option = results.option({
+    children: [{
+      id: 'test'
+    }],
+    element: $option[0],
+    text: 'test'
+  });
+
+  assert.equal(option.getAttribute('aria-label'), 'test');
+});
+
+test('non-group options are given the option role', function (assert) {
+  var results = new Results($('<select></select>'), new Options({}));
+
+  var $option = $('<option></option>');
+  var option = results.option({
+    id: 'test',
+    element: $option[0]
+  });
+
+  assert.equal(option.getAttribute('role'), 'option');
+});

--- a/tests/selection/search-a11y-tests.js
+++ b/tests/selection/search-a11y-tests.js
@@ -9,6 +9,26 @@ var Utils = require('select2/utils');
 var Options = require('select2/options');
 var options = new Options({});
 
+test('role attribute is set to searchbox', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  assert.equal(
+    $selection.find('input').attr('role'),
+    'searchbox',
+    'The search box is marked as a search box'
+  );
+});
+
 test('aria-autocomplete attribute is present', function (assert) {
   var $select = $('#qunit-fixture .multiple');
 

--- a/tests/selection/search-a11y-tests.js
+++ b/tests/selection/search-a11y-tests.js
@@ -16,6 +16,9 @@ test('aria-autocomplete attribute is present', function (assert) {
   var selection = new CustomSelection($select, options);
   var $selection = selection.render();
 
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
   // Update the selection so the search is rendered
   selection.update([]);
 
@@ -23,6 +26,81 @@ test('aria-autocomplete attribute is present', function (assert) {
     $selection.find('input').attr('aria-autocomplete'),
     'list',
     'The search box is marked as autocomplete'
+  );
+});
+
+test('aria-activedescendant should not be set initiailly', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  var $search = $selection.find('input');
+
+  assert.ok(
+    !$search.attr('aria-activedescendant'),
+    'The search box should not point to anything when it is first rendered'
+  );
+});
+
+test('aria-activedescendant should be set after highlight', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  container.trigger('results:focus', {
+    data: {
+      _resultId: 'test'
+    }
+  });
+
+  var $search = $selection.find('input');
+
+  assert.equal(
+    $search.attr('aria-activedescendant'),
+    'test',
+    'The search is pointing to the focused result'
+  );
+});
+
+test('activedescendant should remove if there is no ID', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  var $search = $selection.find('input');
+  $search.attr('aria-activedescendant', 'test');
+
+  container.trigger('results:focus', {
+    data: {}
+  });
+
+  assert.ok(
+    !$search.attr('aria-activedescendant'),
+    'There is no result for the search to be pointing to'
   );
 });
 
@@ -47,5 +125,73 @@ test('aria-activedescendant should be removed when closed', function (assert) {
   assert.ok(
     !$search.attr('aria-activedescendant'),
     'There is no active descendant when the dropdown is closed'
+  );
+});
+
+test('aria-owns should not be set initiailly', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  var $search = $selection.find('input');
+
+  assert.ok(
+    !$search.attr('aria-owns'),
+    'The search box should not point to the results when it is first rendered'
+  );
+});
+
+test('aria-owns should be set when opened', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  var $search = $selection.find('input');
+
+  container.trigger('open');
+
+  assert.ok(
+    $search.attr('aria-owns'),
+    'The search should point to the results when it is opened'
+  );
+});
+
+test('aria-owns should be removed when closed', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  var $search = $selection.find('input');
+  $search.attr('aria-owns', 'something');
+
+  container.trigger('close');
+
+  assert.ok(
+    !$search.attr('aria-owns'),
+    'There are no results for the search box to point to when it is closed'
   );
 });

--- a/tests/selection/search-a11y-tests.js
+++ b/tests/selection/search-a11y-tests.js
@@ -148,7 +148,7 @@ test('aria-activedescendant should be removed when closed', function (assert) {
   );
 });
 
-test('aria-owns should not be set initiailly', function (assert) {
+test('aria-controls should not be set initiailly', function (assert) {
   var $select = $('#qunit-fixture .multiple');
 
   var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
@@ -164,12 +164,12 @@ test('aria-owns should not be set initiailly', function (assert) {
   var $search = $selection.find('input');
 
   assert.ok(
-    !$search.attr('aria-owns'),
+    !$search.attr('aria-controls'),
     'The search box should not point to the results when it is first rendered'
   );
 });
 
-test('aria-owns should be set when opened', function (assert) {
+test('aria-controls should be set when opened', function (assert) {
   var $select = $('#qunit-fixture .multiple');
 
   var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
@@ -187,12 +187,12 @@ test('aria-owns should be set when opened', function (assert) {
   container.trigger('open');
 
   assert.ok(
-    $search.attr('aria-owns'),
+    $search.attr('aria-controls'),
     'The search should point to the results when it is opened'
   );
 });
 
-test('aria-owns should be removed when closed', function (assert) {
+test('aria-controls should be removed when closed', function (assert) {
   var $select = $('#qunit-fixture .multiple');
 
   var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
@@ -206,12 +206,12 @@ test('aria-owns should be removed when closed', function (assert) {
   selection.update([]);
 
   var $search = $selection.find('input');
-  $search.attr('aria-owns', 'something');
+  $search.attr('aria-controls', 'something');
 
   container.trigger('close');
 
   assert.ok(
-    !$search.attr('aria-owns'),
+    !$search.attr('aria-controls'),
     'There are no results for the search box to point to when it is closed'
   );
 });

--- a/tests/selection/search-a11y-tests.js
+++ b/tests/selection/search-a11y-tests.js
@@ -1,4 +1,4 @@
-module('Accessibility - Search');
+module('Selection containers - Inline search - Accessibility');
 
 var MultipleSelection = require('select2/selection/multiple');
 var InlineSearch = require('select2/selection/search');

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -71,6 +71,7 @@
 
     <script src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
     <script src="dropdown/positioning-tests.js" type="text/javascript"></script>
+    <script src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
     <script src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
     <script src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>
 

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -81,6 +81,7 @@
     <script src="options/translation-tests.js" type="text/javascript"></script>
     <script src="options/width-tests.js" type="text/javascript"></script>
 
+    <script src="results/a11y-tests.js" type="text/javascript"></script>
     <script src="results/focusing-tests.js" type="text/javascript"></script>
     <script src="results/infiniteScroll-tests.js" type="text/javascript"></script>
     <script src="results/option-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -57,7 +57,6 @@
     <script src="helpers.js" type="text/javascript"></script>
 
     <script src="a11y/selection-tests.js" type="text/javascript"></script>
-    <script src="a11y/search-tests.js" type="text/javascript"></script>
 
     <script src="data/array-tests.js" type="text/javascript"></script>
     <script src="data/base-tests.js" type="text/javascript"></script>
@@ -91,6 +90,7 @@
     <script src="selection/multiple-tests.js" type="text/javascript"></script>
     <script src="selection/placeholder-tests.js" type="text/javascript"></script>
     <script src="selection/search-tests.js" type="text/javascript"></script>
+    <script src="selection/search-a11y-tests.js" type="text/javascript"></script>
     <script src="selection/search-placeholder-tests.js" type="text/javascript"></script>
     <script src="selection/single-tests.js" type="text/javascript"></script>
     <script src="selection/stopPropagation-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -71,6 +71,7 @@
 
     <script src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
     <script src="dropdown/positioning-tests.js" type="text/javascript"></script>
+    <script src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
     <script src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
     <script src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>
 

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -81,6 +81,7 @@
     <script src="options/translation-tests.js" type="text/javascript"></script>
     <script src="options/width-tests.js" type="text/javascript"></script>
 
+    <script src="results/a11y-tests.js" type="text/javascript"></script>
     <script src="results/focusing-tests.js" type="text/javascript"></script>
     <script src="results/infiniteScroll-tests.js" type="text/javascript"></script>
     <script src="results/option-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -57,7 +57,6 @@
     <script src="helpers.js" type="text/javascript"></script>
 
     <script src="a11y/selection-tests.js" type="text/javascript"></script>
-    <script src="a11y/search-tests.js" type="text/javascript"></script>
 
     <script src="data/array-tests.js" type="text/javascript"></script>
     <script src="data/base-tests.js" type="text/javascript"></script>
@@ -91,6 +90,7 @@
     <script src="selection/multiple-tests.js" type="text/javascript"></script>
     <script src="selection/placeholder-tests.js" type="text/javascript"></script>
     <script src="selection/search-tests.js" type="text/javascript"></script>
+    <script src="selection/search-a11y-tests.js" type="text/javascript"></script>
     <script src="selection/search-placeholder-tests.js" type="text/javascript"></script>
     <script src="selection/single-tests.js" type="text/javascript"></script>
     <script src="selection/stopPropagation-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -71,6 +71,7 @@
 
     <script src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
     <script src="dropdown/positioning-tests.js" type="text/javascript"></script>
+    <script src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
     <script src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
     <script src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>
 

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -81,6 +81,7 @@
     <script src="options/translation-tests.js" type="text/javascript"></script>
     <script src="options/width-tests.js" type="text/javascript"></script>
 
+    <script src="results/a11y-tests.js" type="text/javascript"></script>
     <script src="results/focusing-tests.js" type="text/javascript"></script>
     <script src="results/infiniteScroll-tests.js" type="text/javascript"></script>
     <script src="results/option-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -57,7 +57,6 @@
     <script src="helpers.js" type="text/javascript"></script>
 
     <script src="a11y/selection-tests.js" type="text/javascript"></script>
-    <script src="a11y/search-tests.js" type="text/javascript"></script>
 
     <script src="data/array-tests.js" type="text/javascript"></script>
     <script src="data/base-tests.js" type="text/javascript"></script>
@@ -91,6 +90,7 @@
     <script src="selection/multiple-tests.js" type="text/javascript"></script>
     <script src="selection/placeholder-tests.js" type="text/javascript"></script>
     <script src="selection/search-tests.js" type="text/javascript"></script>
+    <script src="selection/search-a11y-tests.js" type="text/javascript"></script>
     <script src="selection/search-placeholder-tests.js" type="text/javascript"></script>
     <script src="selection/single-tests.js" type="text/javascript"></script>
     <script src="selection/stopPropagation-tests.js" type="text/javascript"></script>


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Move accessibility tests for selections in with the other tests for selections
- Set `aria-owns` and `aria-activedescendent` for the search box in selections

If this is related to an existing ticket, include a link to it as well.

One small piece of #3735.
The code here is heavily based on #4348 but is updated for the changes that have been made over the years.