### PR TITLE
Clear search after select when closeOnSelect === false

### DIFF
--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -55,6 +55,10 @@ define([
       self.$search.trigger('focus');
     });
 
+    container.on('select', function () {
+      self.$search.val('');
+    });
+
     container.on('results:focus', function (params) {
       self.$search.attr('aria-activedescendant', params.id);
     });

--- a/tests/selection/search-tests.js
+++ b/tests/selection/search-tests.js
@@ -275,3 +275,31 @@ test('search box with text should not close dropdown', function (assert) {
   $search.val('test');
   $search.trigger('click');
 });
+
+test('search box should be cleared after select', function (assert) {
+  assert.expect(1);
+
+  var $container = $('#qunit-fixture .event-container');
+  var container = new MockContainer();
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+
+  var $element = $('#qunit-fixture .multiple');
+  var selection = new CustomSelection($element, options);
+
+  var $selection = selection.render();
+  selection.bind(container, $container);
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  // Make it visible so the browser can place focus on the search
+  $container.append($selection);
+
+  var $search = $selection.find('input');
+  $search.val('test');
+
+  container.trigger('select', {});
+
+  assert.equal($search.val(), '', 'The search text should be empty');
+});


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Always clear selection search after select even when closeOnSelect === false.

If this is related to an existing ticket, include a link to it as well.

Fixes #4698