### PR TITLE
Fix generated options not receiving result IDs

### DIFF
--- a/src/js/select2/data/array.js
+++ b/src/js/select2/data/array.js
@@ -4,14 +4,18 @@ define([
   'jquery'
 ], function (SelectAdapter, Utils, $) {
   function ArrayAdapter ($element, options) {
-    var data = options.get('data') || [];
+    this._dataToConvert = options.get('data') || [];
 
     ArrayAdapter.__super__.constructor.call(this, $element, options);
-
-    this.addOptions(this.convertToOptions(data));
   }
 
   Utils.Extend(ArrayAdapter, SelectAdapter);
+
+  ArrayAdapter.prototype.bind = function (container, $container) {
+    ArrayAdapter.__super__.bind.call(this, container, $container);
+
+    this.addOptions(this.convertToOptions(this._dataToConvert));
+  };
 
   ArrayAdapter.prototype.select = function (data) {
     var $option = this.$element.find('option').filter(function (i, elm) {

--- a/tests/data/array-tests.js
+++ b/tests/data/array-tests.js
@@ -71,6 +71,9 @@ test('current gets default for single', function (assert) {
 
   var data = new ArrayData($select, arrayOptions);
 
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
+
   data.current(function (val) {
     assert.equal(
       val.length,
@@ -93,6 +96,9 @@ test('current gets default for multiple', function (assert) {
 
   var data = new ArrayData($select, arrayOptions);
 
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
+
   data.current(function (val) {
     assert.equal(
       val.length,
@@ -106,6 +112,9 @@ test('current works with existing selections', function (assert) {
   var $select = $('#qunit-fixture .multiple');
 
   var data = new ArrayData($select, arrayOptions);
+
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
 
   $select.val(['One']);
 
@@ -136,6 +145,9 @@ test('current works with selected data', function (assert) {
   var $select = $('#qunit-fixture .single-empty');
 
   var data = new ArrayData($select, arrayOptions);
+
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
 
   data.select({
     id: '2',
@@ -170,6 +182,9 @@ test('select works for single', function (assert) {
 
   var data = new ArrayData($select, arrayOptions);
 
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
+
   assert.equal(
     $select.val(),
     'default',
@@ -193,6 +208,9 @@ test('multiple sets the value', function (assert) {
 
   var data = new ArrayData($select, arrayOptions);
 
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
+
   assert.ok(
     $select.val() == null || $select.val().length == 0,
     'nothing should be selected'
@@ -211,6 +229,9 @@ test('multiple adds to the old value', function (assert) {
 
   var data = new ArrayData($select, arrayOptions);
 
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
+
   $select.val(['One']);
 
   assert.deepEqual($select.val(), ['One']);
@@ -228,6 +249,9 @@ test('option tags are automatically generated', function (assert) {
 
   var data = new ArrayData($select, arrayOptions);
 
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
+
   assert.equal(
     $select.find('option').length,
     4,
@@ -235,10 +259,31 @@ test('option tags are automatically generated', function (assert) {
   );
 });
 
+test('automatically generated option tags have a result id', function (assert) {
+  var $select = $('#qunit-fixture .single-empty');
+
+  var data = new ArrayData($select, arrayOptions);
+
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
+
+  data.select({
+    id: 'default'
+  });
+
+  assert.ok(
+    Utils.GetData($select.find(':selected')[0], 'data')._resultId,
+    '<option> default should have a result ID assigned'
+  );
+});
+
 test('option tags can receive new data', function(assert) {
   var $select = $('#qunit-fixture .single');
 
   var data = new ArrayData($select, extraOptions);
+
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
 
   assert.equal(
     $select.find('option').length,
@@ -270,6 +315,9 @@ test('optgroup tags can also be generated', function (assert) {
 
   var data = new ArrayData($select, nestedOptions);
 
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
+
   assert.equal(
     $select.find('option').length,
     1,
@@ -287,6 +335,9 @@ test('optgroup tags have the right properties', function (assert) {
   var $select = $('#qunit-fixture .single-empty');
 
   var data = new ArrayData($select, nestedOptions);
+
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
 
   var $group = $select.children('optgroup');
 
@@ -327,6 +378,9 @@ test('existing selections are respected on initialization', function (assert) {
     assert.equal($select.val(), 'Second');
 
     var data = new ArrayData($select, options);
+
+    var container = new MockContainer();
+    data.bind(container, $('<div></div>'));
 
     assert.equal($select.val(), 'Second');
 });

--- a/tests/data/inputData-tests.js
+++ b/tests/data/inputData-tests.js
@@ -23,6 +23,9 @@ test('test that options can be selected', function (assert) {
 
   var adapter = new InputAdapter($element, options);
 
+  var container = new MockContainer();
+  adapter.bind(container, $('<div></div>'));
+
   adapter.select({
     id: 'test'
   });
@@ -47,6 +50,9 @@ test('unselect the single selected option clears the value', function (assert) {
   var $element = $('<input />');
 
   var adapter = new InputAdapter($element, options);
+
+  var container = new MockContainer();
+  adapter.bind(container, $('<div></div>'));
 
   adapter.unselect({
     id: 'test'
@@ -81,6 +87,9 @@ test('options can be unselected individually', function (assert) {
 
   var adapter = new InputAdapter($element, options);
 
+  var container = new MockContainer();
+  adapter.bind(container, $('<div></div>'));
+
   adapter.unselect({
     id: 'test2'
   });
@@ -106,6 +115,9 @@ test('default values can be set', function (assert) {
   var $element = $('<input value="test" />');
 
   var adapter = new InputAdapter($element, options);
+
+  var container = new MockContainer();
+  adapter.bind(container, $('<div></div>'));
 
   adapter.current(function (data) {
     assert.equal(
@@ -141,6 +153,9 @@ test('no default value', function (assert) {
   var $element = $('<input />');
 
   var adapter = new InputAdapter($element, options);
+
+  var container = new MockContainer();
+  adapter.bind(container, $('<div></div>'));
 
   adapter.current(function (data) {
     assert.equal(


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- `data: ` and `tags: ` options are automatically added after binding to the container
- Fixed tests so they actually properly bind

If this is related to an existing ticket, include a link to it as well.

Fixes #4350