### PR TITLE
Select2 now clears the internal ID when it is destroyed

### DIFF
--- a/src/js/select2/utils.js
+++ b/src/js/select2/utils.js
@@ -332,6 +332,8 @@ define([
     if (Utils.__cache[id] != null) {
       delete Utils.__cache[id];
     }
+
+    element.removeAttribute('data-select2-id');
   };
 
   return Utils;

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -94,6 +94,7 @@
     <script src="selection/single-tests.js" type="text/javascript"></script>
     <script src="selection/stopPropagation-tests.js" type="text/javascript"></script>
 
+    <script src="utils/data-tests.js" type="text/javascript"></script>
     <script src="utils/decorator-tests.js" type="text/javascript"></script>
     <script src="utils/escapeMarkup-tests.js" type="text/javascript"></script>
   </body>

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -94,6 +94,7 @@
     <script src="selection/single-tests.js" type="text/javascript"></script>
     <script src="selection/stopPropagation-tests.js" type="text/javascript"></script>
 
+    <script src="utils/data-tests.js" type="text/javascript"></script>
     <script src="utils/decorator-tests.js" type="text/javascript"></script>
     <script src="utils/escapeMarkup-tests.js" type="text/javascript"></script>
   </body>

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -94,6 +94,7 @@
     <script src="selection/single-tests.js" type="text/javascript"></script>
     <script src="selection/stopPropagation-tests.js" type="text/javascript"></script>
 
+    <script src="utils/data-tests.js" type="text/javascript"></script>
     <script src="utils/decorator-tests.js" type="text/javascript"></script>
     <script src="utils/escapeMarkup-tests.js" type="text/javascript"></script>
   </body>

--- a/tests/utils/data-tests.js
+++ b/tests/utils/data-tests.js
@@ -1,0 +1,36 @@
+module('Utils - RemoveData');
+
+var $ = require('jquery');
+var Utils = require('select2/utils');
+
+test('The data-select2-id attribute is removed', function (assert) {
+    var $element = $('<select data-select2-id="test"></select>');
+
+    Utils.RemoveData($element[0]);
+
+    assert.notEqual(
+        $element.attr('data-select2-id'),
+        'test',
+        'The internal attribute was not removed when the data was cleared'
+    );
+});
+
+test('The internal cache for the element is cleared', function (assert) {
+    var $element = $('<select data-select2-id="test"></select>');
+
+    Utils.__cache.test = {
+        'foo': 'bar'
+    };
+
+    Utils.RemoveData($element[0]);
+
+    assert.equal(Utils.__cache.test, null, 'The cache should now be empty');
+});
+
+test('Calling it on an element without data works', function (assert) {
+    assert.expect(0);
+
+    var $element = $('<select></select>');
+
+    Utils.RemoveData($element[0]);
+});


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Remove the `data-select2-id` attribute when `RemoveData` is called
- Add some tests for `RemoveData

If this is related to an existing ticket, include a link to it as well.

Fixes #5247