### PR TITLE
Updated the qunit version to drop phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-connect": "^2.0.0",
     "grunt-contrib-jshint": "^1.1.0",
-    "grunt-contrib-qunit": "^1.3.0",
+    "grunt-contrib-qunit": "^3.1.0",
     "grunt-contrib-requirejs": "^1.0.0",
     "grunt-contrib-uglify": "~4.0.1",
     "grunt-contrib-watch": "~1.1.0",


### PR DESCRIPTION
Tests are currently being run with phantomjs which the maintainer
recomends switching to puppeteer and chrome

This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation
- [x] Misc

The following changes were made

- Upgrading grunt-qunit-contrib
- This converts us from phantomjs to headless chrome

If this is related to an existing ticket, include a link to it as well.
