### PR TITLE
Fix dropdown positioning when displayed above with messages

### DIFF
--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -33,6 +33,11 @@ define([
       self._resizeDropdown();
     });
 
+    container.on('results:message', function () {
+      self._positionDropdown();
+      self._resizeDropdown();
+    });
+
     container.on('select', function () {
       self._positionDropdown();
       self._resizeDropdown();


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Reposition dropdown whenever a message is displayed in the results

If this is related to an existing ticket, include a link to it as well.

Fixes #4614
Fixes #4616
Fixes #5253
Closes #5196