### PR TITLE
Add smooth scrolling to results on iOS Devices

### DIFF
--- a/src/scss/_dropdown.scss
+++ b/src/scss/_dropdown.scss
@@ -17,6 +17,7 @@
 }
 
 .select2-results {
+  -webkit-overflow-scrolling: touch;
   display: block;
 }
 


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

This CSS fix only enables "smooth" scrolling on the results on iOS Devices.

From the Docs (https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling):

"Use momentum-based scrolling, where the content continues to scroll for a while after finishing the scroll gesture and removing your finger from the touchscreen. The speed and duration of the continued scrolling is proportional to how vigorous the scroll gesture was. "

It should be now easier to scroll long result lists on a iOS mobile Device.

Cheers,
Bjoern