### PR TITLE
Solucionado error al abrir al en ventana modal

### DIFF
--- a/dist/js/select2.full.js
+++ b/dist/js/select2.full.js
@@ -5461,8 +5461,8 @@ S2.define('select2/core',[
     if (method == 'element') {
       var elementWidth = $element.outerWidth(false);
 
-      if (elementWidth <= 0) {
-        return 'auto';
+      if (elementWidth <= 1) {
+        return '100%';
       }
 
       return elementWidth + 'px';


### PR DESCRIPTION
Compatible con Bootstrap 4.

This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Permite cargar un select2 en una ventana modal

If this is related to an existing ticket, include a link to it as well.
