### PR TITLE
Update _single.scss

### DIFF
--- a/src/scss/theme/default/_single.scss
+++ b/src/scss/theme/default/_single.scss
@@ -12,6 +12,8 @@
     cursor: pointer;
     float: right;
     font-weight: bold;
+    margin-right: 8px;
+    z-index: 9;
   }
 
   .select2-selection__placeholder {


### PR DESCRIPTION
The "x" button is overlaped by the dropdown button.
With this margin right and z-index it is guarateed both button are displayed and working

This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

-
-
-

If this is related to an existing ticket, include a link to it as well.
