### PR TITLE
Replace cdnjs with jsDelivr in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Browser compatibility
 
 Usage
 -----
-You can source Select2 directly from a CDN like [JSDliver][jsdelivr] or
-[CDNJS][cdnjs], [download it from this GitHub repo][releases], or use one of
+You can source Select2 directly from a CDN like [jsDelivr][jsdelivr] or
+[cdnjs][cdnjs], [download it from this GitHub repo][releases], or use one of
 the integrations below.
 
 Integrations

--- a/docs/pages/01.getting-started/01.installation/docs.md
+++ b/docs/pages/01.getting-started/01.installation/docs.md
@@ -10,11 +10,11 @@ In order to use Select2, you must include the compiled JavaScript and CSS files 
 
 A CDN (content delivery network) is the fastest way to get up and running with Select2!
 
-Select2 is hosted on both the [cdnjs](https://cdnjs.com/libraries/select2) and [jsDelivr](https://www.jsdelivr.com/#!select2) CDNs. Simply include the following lines of code in the `<head>` section of your page:
+Select2 is hosted on both the [jsDelivr](https://www.jsdelivr.com/package/npm/select2) and [cdnjs](https://cdnjs.com/libraries/select2) CDNs. Simply include the following lines of code in the `<head>` section of your page:
 
 ```
-<link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.11/css/select2.min.css" rel="stylesheet" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.11/js/select2.min.js"></script>
+<link href="https://cdn.jsdelivr.net/npm/select2@4.0.11/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.0.11/dist/js/select2.min.js"></script>
 ```
 
 >>> <i class="fa fa-info-circle"></i> Immediately following a new release, it takes some time for CDNs to catch up and get the new versions live on the CDN.


### PR DESCRIPTION
This is needed until cdnjs figures out their future in
cdnjs/cdnjs#13524. Until then, we will just reference their existence
and promote jsDelivr to the primary source.

This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation
- [x] Documentation

The following changes were made

- Swapped out jsDelivr for cdnjs in the docs

If this is related to an existing ticket, include a link to it as well.
