### PR TITLE
Fix "edit this page" links in docs

### DIFF
--- a/docs/themes/site/site.yaml
+++ b/docs/themes/site/site.yaml
@@ -9,5 +9,5 @@ streams:
 google_analytics_code: UA-57144786-2
 github:
     position: top                                   # top | bottom | off
-    tree: https://github.com/select2/docs/blob/develop/
-    commits: https://github.com/select2/docs/commits/develop/
+    tree: https://github.com/select2/select2/blob/develop/docs/
+    commits: https://github.com/select2/select2/commits/develop/docs/


### PR DESCRIPTION
Currently the docs on select2.org link to https://github.com/select2/docs which has been archived. I believe this should fix that.

This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Update github configuration for docs theme
