### PR TITLE
Docs: Fix Selections templating example

### DIFF
--- a/docs/pages/08.selections/docs.md
+++ b/docs/pages/08.selections/docs.md
@@ -28,12 +28,8 @@ function formatState (state) {
 
   var baseUrl = "{{ url('user://pages/images/flags') }}";
   var $state = $(
-    '<span><img class="img-flag" /> <span></span></span>'
+    '<span><img src="' + baseUrl + '/' + state.element.value.toLowerCase() + '.png" class="img-flag" /> ' + state.text + '</span>'
   );
-
-  // Use .text() instead of HTML string concatenation to avoid script injection issues
-  $state.find("span").text(state.text);
-  $state.find("img").attr("src", baseUrl + "/" + state.element.value.toLowerCase() + ".png");
 
   return $state;
 };


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
The [docs page for selections](https://select2.org/selections) currently does not render the flags as intended in the example. This makes the code the same as is used on the [dropdown page](https://select2.org/dropdown), which does work
<img width="837" alt="Screen Shot 2019-10-31 at 1 21 22 PM" src="https://user-images.githubusercontent.com/157270/67983166-5f80ca00-fbe1-11e9-98dd-efb4b748f9cf.png">
<img width="830" alt="Screen Shot 2019-10-31 at 1 21 05 PM" src="https://user-images.githubusercontent.com/157270/67983170-627bba80-fbe1-11e9-9729-035d17bad98d.png">
