### PR TITLE
Only trigger 'selection:update' once on DOM change events

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -404,7 +404,7 @@ define([
       }
     } else if (mutations.removedNodes && mutations.removedNodes.length > 0) {
       changed = true;
-    } else if (Array.isArray(mutations)) {
+    } else if ($.isArray(mutations)) {
       $.each(mutations, function(evt, mutation) {
         if (self._isChangeMutation(evt, mutation)) {
           // We've found a change mutation.

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -407,13 +407,14 @@ define([
     } else if (Array.isArray(mutations)) {
       $.each(mutations, function(evt, mutation) {
         if (self._isChangeMutation(evt, mutation)) {
-          // We've found a change mutation, let's escape from the loop and continue
+          // We've found a change mutation.
+          // Let's escape from the loop and continue
           changed = true;
           return false;
         }
       });
     }
-    return changed
+    return changed;
   };
 
   Select2.prototype._syncSubtree = function (evt, mutations) {

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -290,7 +290,6 @@ test('searching tags does not loose focus', function (assert) {
 
 
 test('adding multiple options calls selection:update once', function (assert) {
-
   assert.expect(1);
 
   var asyncDone = assert.async();

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -1,3 +1,4 @@
+/*jshint browser: true */
 module('DOM integration');
 
 test('adding a new unselected option changes nothing', function (assert) {
@@ -285,4 +286,48 @@ test('searching tags does not loose focus', function (assert) {
 
   select.selection.trigger('query', {term: 'f'});
   select.selection.trigger('query', {term: 'ff'});
+});
+
+
+test('adding multiple options calls selection:update once', function (assert) {
+
+  assert.expect(1);
+
+  var asyncDone = assert.async();
+
+  var $ = require('jquery');
+  var Select2 = require('select2/core');
+
+  var content = '<select>';
+  var options = '';
+
+  for (var i = 0; i < 4000; i++) {
+    options += '<option>' + i + '</option>';
+  }
+
+  content += options;
+  content += '</select>';
+
+  var $select = $(content);
+
+  $('#qunit-fixture').append($select);
+
+  var select = new Select2($select);
+
+  var eventCalls = 0;
+
+  select.on('selection:update', function () {
+    eventCalls++;
+  });
+
+  $select.html(options);
+
+  setTimeout(function () {
+    assert.equal(
+      eventCalls,
+      1,
+      'selection:update was called more than once'
+    );
+    asyncDone();
+  }, 0);
 });


### PR DESCRIPTION
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Rather than triggering DOM updates for every mutation within the select, only do it once if at least one mutation is detected.

I've had an issue when using select2 with datatables editor. I have a dropdown that has 4000+ elements, loaded via datatables editor and ajax. Everytime I filter/sort/change page on the table a new request fires to get the data the correct page, but also (annoyingly and seemingly unnecessarily) the list of options for the dropdown gets returned again... This then causes the page to become unresponsive as select2 goes through and refreshes the DOM (I think, it's certainly doing something along those lines) 4000+ times for each option being removed, and 4000+ times for each option being added.

This issue didn't exist before 4.0.3, and the below changes fix it. All tests are still passing, but I could very easily have overlooked something important though.
