### PR TITLE
Fix Contribute link

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The license is available within the repository in the [LICENSE][license] file.
 
 ### Code Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute. [[Contribute](.github/CONTRIBUTING.md)].
 <a href="https://github.com/select2/select2/graphs/contributors"><img src="https://opencollective.com/select2/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix

Hi, the Contribute link returned for me Page Not Found. This is a fix for it.

Thank you all for this awesome library!

PS:  Another thing, this link is returning not found too: `https://opencollective.com/select2/contributors.svg?width=890&button=false`. It appears at the side of the Contribute link. I'm not sure how to solve this, so I'm just saying.
