### PR TITLE
Including the original event on enter key press and passing it along to final triggers

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -335,7 +335,9 @@ define([
 
           evt.preventDefault();
         } else if (key === KEYS.ENTER) {
-          self.trigger('results:select', evt);
+          self.trigger('results:select', {
+            originalEvent: evt
+          });
 
           evt.preventDefault();
         } else if ((key === KEYS.SPACE && evt.ctrlKey)) {

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -335,7 +335,7 @@ define([
 
           evt.preventDefault();
         } else if (key === KEYS.ENTER) {
-          self.trigger('results:select', {});
+          self.trigger('results:select', evt);
 
           evt.preventDefault();
         } else if ((key === KEYS.SPACE && evt.ctrlKey)) {

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -325,7 +325,7 @@ define([
       $highlighted.trigger('mouseup');
     });
 
-    container.on('results:select', function () {
+    container.on('results:select', function (evt) {
       var $highlighted = self.getHighlightedResults();
 
       if ($highlighted.length === 0) {
@@ -335,9 +335,12 @@ define([
       var data = Utils.GetData($highlighted[0], 'data');
 
       if ($highlighted.attr('aria-selected') == 'true') {
-        self.trigger('close', {});
+        self.trigger('close', {
+          originalEvent: evt
+        });
       } else {
         self.trigger('select', {
+          originalEvent: evt,
           data: data
         });
       }

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -336,11 +336,11 @@ define([
 
       if ($highlighted.attr('aria-selected') == 'true') {
         self.trigger('close', {
-          originalEvent: evt
+          originalEvent: evt.originalEvent
         });
       } else {
         self.trigger('select', {
-          originalEvent: evt,
+          originalEvent: evt.originalEvent,
           data: data
         });
       }


### PR DESCRIPTION
This is a continuation of the work done for #5513 by @6pac.

The original event is included if the user tabs off the dropdown, but not if the user uses the enter key to select the item.  This change adds the original event to the enter key press and then makes sure it is passed along to both the `close `and `select `triggers inside the the `results:select` handler.

The existing container `select` handler already includes the original event if it is present, so this is all that was needed to get that to work.
