### PR TITLE
Changed tab key press to behave the same as enter key and select the highlighted option

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -329,12 +329,11 @@ define([
       var key = evt.which;
 
       if (self.isOpen()) {
-        if (key === KEYS.ESC || key === KEYS.TAB ||
-            (key === KEYS.UP && evt.altKey)) {
+        if (key === KEYS.ESC || (key === KEYS.UP && evt.altKey)) {
           self.close(evt);
 
           evt.preventDefault();
-        } else if (key === KEYS.ENTER) {
+        } else if (key === KEYS.ENTER || key === KEYS.TAB) {
           self.trigger('results:select', {});
 
           evt.preventDefault();


### PR DESCRIPTION
Changed tab key press to behave the same as enter key and select the highlighted option.  This is consistent with modern browser behavior for `<select>` elements.

#4820 