### PR TITLE
Fix selection search resizeSearch on close

### DIFF
--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -40,6 +40,7 @@ define([
 
     container.on('close', function () {
       self.$search.val('');
+      self.resizeSearch();
       self.$search.removeAttr('aria-controls');
       self.$search.removeAttr('aria-activedescendant');
       self.$search.trigger('focus');


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Add call for resizeSearch after clearing search element (selection search)

Reproduction

1) type text => width increases
2) without selecting any choice press 'Esc' 
3) input value is empty but width of input element isn't updated
