### PR TITLE
JQuery "find" replaced with more efficient "querySelectorAll" in SelectAdapter

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -14,15 +14,19 @@ define([
 
   SelectAdapter.prototype.current = function (callback) {
     var data = [];
-    var self = this;
 
-    this.$element.find(':selected').each(function () {
-      var $option = $(this);
+    var domElement = this.$element[0];
 
-      var option = self.item($option);
+    var selectedElements = domElement.querySelectorAll(':checked');
+
+    for (var index = 0; index < selectedElements.length; index++) {
+      var selectedElement = selectedElements[index];
+      var $option = $(selectedElement);
+
+      var option = this.item($option);
 
       data.push(option);
-    });
+    }
 
     callback(data);
   };

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -13,20 +13,14 @@ define([
   Utils.Extend(SelectAdapter, BaseAdapter);
 
   SelectAdapter.prototype.current = function (callback) {
-    var data = [];
+    var self = this;
 
-    var domElement = this.$element[0];
-
-    var selectedElements = domElement.querySelectorAll(':checked');
-
-    for (var index = 0; index < selectedElements.length; index++) {
-      var selectedElement = selectedElements[index];
-      var $option = $(selectedElement);
-
-      var option = this.item($option);
-
-      data.push(option);
-    }
+    var data = Array.prototype.map.call(
+      this.$element[0].querySelectorAll(':checked'),
+      function (selectedElement) {
+        return self.item($(selectedElement));
+      }
+    );
 
     callback(data);
   };


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- in `SelectAdapter`'s `current` method replaced expensive call to `jQuery.find` with more efficient call to `DOMElement.querySelectorAll`

According to [W3C Recommendation 06 November 2018](https://www.w3.org/TR/selectors-3/#checked), 

> the :checked pseudo-class initially applies to such elements that have the HTML4 selected and checked attributes

which is applicable for our case.

Here is an example illustrating the problems of jQuery.find method: https://jsfiddle.net/vyshkant/nzr4kp8u/12/

**CAUTION**: an execution of the example might take about 2 minutes (which actually illustrates the degradation of jQuery.find with increasing the number of `option` tags.

In my personal case I have a middle-size db which includes about 20 000 of options and it is impossible to use Select2 because of the timing.