### PR TITLE
Add the option to pre-select in case of data array

### DIFF
--- a/src/js/select2/options.js
+++ b/src/js/select2/options.js
@@ -127,6 +127,19 @@ define([
       }
     }
 
+    if ($e.data('selected')) {
+      let selected = $e.data('selected');
+      if (!Array.isArray(selected)) {
+        selected = [selected];
+      }
+      selected.forEach(s => {
+        const index = this.options.data.findIndex(x => x.id === s);
+        if (index !== false) {
+          this.options.data[index].selected = true;
+        }
+      });
+    }
+    
     return this;
   };
 

--- a/src/js/select2/options.js
+++ b/src/js/select2/options.js
@@ -128,16 +128,18 @@ define([
     }
 
     if ($e.data('selected')) {
-      let selected = $e.data('selected');
+      var selected = $e.data('selected');
       if (!Array.isArray(selected)) {
         selected = [selected];
       }
-      selected.forEach(s => {
-        const index = this.options.data.findIndex(x => x.id === s);
+      selected.forEach(function(s) {
+        var index = this.options.data.findIndex(function (x) {
+          return x.id === s;
+        });
         if (index !== false) {
           this.options.data[index].selected = true;
         }
-      });
+      }.bind(this));
     }
     
     return this;


### PR DESCRIPTION
You can use `data-selected` attribute with a single id (`"5"`) or an array of multiple ids (`"[1,3,5]"`), useful in case you're getting `data-data` straight from your database but your selected options are comming from a different location.

This pull request includes a __New feature__ .

The following changes were made

- Before returning the scope of `Options.prototype.fromElement`, some`options.data` are manipulated to add `.selected = true`

This is related the existing ticket: #5778 
