### PR TITLE
Update highlightFirstItem to take tags in to consideration

### DIFF
--- a/src/js/select2/data/tags.js
+++ b/src/js/select2/data/tags.js
@@ -78,7 +78,7 @@ define([
 
       if (tag != null) {
         var $option = self.option(tag);
-        $option.attr('data-select2-tag', true);
+        $option.attr('data-select2-tag', 'true');
 
         self.addOptions([$option]);
 

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -33,6 +33,7 @@ define([
   './dropdown/selectOnClose',
   './dropdown/closeOnSelect',
   './dropdown/dropdownCss',
+  './dropdown/tagsSearchHighlight',
 
   './i18n/en'
 ], function ($,
@@ -49,7 +50,7 @@ define([
 
              Dropdown, DropdownSearch, HidePlaceholder, InfiniteScroll,
              AttachBody, MinimumResultsForSearch, SelectOnClose, CloseOnSelect,
-             DropdownCSS,
+             DropdownCSS, TagsSearchHighlight,
 
              EnglishTranslation) {
   function Defaults () {
@@ -122,6 +123,13 @@ define([
         options.resultsAdapter = Utils.Decorate(
           options.resultsAdapter,
           SelectOnClose
+        );
+      }
+
+      if (options.tags) {
+        options.resultsAdapter = Utils.Decorate(
+          options.resultsAdapter,
+          TagsSearchHighlight
         );
       }
     }

--- a/src/js/select2/dropdown/tagsSearchHighlight.js
+++ b/src/js/select2/dropdown/tagsSearchHighlight.js
@@ -1,31 +1,31 @@
 define([
-    '../utils'
+  '../utils'
 ], function (Utils) {
-    function TagsSearchHighlight () { }
+  function TagsSearchHighlight () { }
 
-    TagsSearchHighlight.prototype.highlightFirstItem = function (decorated) {
-        var $options = this.$results
-        .find(
-            '.select2-results__option--selectable' +
-            ':not(.select2-results__option--selected)'
-        );
+  TagsSearchHighlight.prototype.highlightFirstItem = function (decorated) {
+    var $options = this.$results
+    .find(
+      '.select2-results__option--selectable' +
+      ':not(.select2-results__option--selected)'
+    );
 
-        if ($options.length > 0) {
-            var $firstOption = $options.first();
-            var data = Utils.GetData($firstOption[0], 'data');
-            var firstElement = data.element;
+    if ($options.length > 0) {
+      var $firstOption = $options.first();
+      var data = Utils.GetData($firstOption[0], 'data');
+      var firstElement = data.element;
 
-            if (firstElement && firstElement.getAttribute) {
-                if (firstElement.getAttribute('data-select2-tag') === 'true') {
-                    $firstOption.trigger('mouseenter');
+      if (firstElement && firstElement.getAttribute) {
+        if (firstElement.getAttribute('data-select2-tag') === 'true') {
+          $firstOption.trigger('mouseenter');
 
-                    return;
-                }
-            }
+          return;
         }
+      }
+    }
 
-        decorated.call(this);
-    };
+    decorated.call(this);
+  };
 
-    return TagsSearchHighlight;
+  return TagsSearchHighlight;
 });

--- a/src/js/select2/dropdown/tagsSearchHighlight.js
+++ b/src/js/select2/dropdown/tagsSearchHighlight.js
@@ -1,0 +1,31 @@
+define([
+    '../utils'
+], function (Utils) {
+    function TagsSearchHighlight () { }
+
+    TagsSearchHighlight.prototype.highlightFirstItem = function (decorated) {
+        var $options = this.$results
+        .find(
+            '.select2-results__option--selectable' +
+            ':not(.select2-results__option--selected)'
+        );
+
+        if ($options.length > 0) {
+            var $firstOption = $options.first();
+            var data = Utils.GetData($firstOption[0], 'data');
+            var firstElement = data.element;
+
+            if (firstElement && firstElement.getAttribute) {
+                if (firstElement.getAttribute('data-select2-tag') === 'true') {
+                    $firstOption.trigger('mouseenter');
+
+                    return;
+                }
+            }
+        }
+
+        decorated.call(this);
+    };
+
+    return TagsSearchHighlight;
+});

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -102,9 +102,13 @@ define([
       .find('.select2-results__option--selectable');
 
     var $selected = $options.filter('.select2-results__option--selected');
+    var $unselected  = $options.filter('[aria-selected=false]');
 
-    // Check if there are any selected options
-    if ($selected.length > 0) {
+    // Check if there are any unselected options in tags mode
+    if ($unselected.length > 0 && this.options.get('tags')) {
+      $unselected.last().trigger('mouseenter');
+    } else if ($selected.length > 0) {
+      // Check if there are any selected options
       // If there are selected options, highlight the first
       $selected.first().trigger('mouseenter');
     } else {

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -102,13 +102,9 @@ define([
       .find('.select2-results__option--selectable');
 
     var $selected = $options.filter('.select2-results__option--selected');
-    var $unselected  = $options.filter('[aria-selected=false]');
 
-    // Check if there are any unselected options in tags mode
-    if ($unselected.length > 0 && this.options.get('tags')) {
-      $unselected.last().trigger('mouseenter');
-    } else if ($selected.length > 0) {
-      // Check if there are any selected options
+    // Check if there are any selected options
+    if ($selected.length > 0) {
       // If there are selected options, highlight the first
       $selected.first().trigger('mouseenter');
     } else {

--- a/tests/results/focusing-tests.js
+++ b/tests/results/focusing-tests.js
@@ -239,3 +239,113 @@ test('!scrollAfterSelect does not trigger results:focus', function (assert) {
 
   container.trigger('select', {});
 });
+
+test('tag result is highlighted with no other selections', function (assert) {
+  assert.expect(2);
+
+  var $ = require('jquery');
+
+  var $select = $('<select></select>');
+  var $parent = $('<div></div>');
+
+  var $container = $('<span></span>');
+  var container = new MockContainer();
+
+  $parent.appendTo($('#qunit-fixture'));
+  $select.appendTo($parent);
+
+  var Utils = require('select2/utils');
+  var Options = require('select2/options');
+
+  var Results = require('select2/results');
+  var Tags = require('select2/dropdown/tagsSearchHighlight');
+  var TagResults = Utils.Decorate(Results, Tags);
+
+  var results = new TagResults($select, new Options({}));
+
+  // Fake the data adapter for the `setClasses` method
+  results.data = {};
+  results.data.current = function (callback) {
+    callback([]);
+  };
+
+  results.render();
+
+  results.bind(container, $container);
+
+  results.on('results:focus', function (params) {
+    assert.equal(params.data.id, 'tag');
+    assert.equal(params.data.text, 'Tag');
+  });
+
+  var tagElement = $('<option data-select2-tag="true"></option>')[0];
+
+  container.trigger('results:all', {
+    data: {
+      results: [
+        {
+          id: 'tag',
+          text: 'Tag',
+          element: tagElement
+        }
+      ]
+    }
+  });
+});
+
+test('tag result is highlighted with other selections', function (assert) {
+  assert.expect(2);
+
+  var $ = require('jquery');
+
+  var $select = $('<select></select>');
+  var $parent = $('<div></div>');
+
+  var $container = $('<span></span>');
+  var container = new MockContainer();
+
+  $parent.appendTo($('#qunit-fixture'));
+  $select.appendTo($parent);
+
+  var Utils = require('select2/utils');
+  var Options = require('select2/options');
+
+  var Results = require('select2/results');
+  var Tags = require('select2/dropdown/tagsSearchHighlight');
+  var TagResults = Utils.Decorate(Results, Tags);
+
+  var results = new TagResults($select, new Options({}));
+
+  // Fake the data adapter for the `setClasses` method
+  results.data = {};
+  results.data.current = function (callback) {
+    callback([{ id: 'test' }]);
+  };
+
+  results.render();
+
+  results.bind(container, $container);
+
+  results.on('results:focus', function (params) {
+    assert.equal(params.data.id, 'tag');
+    assert.equal(params.data.text, 'Tag');
+  });
+
+  var tagElement = $('<option data-select2-tag="true"></option>')[0];
+
+  container.trigger('results:all', {
+    data: {
+      results: [
+        {
+          id: 'tag',
+          text: 'Tag',
+          element: tagElement
+        },
+        {
+          id: 'test',
+          text: 'Test'
+        }
+      ]
+    }
+  });
+});


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made:

- Update `Results.prototype.highlightFirstItem` to check for unselected options and if the `tags` option is set. If so, highlight this first instead of a previously selected option.

This works at the moment when no tags exist, but not when there are existing selected tags.

__Fix__

![image](https://user-images.githubusercontent.com/1721925/77555279-00349680-6eaf-11ea-827c-9a5a9476f0af.png)

__Current__

![image](https://user-images.githubusercontent.com/1721925/77555485-2f4b0800-6eaf-11ea-8a30-8a9f30383972.png)

