### PR TITLE
Fix select2#5378 ie11 specific focus issue.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function (grunt) {
     cwd: 'src/js'
   }, 'select2/i18n/*.js');
 
-  var testFiles = grunt.file.expand('tests/**/*.html');
+  var testFiles = grunt.file.expand('tests/**/!(manual)*.html');
   var testUrls = testFiles.map(function (filePath) {
     return 'http://localhost:9999/' + filePath;
   });

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -27,6 +27,14 @@ define([
   };
 
   Search.prototype.bind = function (decorated, container, $container) {
+    // Try to detect the IE version should the `documentMode` property that
+    // is stored on the document. This is only implemented in IE and is
+    // slightly cleaner than doing a user agent check.
+    // This property is not available in Edge, but Edge also doesn't have
+    // this bug.
+    var msie = document.documentMode;
+    var disableInputEvents = msie && msie <= 11;
+
     var self = this;
 
     var resultsId = container.id + '-results';
@@ -72,7 +80,14 @@ define([
     });
 
     this.$selection.on('focusout', '.select2-search--inline', function (evt) {
-      self._handleBlur(evt);
+      // IE moves the focus to body at random moments, if that happens, refocus.
+      if(disableInputEvents &&
+         evt.relatedTarget && evt.relatedTarget.localName === 'body') {
+        evt.preventDefault();
+        self.$search.trigger('focus');
+      } else {
+        self._handleBlur(evt);
+      }
     });
 
     this.$selection.on('keydown', '.select2-search--inline', function (evt) {
@@ -103,14 +118,6 @@ define([
         evt.stopPropagation();
       }
     });
-
-    // Try to detect the IE version should the `documentMode` property that
-    // is stored on the document. This is only implemented in IE and is
-    // slightly cleaner than doing a user agent check.
-    // This property is not available in Edge, but Edge also doesn't have
-    // this bug.
-    var msie = document.documentMode;
-    var disableInputEvents = msie && msie <= 11;
 
     // Workaround for browsers which do not support the `input` event
     // This will prevent double-triggering of events for browsers which support

--- a/tests/manual-test-ie11.html
+++ b/tests/manual-test-ie11.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Select2</title>
+    <script src="vendor/jquery-3.4.1.js" type="text/javascript"></script>
+    <link href="../dist/css/select2.css" type="text/css" rel="stylesheet"/>
+    <script src="../dist/js/select2.full.js" type="text/javascript"></script>
+</head>
+<body>
+        <div id="body-inner">
+            <div class="s2-example">
+                <p>
+                    Currently no automatic testing for IE11. This page allows you to manually test IE11.<br>
+                    The bug: After typing 1, 2, or 3 characters you will loose focus and can no longer continue typing.<br>
+                    <br>
+                    <select class="js-example-tags form-control" multiple="multiple" style="width:500px;">
+                        <option selected="selected">orange</option>
+                        <option>white</option>
+                        <option selected="selected">purple</option>
+                    </select>
+                </p>
+            </div>
+            <script type="text/javascript">
+                $(".js-example-tags").select2({ tags: true });
+            </script>
+        </div>
+</body>
+</html>

--- a/tests/manual-test-ie11.html
+++ b/tests/manual-test-ie11.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="utf-8"/>
     <title>Select2</title>
-    <script src="../vendor/jquery-3.4.1.js" type="text/javascript"></script>
-    <link href="../../dist/css/select2.css" type="text/css" rel="stylesheet"/>
-    <script src="../../dist/js/select2.full.js" type="text/javascript"></script>
+    <script src="vendor/jquery-3.4.1.js" type="text/javascript"></script>
+    <link href="../dist/css/select2.css" type="text/css" rel="stylesheet"/>
+    <script src="../dist/js/select2.full.js" type="text/javascript"></script>
 </head>
 <body>
         <div id="body-inner">

--- a/tests/manual/manual-test-ie11.html
+++ b/tests/manual/manual-test-ie11.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="utf-8"/>
     <title>Select2</title>
-    <script src="vendor/jquery-3.4.1.js" type="text/javascript"></script>
-    <link href="../dist/css/select2.css" type="text/css" rel="stylesheet"/>
-    <script src="../dist/js/select2.full.js" type="text/javascript"></script>
+    <script src="../vendor/jquery-3.4.1.js" type="text/javascript"></script>
+    <link href="../../dist/css/select2.css" type="text/css" rel="stylesheet"/>
+    <script src="../../dist/js/select2.full.js" type="text/javascript"></script>
 </head>
 <body>
         <div id="body-inner">


### PR DESCRIPTION
This pull request includes a
- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
 - Existing IE detection moved up a few lines so they are declared before they are used.
 - On the focusout event of the search-input use the existing variable to detect IE
 - If IE, and the event comes from the tag, refocuses so we can keep typing
 - Couldn't add an automatic IE11 test but added a html file where you can manually test this issue

If this is related to an existing ticket, include a link to it as well.
Original issue #5378 
Original PR #5453 / second attempt PR #5658 
Probably fixes the same issue as was attempted by the removed code from https://github.com/select2/select2/commit/a83be86e9a2ecf0965ffa20965efe855783e0c24 
I think the removed code no longer fixes the issue and can stay removed.


