### PR TITLE
Remove support for legacy IE

### DIFF
--- a/src/js/jquery.select2.js
+++ b/src/js/jquery.select2.js
@@ -39,7 +39,7 @@ define([
         });
 
         // Check if we should be returning `this`
-        if ($.inArray(options, thisMethods) > -1) {
+        if (thisMethods.indexOf(options) > -1) {
           return this;
         }
 

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -545,7 +545,7 @@ define([
     var newVal = args[0];
 
     if (Array.isArray(newVal)) {
-      newVal = $.map(newVal, function (obj) {
+      newVal = newVal.map(function (obj) {
         return obj.toString();
       });
     }

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -77,7 +77,7 @@ define([
     });
 
     // Hide the original select
-    $element.addClass('select2-hidden-accessible');
+    $element[0].classList.add('select2-hidden-accessible');
     $element.attr('aria-hidden', 'true');
 
     // Synchronize any monitored attributes
@@ -284,23 +284,23 @@ define([
     var self = this;
 
     this.on('open', function () {
-      self.$container.addClass('select2-container--open');
+      self.$container[0].classList.add('select2-container--open');
     });
 
     this.on('close', function () {
-      self.$container.removeClass('select2-container--open');
+      self.$container[0].classList.remove('select2-container--open');
     });
 
     this.on('enable', function () {
-      self.$container.removeClass('select2-container--disabled');
+      self.$container[0].classList.remove('select2-container--disabled');
     });
 
     this.on('disable', function () {
-      self.$container.addClass('select2-container--disabled');
+      self.$container[0].classList.add('select2-container--disabled');
     });
 
     this.on('blur', function () {
-      self.$container.removeClass('select2-container--focus');
+      self.$container[0].classList.remove('select2-container--focus');
     });
 
     this.on('query', function (params) {
@@ -523,11 +523,11 @@ define([
   };
 
   Select2.prototype.isOpen = function () {
-    return this.$container.hasClass('select2-container--open');
+    return this.$container[0].classList.contains('select2-container--open');
   };
 
   Select2.prototype.hasFocus = function () {
-    return this.$container.hasClass('select2-container--focus');
+    return this.$container[0].classList.contains('select2-container--focus');
   };
 
   Select2.prototype.focus = function (data) {
@@ -536,7 +536,7 @@ define([
       return;
     }
 
-    this.$container.addClass('select2-container--focus');
+    this.$container[0].classList.add('select2-container--focus');
     this.trigger('focus', {});
   };
 
@@ -625,7 +625,7 @@ define([
     this.$element.attr('tabindex',
     Utils.GetData(this.$element[0], 'old-tabindex'));
 
-    this.$element.removeClass('select2-hidden-accessible');
+    this.$element[0].classList.remove('select2-hidden-accessible');
     this.$element.attr('aria-hidden', 'false');
     Utils.RemoveData(this.$element[0]);
     this.$element.removeData('select2');
@@ -653,7 +653,8 @@ define([
 
     this.$container = $container;
 
-    this.$container.addClass('select2-container--' + this.options.get('theme'));
+    this.$container[0].classList
+      .add('select2-container--' + this.options.get('theme'));
 
     Utils.StoreData($container[0], 'element', this.$element);
 

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -256,7 +256,7 @@ define([
     });
 
     this.selection.on('*', function (name, params) {
-      if ($.inArray(name, nonRelayEvents) !== -1) {
+      if (nonRelayEvents.indexOf(name) !== -1) {
         return;
       }
 

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -404,7 +404,7 @@ define([
       }
     } else if (mutations.removedNodes && mutations.removedNodes.length > 0) {
       changed = true;
-    } else if ($.isArray(mutations)) {
+    } else if (Array.isArray(mutations)) {
       $.each(mutations, function(evt, mutation) {
         if (self._isChangeMutation(evt, mutation)) {
           // We've found a change mutation.
@@ -590,7 +590,7 @@ define([
 
     var newVal = args[0];
 
-    if ($.isArray(newVal)) {
+    if (Array.isArray(newVal)) {
       newVal = $.map(newVal, function (obj) {
         return obj.toString();
       });

--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -70,7 +70,7 @@ define([
 
         if (self.options.get('debug') && window.console && console.error) {
           // Check to make sure that the response included a `results` key.
-          if (!results || !results.results || !$.isArray(results.results)) {
+          if (!results || !results.results || !Array.isArray(results.results)) {
             console.error(
               'Select2: The AJAX results did not return an array in the ' +
               '`results` key of the response.'

--- a/src/js/select2/data/array.js
+++ b/src/js/select2/data/array.js
@@ -52,7 +52,7 @@ define([
       var item = this._normalizeItem(data[d]);
 
       // Skip items which were pre-loaded, only merge the data
-      if ($.inArray(item.id, existingIds) >= 0) {
+      if (existingIds.indexOf(item.id) >= 0) {
         var $existingOption = $existing.filter(onlyItem(item));
 
         var existingData = this.item($existingOption);

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -53,7 +53,7 @@ define([
         for (var d = 0; d < data.length; d++) {
           var id = data[d].id;
 
-          if ($.inArray(id, val) === -1) {
+          if (val.indexOf(id) === -1) {
             val.push(id);
           }
         }
@@ -95,7 +95,7 @@ define([
       for (var d = 0; d < currentData.length; d++) {
         var id = currentData[d].id;
 
-        if (id !== data.id && $.inArray(id, val) === -1) {
+        if (id !== data.id && val.indexOf(id) === -1) {
           val.push(id);
         }
       }

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -33,7 +33,9 @@ define([
     data.selected = true;
 
     // If data.element is a DOM node, use it instead
-    if ($(data.element).is('option')) {
+    if (
+      data.element != null && data.element.tagName.toLowerCase() === 'option'
+    ) {
       data.element.selected = true;
 
       this.$element.trigger('input').trigger('change');
@@ -76,7 +78,10 @@ define([
 
     data.selected = false;
 
-    if ($(data.element).is('option')) {
+    if (
+      data.element != null &&
+      data.element.tagName.toLowerCase() === 'option'
+    ) {
       data.element.selected = false;
 
       this.$element.trigger('input').trigger('change');
@@ -130,11 +135,14 @@ define([
     var $options = this.$element.children();
 
     $options.each(function () {
-      var $option = $(this);
-
-      if (!$option.is('option') && !$option.is('optgroup')) {
+      if (
+        this.tagName.toLowerCase() !== 'option' &&
+        this.tagName.toLowerCase() !== 'optgroup'
+      ) {
         return;
       }
+
+      var $option = $(this);
 
       var option = self.item($option);
 
@@ -186,15 +194,13 @@ define([
       option.title = data.title;
     }
 
-    var $option = $(option);
-
     var normalizedData = this._normalizeItem(data);
     normalizedData.element = option;
 
     // Override the option's data with the combined data
     Utils.StoreData(option, 'data', normalizedData);
 
-    return $option;
+    return $(option);
   };
 
   SelectAdapter.prototype.item = function ($option) {
@@ -206,7 +212,9 @@ define([
       return data;
     }
 
-    if ($option.is('option')) {
+    var option = $option[0];
+
+    if (option.tagName.toLowerCase() === 'option') {
       data = {
         id: $option.val(),
         text: $option.text(),
@@ -214,7 +222,7 @@ define([
         selected: $option.prop('selected'),
         title: $option.prop('title')
       };
-    } else if ($option.is('optgroup')) {
+    } else if (option.tagName.toLowerCase() === 'optgroup') {
       data = {
         text: $option.prop('label'),
         children: [],

--- a/src/js/select2/data/tags.js
+++ b/src/js/select2/data/tags.js
@@ -94,7 +94,11 @@ define([
   };
 
   Tags.prototype.createTag = function (decorated, params) {
-    var term = $.trim(params.term);
+    if (params.term == null) {
+      return null;
+    }
+
+    var term = params.term.trim();
 
     if (term === '') {
       return null;

--- a/src/js/select2/data/tags.js
+++ b/src/js/select2/data/tags.js
@@ -18,7 +18,7 @@ define([
 
     decorated.call(this, $element, options);
 
-    if ($.isArray(tags)) {
+    if (Array.isArray(tags)) {
       for (var t = 0; t < tags.length; t++) {
         var tag = tags[t];
         var item = this._normalizeItem(tag);

--- a/src/js/select2/data/tokenizer.js
+++ b/src/js/select2/data/tokenizer.js
@@ -82,7 +82,7 @@ define([
     while (i < term.length) {
       var termChar = term[i];
 
-      if ($.inArray(termChar, separators) === -1) {
+      if (separators.indexOf(termChar) === -1) {
         i++;
 
         continue;

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -251,7 +251,7 @@ define([
 
     function matcher (params, data) {
       // Always return the object if there is nothing to compare
-      if ($.trim(params.term) === '') {
+      if (params.term == null || params.term.trim() === '') {
         return data;
       }
 

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -355,7 +355,7 @@ define([
 
     var languages;
 
-    if (!$.isArray(language)) {
+    if (!Array.isArray(language)) {
       languages = [language];
     } else {
       languages = language;

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -41,8 +41,8 @@ define([
     // Clone all of the container classes
     $dropdown.attr('class', $container.attr('class'));
 
-    $dropdown.removeClass('select2');
-    $dropdown.addClass('select2-container--open');
+    $dropdown[0].classList.remove('select2');
+    $dropdown[0].classList.add('select2-container--open');
 
     $dropdown.css({
       position: 'absolute',
@@ -148,8 +148,10 @@ define([
   AttachBody.prototype._positionDropdown = function () {
     var $window = $(window);
 
-    var isCurrentlyAbove = this.$dropdown.hasClass('select2-dropdown--above');
-    var isCurrentlyBelow = this.$dropdown.hasClass('select2-dropdown--below');
+    var isCurrentlyAbove = this.$dropdown[0].classList
+      .contains('select2-dropdown--above');
+    var isCurrentlyBelow = this.$dropdown[0].classList
+      .contains('select2-dropdown--below');
 
     var newDirection = null;
 
@@ -221,12 +223,13 @@ define([
     }
 
     if (newDirection != null) {
-      this.$dropdown
-        .removeClass('select2-dropdown--below select2-dropdown--above')
-        .addClass('select2-dropdown--' + newDirection);
-      this.$container
-        .removeClass('select2-container--below select2-container--above')
-        .addClass('select2-container--' + newDirection);
+      this.$dropdown[0].classList.remove('select2-dropdown--below');
+      this.$dropdown[0].classList.remove('select2-dropdown--above');
+      this.$dropdown[0].classList.add('select2-dropdown--' + newDirection);
+
+      this.$container[0].classList.remove('select2-container--below');
+      this.$container[0].classList.remove('select2-container--above');
+      this.$container[0].classList.add('select2-container--' + newDirection);
     }
 
     this.$dropdownContainer.css(css);

--- a/src/js/select2/dropdown/attachContainer.js
+++ b/src/js/select2/dropdown/attachContainer.js
@@ -10,8 +10,8 @@ define([
     var $dropdownContainer = $container.find('.dropdown-wrapper');
     $dropdownContainer.append($dropdown);
 
-    $dropdown.addClass('select2-dropdown--below');
-    $container.addClass('select2-container--below');
+    $dropdown[0].classList.add('select2-dropdown--below');
+    $container[0].classList.add('select2-container--below');
   };
 
   return AttachContainer;

--- a/src/js/select2/dropdown/dropdownCss.js
+++ b/src/js/select2/dropdown/dropdownCss.js
@@ -1,7 +1,6 @@
 define([
-  'jquery',
   '../utils'
-], function ($, Utils) {
+], function (Utils) {
   function DropdownCSS () { }
 
   DropdownCSS.prototype.render = function (decorated) {
@@ -12,7 +11,7 @@ define([
     if (dropdownCssClass.indexOf(':all:') !== -1) {
       dropdownCssClass = dropdownCssClass.replace(':all:', '');
 
-      Utils.copyNonInternalCssClasses($dropdown, this.$element);
+      Utils.copyNonInternalCssClasses($dropdown[0], this.$element[0]);
     }
 
     $dropdown.addClass(dropdownCssClass);

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -78,9 +78,9 @@ define([
         var showSearch = self.showSearch(params);
 
         if (showSearch) {
-          self.$searchContainer.removeClass('select2-search--hide');
+          self.$searchContainer[0].classList.remove('select2-search--hide');
         } else {
-          self.$searchContainer.addClass('select2-search--hide');
+          self.$searchContainer[0].classList.add('select2-search--hide');
         }
       }
     });

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -1,7 +1,6 @@
 define([
-  'jquery',
-  '../utils'
-], function ($, Utils) {
+  'jquery'
+], function ($) {
   function Search () { }
 
   Search.prototype.render = function (decorated) {

--- a/src/js/select2/options.js
+++ b/src/js/select2/options.js
@@ -106,7 +106,7 @@ define([
     data = Utils._convertData(data);
 
     for (var key in data) {
-      if ($.inArray(key, excludedData) > -1) {
+      if (excludedData.indexOf(key) > -1) {
         continue;
       }
 

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -136,7 +136,7 @@ define([
         var id = '' + item.id;
 
         if ((item.element != null && item.element.selected) ||
-            (item.element == null && $.inArray(id, selectedIds) > -1)) {
+            (item.element == null && selectedIds.indexOf(id) > -1)) {
           $option.attr('aria-selected', 'true');
         } else {
           $option.attr('aria-selected', 'false');

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -120,7 +120,7 @@ define([
     var self = this;
 
     this.data.current(function (selected) {
-      var selectedIds = $.map(selected, function (s) {
+      var selectedIds = selected.map(function (s) {
         return s.id.toString();
       });
 

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -409,7 +409,7 @@ define([
     });
 
     container.on('results:focus', function (params) {
-      params.element.addClass('select2-results__option--highlighted');
+      params.element[0].classList.add('select2-results__option--highlighted');
     });
 
     container.on('results:message', function (params) {

--- a/src/js/select2/selection/eventRelay.js
+++ b/src/js/select2/selection/eventRelay.js
@@ -21,7 +21,7 @@ define([
 
     container.on('*', function (name, params) {
       // Ignore events that should not be relayed
-      if ($.inArray(name, relayEvents) === -1) {
+      if (relayEvents.indexOf(name) === -1) {
         return;
       }
 
@@ -36,7 +36,7 @@ define([
       self.$element.trigger(evt);
 
       // Only handle preventable events if it was one
-      if ($.inArray(name, preventableEvents) === -1) {
+      if (preventableEvents.indexOf(name) === -1) {
         return;
       }
 

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -12,7 +12,7 @@ define([
   MultipleSelection.prototype.render = function () {
     var $selection = MultipleSelection.__super__.render.call(this);
 
-    $selection.addClass('select2-selection--multiple');
+    $selection[0].classList.add('select2-selection--multiple');
 
     $selection.html(
       '<ul class="select2-selection__rendered"></ul>'

--- a/src/js/select2/selection/placeholder.js
+++ b/src/js/select2/selection/placeholder.js
@@ -22,8 +22,8 @@ define([
     var $placeholder = this.selectionContainer();
 
     $placeholder.html(this.display(placeholder));
-    $placeholder.addClass('select2-selection__placeholder')
-                .removeClass('select2-selection__choice');
+    $placeholder[0].classList.add('select2-selection__placeholder');
+    $placeholder[0].classList.remove('select2-selection__choice');
 
     return $placeholder;
   };

--- a/src/js/select2/selection/placeholder.js
+++ b/src/js/select2/selection/placeholder.js
@@ -1,6 +1,6 @@
 define([
-  '../utils'
-], function (Utils) {
+
+], function () {
   function Placeholder (decorated, $element, options) {
     this.placeholder = this.normalizePlaceholder(options.get('placeholder'));
 

--- a/src/js/select2/selection/selectionCss.js
+++ b/src/js/select2/selection/selectionCss.js
@@ -1,7 +1,6 @@
 define([
-  'jquery',
   '../utils'
-], function ($, Utils) {
+], function (Utils) {
   function SelectionCSS () { }
 
   SelectionCSS.prototype.render = function (decorated) {
@@ -12,7 +11,7 @@ define([
     if (selectionCssClass.indexOf(':all:') !== -1) {
       selectionCssClass = selectionCssClass.replace(':all:', '');
 
-      Utils.copyNonInternalCssClasses($selection, this.$element);
+      Utils.copyNonInternalCssClasses($selection[0], this.$element[0]);
     }
 
     $selection.addClass(selectionCssClass);

--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -13,7 +13,7 @@ define([
   SingleSelection.prototype.render = function () {
     var $selection = SingleSelection.__super__.render.call(this);
 
-    $selection.addClass('select2-selection--single');
+    $selection[0].classList.add('select2-selection--single');
 
     $selection.html(
       '<span class="select2-selection__rendered"></span>' +

--- a/src/js/select2/utils.js
+++ b/src/js/select2/utils.js
@@ -319,32 +319,26 @@ define([
     element.removeAttribute('data-select2-id');
   };
 
-  Utils.copyNonInternalCssClasses = function ($dest, $src) {
-    var classes, replacements = [], adapted;
+  Utils.copyNonInternalCssClasses = function (dest, src) {
+    var classes;
 
-    classes = $dest.attr('class').trim();
+    var destinationClasses = dest.getAttribute('class').trim().split(/\s+/);
 
-    if (classes) {
-      $(classes.split(/\s+/)).each(function () {
-        // Save all Select2 classes
-        if (this.indexOf('select2-') === 0) {
-          replacements.push(this);
-        }
-      });
-    }
+    destinationClasses = destinationClasses.filter(function (clazz) {
+      // Save all Select2 classes
+      return clazz.indexOf('select2-') === 0;
+    });
 
-    classes = $src.attr('class').trim();
+    var sourceClasses = src.getAttribute('class').trim().split(/\s+/);
 
-    if (classes) {
-      $(classes.split(/\s+/)).each(function () {
-        // Only copy non-Select2 classes
-        if (this.indexOf('select2-') !== 0) {
-          replacements.push(this);
-        }
-      });
-    }
+    sourceClasses = sourceClasses.filter(function (clazz) {
+      // Only copy non-Select2 classes
+      return clazz.indexOf('select2-') !== 0;
+    });
 
-    $dest.attr('class', replacements.join(' '));
+    var replacements = destinationClasses.concat(sourceClasses);
+
+    dest.setAttribute('class', replacements.join(' '));
   };
 
   return Utils;

--- a/src/js/select2/utils.js
+++ b/src/js/select2/utils.js
@@ -325,8 +325,6 @@ define([
     classes = $dest.attr('class').trim();
 
     if (classes) {
-      classes = '' + classes; // for IE which returns object
-
       $(classes.split(/\s+/)).each(function () {
         // Save all Select2 classes
         if (this.indexOf('select2-') === 0) {
@@ -338,8 +336,6 @@ define([
     classes = $src.attr('class').trim();
 
     if (classes) {
-      classes = '' + classes; // for IE which returns object
-
       $(classes.split(/\s+/)).each(function () {
         // Only copy non-Select2 classes
         if (this.indexOf('select2-') !== 0) {

--- a/src/js/select2/utils.js
+++ b/src/js/select2/utils.js
@@ -322,7 +322,7 @@ define([
   Utils.copyNonInternalCssClasses = function ($dest, $src) {
     var classes, replacements = [], adapted;
 
-    classes = $.trim($dest.attr('class'));
+    classes = $dest.attr('class').trim();
 
     if (classes) {
       classes = '' + classes; // for IE which returns object
@@ -335,7 +335,7 @@ define([
       });
     }
 
-    classes = $.trim($src.attr('class'));
+    classes = $src.attr('class').trim();
 
     if (classes) {
       classes = '' + classes; // for IE which returns object


### PR DESCRIPTION
This officially drops support for Internet Explorer 10 and below.

This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation
- [x] Miscellaneous

The following changes were made

- Replace `$.trim` with `String.prototype.trim`
- Replace `$.isArray` with `Array.isArray`
- Replace `$.fn.is(tagName)` with `Element.prototype.tagName`
- Replace `$.inArray` with `Array.prototype.indexOf`
- Replace `$.fn.addClass` with `classList.add`
- Replace `$.fn.hasClass` with `classList.contains`
- Replace `$.fn.removeClass` with `classList.remove`
- Remove non-MutationObserver change handling
- Replace `$.map` with `Array.prototype.map`

If this is related to an existing ticket, include a link to it as well.

Fixes #4496