### PR TITLE
Support the autocomplete attribute being set on the original <select>

### DIFF
--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -296,6 +296,7 @@ define([
 
     this.defaults = {
       amdLanguageBase: './i18n/',
+      autocomplete: 'off',
       closeOnSelect: true,
       debug: false,
       dropdownAutoWidth: false,

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -9,13 +9,15 @@ define([
     var $search = $(
       '<span class="select2-search select2-search--dropdown">' +
         '<input class="select2-search__field" type="search" tabindex="-1"' +
-        ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
+        ' autocorrect="off" autocapitalize="none"' +
         ' spellcheck="false" role="searchbox" aria-autocomplete="list" />' +
       '</span>'
     );
 
     this.$searchContainer = $search;
     this.$search = $search.find('input');
+
+    this.$search.prop('autocomplete', this.options.get('autocomplete'));
 
     $rendered.prepend($search);
 

--- a/src/js/select2/options.js
+++ b/src/js/select2/options.js
@@ -28,6 +28,10 @@ define([
       this.options.disabled = $e.prop('disabled');
     }
 
+    if (this.options.autocomplete == null && $e.prop('autocomplete')) {
+      this.options.autocomplete = $e.prop('autocomplete');
+    }
+
     if (this.options.dir == null) {
       if ($e.prop('dir')) {
         this.options.dir = $e.prop('dir');

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -11,13 +11,15 @@ define([
     var $search = $(
       '<li class="select2-search select2-search--inline">' +
         '<input class="select2-search__field" type="search" tabindex="-1"' +
-        ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
+        ' autocorrect="off" autocapitalize="none"' +
         ' spellcheck="false" role="searchbox" aria-autocomplete="list" />' +
       '</li>'
     );
 
     this.$searchContainer = $search;
     this.$search = $search.find('input');
+
+    this.$search.prop('autocomplete', this.options.get('autocomplete'));
 
     var $rendered = decorated.call(this);
 

--- a/tests/dropdown/search-tests.js
+++ b/tests/dropdown/search-tests.js
@@ -1,0 +1,49 @@
+module('Dropdown - Search');
+
+var Dropdown = require('select2/dropdown');
+var DropdownSearch = Utils.Decorate(
+  Dropdown,
+  require('select2/dropdown/search')
+);
+
+var $ = require('jquery');
+var Options = require('select2/options');
+var Utils = require('select2/utils');
+
+var options = new Options({});
+
+test('search box defaults autocomplete to off', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var dropdown = new DropdownSearch($select, options);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  assert.equal(
+    $dropdown.find('input').attr('autocomplete'),
+    'off',
+    'The search box has autocomplete disabled'
+  );
+});
+
+test('search box sets autocomplete from options', function (assert) {
+  var $select = $('#qunit-fixture .single');
+
+  var autocompleteOptions = new Options({
+    autocomplete: 'country-name'
+  });
+
+  var dropdown = new DropdownSearch($select, autocompleteOptions);
+  var $dropdown = dropdown.render();
+
+  var container = new MockContainer();
+  dropdown.bind(container, $('<span></span>'));
+
+  assert.equal(
+    $dropdown.find('input').attr('autocomplete'),
+    'country-name',
+    'The search box sets the right autocomplete attribute'
+  );
+});

--- a/tests/options/element-tests.js
+++ b/tests/options/element-tests.js
@@ -1,0 +1,107 @@
+module('Options - Copying from element');
+
+var $ = require('jquery');
+
+var Options = require('select2/options');
+
+test('copies disabled attribute when set', function (assert) {
+  var $test = $('<select disabled></select>');
+
+  var options = new Options({}, $test);
+
+  assert.ok(options.get('disabled'));
+});
+
+test('does not copy disabled attribute when not set', function (assert) {
+  var $test = $('<select></select>');
+
+  var options = new Options({}, $test);
+
+  assert.ok(!options.get('disabled'));
+});
+
+test('disabled attribute does not override disable option', function (assert) {
+  var $test = $('<select disabled></select>');
+
+  var options = new Options({
+    disabled: false
+  }, $test);
+
+  assert.ok(!options.get('disabled'));
+});
+
+test('disabled option is synchronized back', function (assert) {
+  var $test = $('<select disabled></select>');
+
+  assert.ok($test.prop('disabled'));
+
+  var options = new Options({
+    disabled: false
+  }, $test);
+
+  assert.ok(!$test.prop('disabled'));
+});
+
+test('copies multiple attribute when set', function (assert) {
+  var $test = $('<select multiple></select>');
+
+  var options = new Options({}, $test);
+
+  assert.ok(options.get('multiple'));
+});
+
+test('does not copy multiple attribute when not set', function (assert) {
+  var $test = $('<select></select>');
+
+  var options = new Options({}, $test);
+
+  assert.ok(!options.get('multiple'));
+});
+
+test('multiple attribute does not override multiple option', function (assert) {
+  var $test = $('<select multiple></select>');
+
+  var options = new Options({
+    multiple: false
+  }, $test);
+
+  assert.ok(!options.get('multiple'));
+});
+
+test('multiple option is synchronized back', function (assert) {
+  var $test = $('<select multiple></select>');
+
+  assert.ok($test.prop('multiple'));
+
+  var options = new Options({
+    multiple: false
+  }, $test);
+
+  assert.ok(!$test.prop('multiple'));
+});
+
+test('copies autocomplete attribute when set', function (assert) {
+  var $test = $('<select autocomplete="country-name"></select>');
+
+  var options = new Options({}, $test);
+
+  assert.equal(options.get('autocomplete'), 'country-name');
+});
+
+test('does not copy autocomplete attribute when not set', function (assert) {
+  var $test = $('<select></select>');
+
+  var options = new Options({}, $test);
+
+  assert.equal(options.get('autocomplete'), 'off');
+});
+
+test('autocomplete attribute does not override option', function (assert) {
+  var $test = $('<select autocomplete="country-name"></select>');
+
+  var options = new Options({
+    autocomplete: 'organization'
+  }, $test);
+
+  assert.ok(options.get('autocomplete'), 'organization');
+});

--- a/tests/options/element-tests.js
+++ b/tests/options/element-tests.js
@@ -83,6 +83,12 @@ test('multiple option is synchronized back', function (assert) {
 test('copies autocomplete attribute when set', function (assert) {
   var $test = $('<select autocomplete="country-name"></select>');
 
+  if ($test.prop('autocomplete') !== 'country-name') {
+    // Browser does not support the autocomplete attribute on a select
+    assert.ok(true);
+    return;
+  }
+
   var options = new Options({}, $test);
 
   assert.equal(options.get('autocomplete'), 'country-name');

--- a/tests/selection/search-tests.js
+++ b/tests/selection/search-tests.js
@@ -275,3 +275,47 @@ test('search box with text should not close dropdown', function (assert) {
   $search.val('test');
   $search.trigger('click');
 });
+
+test('search box defaults autocomplete to off', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, options);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  assert.equal(
+    $selection.find('input').attr('autocomplete'),
+    'off',
+    'The search box has autocomplete disabled'
+  );
+});
+
+test('search box sets autocomplete from options', function (assert) {
+  var $select = $('#qunit-fixture .multiple');
+
+  var autocompleteOptions = new Options({
+    autocomplete: 'country-name'
+  });
+
+  var CustomSelection = Utils.Decorate(MultipleSelection, InlineSearch);
+  var selection = new CustomSelection($select, autocompleteOptions);
+  var $selection = selection.render();
+
+  var container = new MockContainer();
+  selection.bind(container, $('<span></span>'));
+
+  // Update the selection so the search is rendered
+  selection.update([]);
+
+  assert.equal(
+    $selection.find('input').attr('autocomplete'),
+    'country-name',
+    'The search box sets the right autocomplete attribute'
+  );
+});

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -78,6 +78,7 @@
 
     <script src="options/ajax-tests.js" type="text/javascript"></script>
     <script src="options/data-tests.js" type="text/javascript"></script>
+    <script src="options/element-tests.js" type="text/javascript"></script>
     <script src="options/translation-tests.js" type="text/javascript"></script>
     <script src="options/width-tests.js" type="text/javascript"></script>
 

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -71,6 +71,7 @@
     <script src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
     <script src="dropdown/dropdownParent-tests.js" type="text/javascript"></script>
     <script src="dropdown/positioning-tests.js" type="text/javascript"></script>
+    <script src="dropdown/search-tests.js" type="text/javascript"></script>
     <script src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
     <script src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
     <script src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -78,6 +78,7 @@
 
     <script src="options/ajax-tests.js" type="text/javascript"></script>
     <script src="options/data-tests.js" type="text/javascript"></script>
+    <script src="options/element-tests.js" type="text/javascript"></script>
     <script src="options/translation-tests.js" type="text/javascript"></script>
     <script src="options/width-tests.js" type="text/javascript"></script>
 

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -71,6 +71,7 @@
     <script src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
     <script src="dropdown/dropdownParent-tests.js" type="text/javascript"></script>
     <script src="dropdown/positioning-tests.js" type="text/javascript"></script>
+    <script src="dropdown/search-tests.js" type="text/javascript"></script>
     <script src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
     <script src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
     <script src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -78,6 +78,7 @@
 
     <script src="options/ajax-tests.js" type="text/javascript"></script>
     <script src="options/data-tests.js" type="text/javascript"></script>
+    <script src="options/element-tests.js" type="text/javascript"></script>
     <script src="options/translation-tests.js" type="text/javascript"></script>
     <script src="options/width-tests.js" type="text/javascript"></script>
 

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -71,6 +71,7 @@
     <script src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
     <script src="dropdown/dropdownParent-tests.js" type="text/javascript"></script>
     <script src="dropdown/positioning-tests.js" type="text/javascript"></script>
+    <script src="dropdown/search-tests.js" type="text/javascript"></script>
     <script src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
     <script src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
     <script src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- The `autocomplete` attribute, when set, is now copied to the search boxes within the dropdown and selection
- The `autocomplete` option can now be set without using the attribute
- Added tests for other options set via attributes

If this is related to an existing ticket, include a link to it as well.

Fixes #5628 
Closes #5670