### PR TITLE
Mark highlighted results with aria-selected

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -174,8 +174,7 @@ define([
     option.classList.add('select2-results__option--selectable');
 
     var attrs = {
-      'role': 'option',
-      'aria-selected': 'false'
+      'role': 'option'
     };
 
     var matches = window.Element.prototype.matches ||
@@ -184,7 +183,6 @@ define([
 
     if ((data.element != null && matches.call(data.element, ':disabled')) ||
         (data.element == null && data.disabled)) {
-      delete attrs['aria-selected'];
       attrs['aria-disabled'] = 'true';
 
       option.classList.remove('select2-results__option--selectable');
@@ -192,7 +190,6 @@ define([
     }
 
     if (data.id == null) {
-      delete attrs['aria-selected'];
       option.classList.remove('select2-results__option--selectable');
     }
 
@@ -207,7 +204,6 @@ define([
     if (data.children) {
       attrs.role = 'group';
       attrs['aria-label'] = data.text;
-      delete attrs['aria-selected'];
 
       option.classList.remove('select2-results__option--selectable');
       option.classList.add('select2-results__option--group');
@@ -419,6 +415,7 @@ define([
 
     container.on('results:focus', function (params) {
       params.element[0].classList.add('select2-results__option--highlighted');
+      params.element[0].setAttribute('aria-selected', 'true');
     });
 
     container.on('results:message', function (params) {
@@ -480,7 +477,8 @@ define([
       var data = Utils.GetData(this, 'data');
 
       self.getHighlightedResults()
-          .removeClass('select2-results__option--highlighted');
+          .removeClass('select2-results__option--highlighted')
+          .attr('aria-selected', 'false');
 
       self.trigger('results:focus', {
         data: data,

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -99,9 +99,9 @@ define([
 
   Results.prototype.highlightFirstItem = function () {
     var $options = this.$results
-      .find('.select2-results__option[aria-selected]');
+      .find('.select2-results__option--selectable');
 
-    var $selected = $options.filter('[aria-selected=true]');
+    var $selected = $options.filter('.select2-results__option--selected');
 
     // Check if there are any selected options
     if ($selected.length > 0) {
@@ -125,7 +125,7 @@ define([
       });
 
       var $options = self.$results
-        .find('.select2-results__option[aria-selected]');
+        .find('.select2-results__option--selectable');
 
       $options.each(function () {
         var $option = $(this);
@@ -137,8 +137,10 @@ define([
 
         if ((item.element != null && item.element.selected) ||
             (item.element == null && selectedIds.indexOf(id) > -1)) {
+          this.classList.add('select2-results__option--selected');
           $option.attr('aria-selected', 'true');
         } else {
+          this.classList.remove('select2-results__option--selected');
           $option.attr('aria-selected', 'false');
         }
       });
@@ -168,7 +170,8 @@ define([
 
   Results.prototype.option = function (data) {
     var option = document.createElement('li');
-    option.className = 'select2-results__option';
+    option.classList.add('select2-results__option');
+    option.classList.add('select2-results__option--selectable');
 
     var attrs = {
       'role': 'option',
@@ -183,10 +186,14 @@ define([
         (data.element == null && data.disabled)) {
       delete attrs['aria-selected'];
       attrs['aria-disabled'] = 'true';
+
+      option.classList.remove('select2-results__option--selectable');
+      option.classList.add('select2-results__option--disabled');
     }
 
     if (data.id == null) {
       delete attrs['aria-selected'];
+      option.classList.remove('select2-results__option--selectable');
     }
 
     if (data._resultId != null) {
@@ -201,6 +208,9 @@ define([
       attrs.role = 'group';
       attrs['aria-label'] = data.text;
       delete attrs['aria-selected'];
+
+      option.classList.remove('select2-results__option--selectable');
+      option.classList.add('select2-results__option--group');
     }
 
     for (var attr in attrs) {
@@ -215,7 +225,6 @@ define([
       var label = document.createElement('strong');
       label.className = 'select2-results__group';
 
-      var $label = $(label);
       this.template(data, label);
 
       var $children = [];
@@ -334,7 +343,7 @@ define([
 
       var data = Utils.GetData($highlighted[0], 'data');
 
-      if ($highlighted.attr('aria-selected') == 'true') {
+      if ($highlighted.hasClass('select2-results__option--selected')) {
         self.trigger('close', {});
       } else {
         self.trigger('select', {
@@ -346,7 +355,7 @@ define([
     container.on('results:previous', function () {
       var $highlighted = self.getHighlightedResults();
 
-      var $options = self.$results.find('[aria-selected]');
+      var $options = self.$results.find('.select2-results__option--selectable');
 
       var currentIndex = $options.index($highlighted);
 
@@ -381,7 +390,7 @@ define([
     container.on('results:next', function () {
       var $highlighted = self.getHighlightedResults();
 
-      var $options = self.$results.find('[aria-selected]');
+      var $options = self.$results.find('.select2-results__option--selectable');
 
       var currentIndex = $options.index($highlighted);
 
@@ -441,13 +450,13 @@ define([
       });
     }
 
-    this.$results.on('mouseup', '.select2-results__option[aria-selected]',
+    this.$results.on('mouseup', '.select2-results__option--selectable',
       function (evt) {
       var $this = $(this);
 
       var data = Utils.GetData(this, 'data');
 
-      if ($this.attr('aria-selected') === 'true') {
+      if ($this.hasClass('select2-results__option--selected')) {
         if (self.options.get('multiple')) {
           self.trigger('unselect', {
             originalEvent: evt,
@@ -466,7 +475,7 @@ define([
       });
     });
 
-    this.$results.on('mouseenter', '.select2-results__option[aria-selected]',
+    this.$results.on('mouseenter', '.select2-results__option--selectable',
       function (evt) {
       var data = Utils.GetData(this, 'data');
 
@@ -498,7 +507,7 @@ define([
       return;
     }
 
-    var $options = this.$results.find('[aria-selected]');
+    var $options = this.$results.find('.select2-results__option--selectable');
 
     var currentIndex = $options.index($highlighted);
 

--- a/src/scss/_dropdown.scss
+++ b/src/scss/_dropdown.scss
@@ -31,10 +31,10 @@
 
   user-select: none;
   -webkit-user-select: none;
+}
 
-  &[aria-selected] {
-    cursor: pointer;
-  }
+.select2-results__option--selectable {
+  cursor: pointer;
 }
 
 .select2-container--open .select2-dropdown {

--- a/src/scss/theme/classic/layout.scss
+++ b/src/scss/theme/classic/layout.scss
@@ -37,17 +37,15 @@
     overflow-y: auto;
   }
 
-  .select2-results__option {
-    &[role=group] {
-      padding: 0;
-    }
-
-    &[aria-disabled=true] {
-      color: $results-choice-fg-unselectable-color;
-    }
+  .select2-results__option--group {
+    padding: 0;
   }
 
-  .select2-results__option--highlighted[aria-selected] {
+  .select2-results__option--disabled {
+    color: $results-choice-fg-unselectable-color;
+  }
+
+  .select2-results__option--highlighted.select2-results__option--selectable {
     background-color: $results-choice-bg-hover-color;
     color: $results-choice-fg-hover-color;
   }

--- a/src/scss/theme/default/layout.scss
+++ b/src/scss/theme/default/layout.scss
@@ -38,18 +38,6 @@
   }
 
   .select2-results__option {
-    &[role=group] {
-      padding: 0;
-    }
-
-    &[aria-disabled=true] {
-      color: #999;
-    }
-
-    &[aria-selected=true] {
-      background-color: #ddd;
-    }
-
     .select2-results__option {
       padding-left: 1em;
 
@@ -84,7 +72,19 @@
     }
   }
 
-  .select2-results__option--highlighted[aria-selected] {
+  .select2-results__option--group {
+    padding: 0;
+  }
+
+  .select2-results__option--disabled {
+    color: #999;
+  }
+
+  .select2-results__option--selected {
+    background-color: #ddd;
+  }
+
+  .select2-results__option--highlighted.select2-results__option--selectable {
     background-color: #5897fb;
     color: white;
   }

--- a/tests/results/option-tests.js
+++ b/tests/results/option-tests.js
@@ -71,7 +71,7 @@ test('options are not selected by default', function (assert) {
     element: $option[0]
   });
 
-  assert.equal(option.getAttribute('aria-selected'), 'false');
+  assert.notOk(option.classList.contains('select2-results__option--selected'));
 });
 
 test('options with children are given the group role', function(assert) {


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- `select2-results__option--selectable` class was introduced to mark options that are selectable within results
- `select2-results__option--selected` class was introduced to mark options that are selected
- `select2-results__option--disabled` class was introduced to mark options that are disabled within results
- `[aria-selected]` is used to indicate the highlighted option instead of indicating that an option is selected

If this is related to an existing ticket, include a link to it as well.
Fixes #4349 