### PR TITLE
Make the multi-select selection area more accessible

### DIFF
--- a/src/js/select2/i18n/en.js
+++ b/src/js/select2/i18n/en.js
@@ -42,6 +42,9 @@ define(function () {
     },
     removeAllItems: function () {
       return 'Remove all items';
+    },
+    removeItem: function () {
+      return 'Remove item';
     }
   };
 });

--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -102,7 +102,7 @@ define([
     var removeAll = this.options.get('translations').get('removeAllItems');
 
     var $remove = $(
-      '<button class="select2-selection__clear" tabindex="-1">' +
+      '<button type="button" class="select2-selection__clear" tabindex="-1">' +
         '&times;' +
       '</button>'
     );

--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -106,7 +106,7 @@ define([
 
     var $remove = $(
       '<button type="button" class="select2-selection__clear" tabindex="-1">' +
-        '&times;' +
+        '<span aria-hidden="true">&times;</span>' +
       '</button>'
     );
     $remove.attr('title', removeAll());

--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -92,6 +92,8 @@ define([
   AllowClear.prototype.update = function (decorated, data) {
     decorated.call(this, data);
 
+    this.$selection.find('.select2-selection__clear').remove();
+
     if (this.$selection.find('.select2-selection__placeholder').length > 0 ||
         data.length === 0) {
       return;
@@ -100,13 +102,14 @@ define([
     var removeAll = this.options.get('translations').get('removeAllItems');
 
     var $remove = $(
-      '<span class="select2-selection__clear" title="' + removeAll() +'">' +
+      '<button class="select2-selection__clear" tabindex="-1">' +
         '&times;' +
-      '</span>'
+      '</button>'
     );
+    $remove.attr('title', removeAll());
     Utils.StoreData($remove[0], 'data', data);
 
-    this.$selection.find('.select2-selection__rendered').prepend($remove);
+    this.$selection.prepend($remove);
   };
 
   return AllowClear;

--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -110,6 +110,7 @@ define([
       '</button>'
     );
     $remove.attr('title', removeAll());
+    $remove.attr('aria-label', removeAll());
     $remove.attr('aria-describedby', selectionId);
     Utils.StoreData($remove[0], 'data', data);
 

--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -99,6 +99,9 @@ define([
       return;
     }
 
+    var selectionId = this.$selection.find('.select2-selection__rendered')
+      .attr('id');
+
     var removeAll = this.options.get('translations').get('removeAllItems');
 
     var $remove = $(
@@ -107,6 +110,7 @@ define([
       '</button>'
     );
     $remove.attr('title', removeAll());
+    $remove.attr('aria-describedby', selectionId);
     Utils.StoreData($remove[0], 'data', data);
 
     this.$selection.prepend($remove);

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -126,14 +126,20 @@ define([
       $selection.find('.select2-selection__choice__display')
         .append(formatted)
         .attr('id', selectionId);
-      $selection.find('.select2-selection__choice__remove')
-        .attr('aria-describedby', selectionId);
 
       var title = selection.title || selection.text;
 
       if (title) {
         $selection.attr('title', title);
       }
+
+      var removeItem = this.options.get('translations').get('removeItem');
+
+      var $remove = $selection.find('.select2-selection__choice__remove');
+
+      $remove.attr('title', removeItem());
+      $remove.attr('aria-label', removeItem());
+      $remove.attr('aria-describedby', selectionId);
 
       Utils.StoreData($selection[0], 'data', selection);
 

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -76,6 +76,7 @@ define([
         '<span class="select2-selection__choice__remove" role="presentation">' +
           '&times;' +
         '</span>' +
+        '<span class="select2-selection__choice__display"></span>' +
       '</li>'
     );
 
@@ -91,13 +92,28 @@ define([
 
     var $selections = [];
 
+    var selectionIdPrefix = this.$selection.find('.select2-selection__rendered')
+      .attr('id') + '-choice-';
+
     for (var d = 0; d < data.length; d++) {
       var selection = data[d];
 
       var $selection = this.selectionContainer();
       var formatted = this.display(selection, $selection);
 
-      $selection.append(formatted);
+      var selectionId = selectionIdPrefix + Utils.generateChars(4) + '-';
+
+      if (selection.id) {
+        selectionId += selection.id;
+      } else {
+        selectionId += Utils.generateChars(4);
+      }
+
+      $selection.find('.select2-selection__choice__display')
+        .append(formatted)
+        .attr('id', selectionId);
+      $selection.find('.select2-selection__choice__remove')
+        .attr('aria-describedby', selectionId);
 
       var title = selection.title || selection.text;
 

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -26,6 +26,9 @@ define([
 
     MultipleSelection.__super__.bind.apply(this, arguments);
 
+    var id = container.id + '-container';
+    this.$selection.find('.select2-selection__rendered').attr('id', id);
+
     this.$selection.on('click', function (evt) {
       self.trigger('toggle', {
         originalEvent: evt

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -55,6 +55,19 @@ define([
         });
       }
     );
+
+    this.$selection.on(
+      'keydown',
+      '.select2-selection__choice__remove',
+      function (evt) {
+        // Ignore the event if it is disabled
+        if (self.isDisabled()) {
+          return;
+        }
+
+        evt.stopPropagation();
+      }
+    );
   };
 
   MultipleSelection.prototype.clear = function () {
@@ -73,9 +86,10 @@ define([
   MultipleSelection.prototype.selectionContainer = function () {
     var $container = $(
       '<li class="select2-selection__choice">' +
-        '<span class="select2-selection__choice__remove" role="presentation">' +
+        '<button type="button" class="select2-selection__choice__remove" ' +
+        'tabindex="-1">' +
           '&times;' +
-        '</span>' +
+        '</button>' +
         '<span class="select2-selection__choice__display"></span>' +
       '</li>'
     );

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -88,7 +88,7 @@ define([
       '<li class="select2-selection__choice">' +
         '<button type="button" class="select2-selection__choice__remove" ' +
         'tabindex="-1">' +
-          '&times;' +
+          '<span aria-hidden="true">&times;</span>' +
         '</button>' +
         '<span class="select2-selection__choice__display"></span>' +
       '</li>'

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -33,8 +33,11 @@ define([
     var self = this;
 
     var resultsId = container.id + '-results';
+    var selectionId = container.id + '-container';
 
     decorated.call(this, container, $container);
+
+    self.$search.attr('aria-describedby', selectionId);
 
     container.on('open', function () {
       self.$search.attr('aria-controls', resultsId);

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -9,11 +9,11 @@ define([
 
   Search.prototype.render = function (decorated) {
     var $search = $(
-      '<li class="select2-search select2-search--inline">' +
+      '<span class="select2-search select2-search--inline">' +
         '<input class="select2-search__field" type="search" tabindex="-1"' +
         ' autocorrect="off" autocapitalize="none"' +
         ' spellcheck="false" role="searchbox" aria-autocomplete="list" />' +
-      '</li>'
+      '</span>'
     );
 
     this.$searchContainer = $search;
@@ -24,6 +24,7 @@ define([
     var $rendered = decorated.call(this);
 
     this._transferTabIndex();
+    $rendered.append(this.$searchContainer);
 
     return $rendered;
   };
@@ -88,8 +89,8 @@ define([
       var key = evt.which;
 
       if (key === KEYS.BACKSPACE && self.$search.val() === '') {
-        var $previousChoice = self.$searchContainer
-          .prev('.select2-selection__choice');
+        var $previousChoice = self.$selection
+          .find('.select2-selection__choice').last();
 
         if ($previousChoice.length > 0) {
           var item = Utils.GetData($previousChoice[0], 'data');
@@ -187,9 +188,6 @@ define([
 
     decorated.call(this, data);
 
-    this.$selection.find('.select2-selection__rendered')
-                   .append(this.$searchContainer);
-
     this.resizeSearch();
     if (searchHadFocus) {
       this.$search.trigger('focus');
@@ -222,11 +220,9 @@ define([
   Search.prototype.resizeSearch = function () {
     this.$search.css('width', '25px');
 
-    var width = '';
+    var width = '100%';
 
-    if (this.$search.attr('placeholder') !== '') {
-      width = this.$selection.find('.select2-selection__rendered').width();
-    } else {
+    if (this.$search.attr('placeholder') === '') {
       var minimumWidth = this.$search.val().length + 1;
 
       width = (minimumWidth * 0.75) + 'em';

--- a/src/scss/_multiple.scss
+++ b/src/scss/_multiple.scss
@@ -10,22 +10,19 @@
   -webkit-user-select: none;
 
   .select2-selection__rendered {
-    display: inline-block;
-    overflow: hidden;
-    padding-left: 8px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    display: inline;
+    list-style: none;
+    padding: 0;
   }
 }
 
 .select2-search--inline {
-  float: left;
-
   .select2-search__field {
     box-sizing: border-box;
     border: none;
     font-size: 100%;
     margin-top: 5px;
+    margin-left: 5px;
     padding: 0;
 
     &::-webkit-search-cancel-button {

--- a/src/scss/_multiple.scss
+++ b/src/scss/_multiple.scss
@@ -14,6 +14,12 @@
     list-style: none;
     padding: 0;
   }
+
+  .select2-selection__clear {
+    background-color: transparent;
+    border: none;
+    font-size: 1em;
+  }
 }
 
 .select2-search--inline {

--- a/src/scss/_single.scss
+++ b/src/scss/_single.scss
@@ -20,7 +20,9 @@
   }
 
   .select2-selection__clear {
-    position: relative;
+    background-color: transparent;
+    border: none;
+    font-size: 1em;
   }
 }
 

--- a/src/scss/theme/classic/_multiple.scss
+++ b/src/scss/theme/classic/_multiple.scss
@@ -8,14 +8,11 @@
 
   outline: 0;
 
+  padding-bottom: 5px;
+  padding-right: 5px;
+
   &:focus {
     border: 1px solid $focus-border-color;
-  }
-
-  .select2-selection__rendered {
-    list-style: none;
-    margin: 0;
-    padding: 0 5px;
   }
 
   .select2-selection__clear {
@@ -30,9 +27,9 @@
 
     cursor: default;
 
-    float: left;
+    display: inline-block;
 
-    margin-right: 5px;
+    margin-left: 5px;
     margin-top: 5px;
     padding: 0 5px;
   }

--- a/src/scss/theme/classic/_multiple.scss
+++ b/src/scss/theme/classic/_multiple.scss
@@ -21,30 +21,39 @@
 
   .select2-selection__choice {
     background-color: #e4e4e4;
-
     border: 1px solid $border-color;
     border-radius: $border-radius;
 
-    cursor: default;
-
     display: inline-block;
-
     margin-left: 5px;
     margin-top: 5px;
-    padding: 0 5px;
+    padding: 0;
+  }
+
+  .select2-selection__choice__display {
+    cursor: default;
+
+    padding-left: 2px;
+    padding-right: 5px;
   }
 
   .select2-selection__choice__remove {
+    background-color: transparent;
+    border: none;
+    border-top-left-radius: $border-radius;
+    border-bottom-left-radius: $border-radius;
+
     color: $remove-color;
     cursor: pointer;
 
-    display: inline-block;
+    font-size: 1em;
     font-weight: bold;
 
-    margin-right: 2px;
+    padding: 0 4px;
 
     &:hover {
       color: $remove-hover-color;
+      outline: none;
     }
   }
 }
@@ -52,14 +61,20 @@
 &[dir="rtl"] {
   .select2-selection--multiple {
     .select2-selection__choice {
-      float: right;
       margin-left: 5px;
       margin-right: auto;
     }
 
+    .select2-selection__choice__display {
+      padding-left: 5px;
+      padding-right: 2px;
+    }
+
     .select2-selection__choice__remove {
-      margin-left: 2px;
-      margin-right: auto;
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      border-top-right-radius: $border-radius;
+      border-bottom-right-radius: $border-radius;
     }
   }
 }

--- a/src/scss/theme/classic/_single.scss
+++ b/src/scss/theme/classic/_single.scss
@@ -21,7 +21,8 @@
     cursor: pointer;
     float: right;
     font-weight: bold;
-    margin-right: 10px;
+    height: 26px;
+    margin-right: 20px;
   }
 
   .select2-selection__placeholder {

--- a/src/scss/theme/default/_multiple.scss
+++ b/src/scss/theme/default/_multiple.scss
@@ -3,18 +3,8 @@
   border: 1px solid #aaa;
   border-radius: 4px;
   cursor: text;
-
-  .select2-selection__rendered {
-    box-sizing: border-box;
-    list-style: none;
-    margin: 0;
-    padding: 0 5px;
-    width: 100%;
-
-    li {
-      list-style: none;
-    }
-  }
+  padding-bottom: 5px;
+  padding-right: 5px;
 
   .select2-selection__clear {
     cursor: pointer;
@@ -37,9 +27,9 @@
     border-radius: 4px;
     cursor: default;
 
-    float: left;
+    display: inline-block;
 
-    margin-right: 5px;
+    margin-left: 5px;
     margin-top: 5px;
     padding: 0 5px;
   }

--- a/src/scss/theme/default/_multiple.scss
+++ b/src/scss/theme/default/_multiple.scss
@@ -23,46 +23,69 @@
 
   .select2-selection__choice {
     background-color: #e4e4e4;
-
     border: 1px solid #aaa;
     border-radius: 4px;
-    cursor: default;
 
     display: inline-block;
-
     margin-left: 5px;
     margin-top: 5px;
-    padding: 0 5px;
+    padding: 0;
+  }
+
+  .select2-selection__choice__display {
+    cursor: default;
+
+    padding-left: 2px;
+    padding-right: 5px;
   }
 
   .select2-selection__choice__remove {
+    background-color: transparent;
+    border: none;
+    border-right: 1px solid #aaa;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+
     color: #999;
     cursor: pointer;
 
-    display: inline-block;
+    font-size: 1em;
     font-weight: bold;
 
-    margin-right: 2px;
+    padding: 0 4px;
 
-    &:hover {
+    &:hover, &:focus {
+      background-color: #f1f1f1;
       color: #333;
+      outline: none;
     }
   }
 }
 
 &[dir="rtl"] {
   .select2-selection--multiple {
-    .select2-selection__choice, .select2-search--inline {
-      float: right;
-    }
-
     .select2-selection__choice {
       margin-left: 5px;
       margin-right: auto;
     }
 
+    .select2-selection__choice__display {
+      padding-left: 5px;
+      padding-right: 2px;
+    }
+
     .select2-selection__choice__remove {
-      margin-left: 2px;
+      border-left: 1px solid #aaa;
+      border-right: none;
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      border-top-right-radius: 4px;
+      border-bottom-right-radius: 4px;
+    }
+
+    .select2-selection__clear {
+      float: left;
+      margin-left: 10px;
       margin-right: auto;
     }
   }

--- a/src/scss/theme/default/_multiple.scss
+++ b/src/scss/theme/default/_multiple.scss
@@ -10,8 +10,9 @@
     cursor: pointer;
     float: right;
     font-weight: bold;
-    margin-top: 5px;
+    height: 20px;
     margin-right: 10px;
+    margin-top: 5px;
 
     // This padding is to account for the bottom border for the first
     // selection row and the top border of the second selection row.

--- a/src/scss/theme/default/_single.scss
+++ b/src/scss/theme/default/_single.scss
@@ -12,6 +12,9 @@
     cursor: pointer;
     float: right;
     font-weight: bold;
+    height: 26px;
+    margin-right: 20px;
+    padding-right: 0px;
   }
 
   .select2-selection__placeholder {

--- a/tests/options/translation-tests.js
+++ b/tests/options/translation-tests.js
@@ -52,7 +52,8 @@ test(
         'maximumSelected',
         'noResults',
         'searching',
-        'removeAllItems'
+        'removeAllItems',
+        'removeItem'
       ]
     );
   }

--- a/tests/selection/search-placeholder-tests.js
+++ b/tests/selection/search-placeholder-tests.js
@@ -43,8 +43,8 @@ test('width does not extend the search box', function (assert) {
 
     assert.equal(
       $search.outerWidth(),
-      60,
-      'The search should not be the entire width of the container'
+      100,
+      'The search should be the entire width of the container'
     );
 
     assert.equal(


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Switch from floating the selections to using inline-block elements
- Move the search field outside of the selection list
- Move the clear button outside of the selection list
- Made the clear button use the `<button>` tag
- Multiple select search is always full width when the placeholder is present

If this is related to an existing ticket, include a link to it as well.
Fixes #4418
Fixes #5585
Closes #5571