### PR TITLE
Respect disabled attribute inherited from containing fieldsets

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -353,7 +353,8 @@ define([
   };
 
   Select2.prototype._syncAttributes = function () {
-    this.options.set('disabled', this.$element.prop('disabled') || Utils.hasDisabledAncestors(this.$element));
+    this.options.set('disabled', this.$element.prop('disabled') ||
+      Utils.hasDisabledAncestors(this.$element));
 
     if (this.isDisabled()) {
       if (this.isOpen()) {

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -353,7 +353,7 @@ define([
   };
 
   Select2.prototype._syncAttributes = function () {
-    this.options.set('disabled', this.$element.prop('disabled') || this.$element.is(':disabled'));
+    this.options.set('disabled', this.$element.prop('disabled') || Utils.hasDisabledAncestors(this.$element));
 
     if (this.isDisabled()) {
       if (this.isOpen()) {

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -219,7 +219,7 @@ define([
 
         self._ancestorObserver.observe(this, {
           attributeFilter: ['disabled'],
-          attributes: true,
+          attributes: true
         });
       });
     }

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -206,6 +206,23 @@ define([
       childList: true,
       subtree: false
     });
+
+    var ancestors = this.$element.parents('fieldset');
+
+    if (ancestors.length) {
+
+      this._ancestorObserver = new window.MutationObserver(function () {
+        self._syncA();
+      });
+
+      ancestors.each(function () {
+
+        self._ancestorObserver.observe(this, {
+          attributeFilter: ['disabled'],
+          attributes: true,
+        });
+      });
+    }
   };
 
   Select2.prototype._registerDataEvents = function () {
@@ -473,7 +490,7 @@ define([
    * @return {false} if the disabled option is false.
    */
   Select2.prototype.isDisabled = function () {
-    return this.options.get('disabled');
+    return this.options.get('disabled') || this.$element.is(':disabled');
   };
 
   Select2.prototype.isOpen = function () {
@@ -558,6 +575,11 @@ define([
 
     this._observer.disconnect();
     this._observer = null;
+
+    if (this._ancestorObserver) {
+      this._ancestorObserver.disconnect();
+      this._ancestorObserver = null;
+    }
 
     this._syncA = null;
     this._syncS = null;

--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -353,7 +353,7 @@ define([
   };
 
   Select2.prototype._syncAttributes = function () {
-    this.options.set('disabled', this.$element.prop('disabled'));
+    this.options.set('disabled', this.$element.prop('disabled') || this.$element.is(':disabled'));
 
     if (this.isDisabled()) {
       if (this.isOpen()) {
@@ -490,7 +490,7 @@ define([
    * @return {false} if the disabled option is false.
    */
   Select2.prototype.isDisabled = function () {
-    return this.options.get('disabled') || this.$element.is(':disabled');
+    return this.options.get('disabled');
   };
 
   Select2.prototype.isOpen = function () {

--- a/src/js/select2/utils.js
+++ b/src/js/select2/utils.js
@@ -351,7 +351,7 @@ define([
       function (disabled, element) {
         return disabled || element.hasAttribute('disabled');
       }, false);
-  }
+  };
 
   return Utils;
 });

--- a/src/js/select2/utils.js
+++ b/src/js/select2/utils.js
@@ -346,5 +346,12 @@ define([
     dest.setAttribute('class', replacements.join(' '));
   };
 
+  Utils.hasDisabledAncestors = function ($element) {
+    return $element.parents('fieldset').get().reduce(
+      function (disabled, element) {
+        return disabled || element.hasAttribute('disabled');
+      }, false);
+  }
+
   return Utils;
 });

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -330,3 +330,29 @@ test('adding multiple options calls selection:update once', function (assert) {
     asyncDone();
   }, 0);
 });
+
+test('disabling containing fieldset disables the control', function (assert) {
+  var $ = require('jquery');
+  var Select2 = require('select2/core');
+
+  var $fieldset = $(
+    '<fieldset>' +
+    '  <select></select>' +
+    '</fieldset>');
+
+  var $select = $fieldset.children();
+
+  $('#qunit-fixture').append($fieldset);
+  
+  var select = new Select2($select);
+
+  assert.equal(
+    select.isDisabled(),
+    false);
+
+  $fieldset.prop('disabled', true);
+
+  assert.equal(
+    select.isDisabled(),
+    true);
+});

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -332,6 +332,10 @@ test('adding multiple options calls selection:update once', function (assert) {
 });
 
 test('disabling containing fieldset disables the control', function (assert) {
+  assert.expect(2);
+
+  var asyncDone = assert.async();
+
   var $ = require('jquery');
   var Select2 = require('select2/core');
 
@@ -352,7 +356,11 @@ test('disabling containing fieldset disables the control', function (assert) {
 
   $fieldset.prop('disabled', true);
 
-  assert.equal(
-    select.isDisabled(),
-    true);
+  setTimeout(function () {
+    assert.equal(
+      select.isDisabled(),
+      true);
+
+    asyncDone();
+  }, 0);
 });

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -364,3 +364,40 @@ test('disabling containing fieldset disables the control', function (assert) {
     asyncDone();
   }, 0);
 });
+
+test('control retains disabled state when parent is toggled', function (assert) {
+  assert.expect(2);
+
+  var asyncDone = assert.async();
+
+  var $ = require('jquery');
+  var Select2 = require('select2/core');
+
+  var $fieldset = $(
+    '<fieldset>' +
+    '  <select></select>' +
+    '</fieldset>');
+
+  var $select = $fieldset.children();
+
+  $('#qunit-fixture').append($fieldset);
+
+  var select = new Select2($select, {
+    disabled: true
+  });
+
+  assert.equal(
+    select.isDisabled(),
+    true);
+
+  $fieldset.prop('disabled', true);
+  $fieldset.prop('disabled', false);
+
+  setTimeout(function () {
+    assert.equal(
+      select.isDisabled(),
+      true);
+
+    asyncDone();
+  }, 0);
+});

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -365,7 +365,8 @@ test('disabling containing fieldset disables the control', function (assert) {
   }, 0);
 });
 
-test('control retains disabled state when parent is toggled', function (assert) {
+test('control retains disabled state when parent is toggled',
+  function (assert) {
   assert.expect(2);
 
   var asyncDone = assert.async();


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Sets up a `MutationObserver` to monitor the `disabled` attribute of containing `frameset` elements (A second observer was used to avoid calling `_syncSubtree`, which shouldn't be necessary for the purposes of this fix)
- Extends the `isDisabled` abstraction to use `$element.is(':disabled')` in order to detect the inherited state

Resolves #2030
