### PR TITLE
Accessibility: fix role for nested options

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -234,7 +234,8 @@ define([
       }
 
       var $childrenContainer = $('<ul></ul>', {
-        'class': 'select2-results__options select2-results__options--nested'
+        'class': 'select2-results__options select2-results__options--nested',
+        'role': 'none'
       });
 
       $childrenContainer.append($children);


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Add `role='none'` to list containing children of optgroup.

See #5915
