### PR TITLE
Moved the initialization of the variable outside the loop

### DIFF
--- a/src/js/jquery.select2.js
+++ b/src/js/jquery.select2.js
@@ -16,7 +16,7 @@ define([
       if (typeof options === 'object') {
         var instanceOptions = $.extend(true, {}, options);
         this.each(function () {
-          new Select2($(this), instanceOptions);
+          new Select2($(this), instanceOptions); // eslint-disable-line no-new
         });
 
         return this;

--- a/src/js/jquery.select2.js
+++ b/src/js/jquery.select2.js
@@ -14,10 +14,9 @@ define([
       options = options || {};
 
       if (typeof options === 'object') {
+        var instanceOptions = $.extend(true, {}, options);
         this.each(function () {
-          var instanceOptions = $.extend(true, {}, options);
-
-          var instance = new Select2($(this), instanceOptions);
+          new Select2($(this), instanceOptions);
         });
 
         return this;


### PR DESCRIPTION
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made for performance improvement when there are many select on a page.
- Moved the initialization of the variable outside the loop
- Removed unused variable

If this is related to an existing ticket, include a link to it as well.
