### PR TITLE
Add a "baseCssClass" option

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -597,6 +597,11 @@ define([
     this.$container[0].classList
       .add('select2-container--' + this.options.get('theme'));
 
+    if (this.options.get('baseCssClass')) {
+      this.$container[0].classList
+        .add(this.options.get('baseCssClass'));
+    }
+
     Utils.StoreData($container[0], 'element', this.$element);
 
     return $container;

--- a/tests/options/element-tests.js
+++ b/tests/options/element-tests.js
@@ -3,6 +3,8 @@ module('Options - Copying from element');
 var $ = require('jquery');
 
 var Options = require('select2/options');
+var Select2 = require('select2/core');
+
 
 test('copies disabled attribute when set', function (assert) {
   var $test = $('<select disabled></select>');
@@ -110,4 +112,15 @@ test('autocomplete attribute does not override option', function (assert) {
   }, $test);
 
   assert.ok(options.get('autocomplete'), 'organization');
+});
+
+test('baseCssClass is correctly implemented', function (assert) {
+  var $test = $('<select></select>');
+
+  var select = new Select2($test, {
+    baseCssClass: 'myContainerClass'
+  });
+  var $container = select.render();
+  assert.ok($container.hasClass('select2'));
+  assert.ok($container.hasClass('myContainerClass'));
 });


### PR DESCRIPTION
Add a 'baseCssClass' option to allow the container for the dropdown to be given a user-supplied css class name.

This has been requested before, e.g. https://github.com/select2/select2/issues/285#issuecomment-427316761; I have called the option `baseCssClass` to avoid confusion with the pre-existing `containerCssClass`.

This pull request includes a

- [x] New feature

The following changes were made:

- Added user-supplied css class to the select2 container
- Added a test to ensure the class exists on the rendered element
