### PR TITLE
Display "null" as the default for tokenSeparators

### DIFF
--- a/docs/pages/03.configuration/01.options-api/docs.md
+++ b/docs/pages/03.configuration/01.options-api/docs.md
@@ -40,6 +40,6 @@ This is a list of all the Select2 configuration options.
 | `templateSelection` | callback | | Customizes the way that [selections are rendered](/selections#templating). |
 | `theme` | string | `default` | Allows you to set the [theme](/appearance#themes). |
 | `tokenizer` | callback | | A callback that handles [automatic tokenization of free-text entry](/tagging#automatic-tokenization-into-tags). |
-| `tokenSeparators` | array | `[]` | The list of characters that should be used as token separators. |
+| `tokenSeparators` | array | `null` | The list of characters that should be used as token separators. |
 | `width` | string | `resolve` | Supports [customization of the container width](/appearance#container-width). |
 | `scrollAfterSelect` | boolean | `false` | If `true`, resolves issue for multiselects using `closeOnSelect: false` that caused the list of results to scroll to the first selection after each select/unselect (see https://github.com/select2/select2/pull/5150). This behaviour was intentional to deal with infinite scroll UI issues (if you need this behavior, set `false`) but it created an issue with multiselect dropdown boxes of fixed length. This pull request adds a configurable option to toggle between these two desirable behaviours. |


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- The documentation will display "null" instead of "[]" as the default value for "tokenSeparators" option. The reasoning is included in the referred issue.

If this is related to an existing ticket, include a link to it as well.
https://github.com/select2/select2/issues/5951