### PR TITLE
Remove deprecated calls to `jQuery.isFunction`

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -45,7 +45,7 @@ define([
 
     if (this._request != null) {
       // JSONP requests cannot always be aborted
-      if ($.isFunction(this._request.abort)) {
+      if (typeof this._request.abort === 'function') {
         this._request.abort();
       }
 


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation
- [x] Improvement

The following changes were made

- I replaced the deprecated jQuery isFunction that was being used in `AjaxAdapter` `(ajax.js)`

If this is related to an existing ticket, include a link to it as well.
