### PR TITLE
show/hide select2

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -553,6 +553,14 @@ define([
     this.$element.val(newVal).trigger('input').trigger('change');
   };
 
+  Select2.prototype.hide = function () {
+    this.$container.hide();
+  };
+
+  Select2.prototype.show = function () {
+    this.$container.show();
+  };
+
   Select2.prototype.destroy = function () {
     this.$container.remove();
 


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- `$el.select2("hide")` will hide the select2
- `$el.select2("show")` will show the select2 when hidden
