### PR TITLE
Fix long text causing the search box and selections to overflow on multiple selects

### DIFF
--- a/dist/css/select2.css
+++ b/dist/css/select2.css
@@ -46,7 +46,8 @@
     font-size: 100%;
     margin-top: 5px;
     margin-left: 5px;
-    padding: 0; }
+    padding: 0;
+    max-width: 100%; }
     .select2-container .select2-search--inline .select2-search__field::-webkit-search-cancel-button {
       -webkit-appearance: none; }
 

--- a/src/scss/_multiple.scss
+++ b/src/scss/_multiple.scss
@@ -30,6 +30,7 @@
     margin-top: 5px;
     margin-left: 5px;
     padding: 0;
+    max-width: 100%;
 
     &::-webkit-search-cancel-button {
       -webkit-appearance: none;

--- a/src/scss/theme/default/_multiple.scss
+++ b/src/scss/theme/default/_multiple.scss
@@ -4,15 +4,18 @@
   border-radius: 4px;
   cursor: text;
   padding-bottom: 5px;
-  padding-right: 5px;
+  padding-right: 25px;
+  position: relative;
 
   .select2-selection__clear {
     cursor: pointer;
-    float: right;
     font-weight: bold;
     height: 20px;
     margin-right: 10px;
     margin-top: 5px;
+
+    position: absolute;
+    right: 0;
 
     // This padding is to account for the bottom border for the first
     // selection row and the top border of the second selection row.

--- a/src/scss/theme/default/_multiple.scss
+++ b/src/scss/theme/default/_multiple.scss
@@ -28,17 +28,21 @@
     background-color: #e4e4e4;
     border: 1px solid #aaa;
     border-radius: 4px;
+    box-sizing: border-box;
 
     display: inline-block;
     margin-left: 5px;
     margin-top: 5px;
     padding: 0;
+    padding-left: 20px;
+
+    position: relative;
 
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
     vertical-align: bottom;
+    white-space: nowrap;
   }
 
   .select2-selection__choice__display {
@@ -62,6 +66,10 @@
     font-weight: bold;
 
     padding: 0 4px;
+
+    position: absolute;
+    left: 0;
+    top: 0;
 
     &:hover, &:focus {
       background-color: #f1f1f1;

--- a/src/scss/theme/default/_multiple.scss
+++ b/src/scss/theme/default/_multiple.scss
@@ -33,6 +33,12 @@
     margin-left: 5px;
     margin-top: 5px;
     padding: 0;
+
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
   }
 
   .select2-selection__choice__display {


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Set `max-width` on search box and selection area
- Pinned the "clear" icon to the top right on multiple selects

If this is related to an existing ticket, include a link to it as well.
Fixes #5863.