### PR TITLE
Fix slow memory leak caused by not clearing cache

### DIFF
--- a/src/js/select2/core.js
+++ b/src/js/select2/core.js
@@ -554,6 +554,7 @@ define([
   };
 
   Select2.prototype.destroy = function () {
+    Utils.RemoveData(this.$container[0]);
     this.$container.remove();
 
     this._observer.disconnect();


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Fixed memory leak caused by element reference not being removed from the cache
-
-

If this is related to an existing ticket, include a link to it as well.
Fixes #5912