### PR TITLE
Set title for single select placeholder

### DIFF
--- a/src/js/select2/selection/placeholder.js
+++ b/src/js/select2/selection/placeholder.js
@@ -25,6 +25,15 @@ define([
     $placeholder[0].classList.add('select2-selection__placeholder');
     $placeholder[0].classList.remove('select2-selection__choice');
 
+    var placeholderTitle = placeholder.title ||
+      placeholder.text ||
+      $placeholder.text();
+
+    this.$selection.find('.select2-selection__rendered').attr(
+      'title',
+      placeholderTitle
+    );
+
     return $placeholder;
   };
 

--- a/tests/selection/placeholder-tests.js
+++ b/tests/selection/placeholder-tests.js
@@ -44,7 +44,6 @@ test('normalizing placeholder gives object for string', function (assert) {
   assert.equal(normalized.text, 'placeholder');
 });
 
-
 test('text is shown for placeholder option on single', function (assert) {
   var selection = new SinglePlaceholder(
     $('#qunit-fixture .single'),
@@ -58,6 +57,50 @@ test('text is shown for placeholder option on single', function (assert) {
   }]);
 
   assert.equal($selection.text(), 'This is the placeholder');
+});
+
+test('title is set for placeholder option on single', function (assert) {
+  var selection = new SinglePlaceholder(
+    $('#qunit-fixture .single'),
+    placeholderOptions
+  );
+
+  var $selection = selection.render();
+
+  selection.update([{
+    id: 'placeholder'
+  }]);
+
+  assert.equal(
+    $selection.find('.select2-selection__rendered').attr('title'),
+    'This is the placeholder'
+  );
+});
+
+test('title is used for placeholder option on single', function (assert) {
+  var placeholderTitleOptions = new Options({
+    placeholder: {
+      id: 'placeholder',
+      text: 'This is the placeholder',
+      title: 'This is the placeholder title'
+    }
+  });
+
+  var selection = new SinglePlaceholder(
+    $('#qunit-fixture .single'),
+    placeholderTitleOptions
+  );
+
+  var $selection = selection.render();
+
+  selection.update([{
+    id: 'placeholder'
+  }]);
+
+  assert.equal(
+    $selection.find('.select2-selection__rendered').attr('title'),
+    'This is the placeholder title'
+  );
 });
 
 test('placeholder is shown when no options are selected', function (assert) {


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Properly set `title` attribute for rendered selection in single select when placeholder is visible

If this is related to an existing ticket, include a link to it as well.

Fixes #5963 