### PR TITLE
Fix error callback with custom transport

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -82,7 +82,7 @@ define([
       }, function () {
         // Attempt to detect if a request was aborted
         // Only works if the transport exposes a status property
-        if ('status' in $request &&
+        if ($request && 'status' in $request &&
             ($request.status === 0 || $request.status === '0')) {
           return;
         }


### PR DESCRIPTION
If custom transport does not return any object 
then calling error callback would result in `Uncaught TypeError: right-hand side of 'in' should be an object, got undefined`.
This patch adds check if $request evaluates to something.

This pull request includes a

- [X] Bug fix

The following changes were made

- Check if transport method returned data
