### PR TITLE
Increased sleep for docs when deploying

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: maddox/actions/sleep@master
         with:
-          args: "60"
+          args: "180"
       - uses: actions/checkout@v1
       - name: Copy to documentation server
         uses: maxheld83/rsync@v0.1.0


### PR DESCRIPTION
This is being increased to help mitigate a deployment race condition that can cause the JavaScript to not load if the npm release does not finish with 60 seconds.

This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Increased the timeout to mitigate a docs deploy race condition if npm is not being super responsive.
-
-

If this is related to an existing ticket, include a link to it as well.
