### PR TITLE
Fix Tokenizer error when an unknown option value is typed in, when `tags` are not enabled

### DIFF
--- a/src/js/select2/data/tokenizer.js
+++ b/src/js/select2/data/tokenizer.js
@@ -33,11 +33,17 @@ define([
 
       // If an existing option wasn't found for it, create the option
       if (!$existingOptions.length) {
-        var $option = self.option(item);
-        $option.attr('data-select2-tag', true);
+        // If tags, allow creating new options
+        if (self.options.get('tags')) {
+          var $option = self.option(item);
+          $option.attr('data-select2-tag', true);
 
-        self._removeOldTags();
-        self.addOptions([$option]);
+          self._removeOldTags();
+          self.addOptions([$option]);
+        } else {
+          // Don't create new option or select item
+          return;
+        }
       }
 
       // Select the item, now that we know there is an option for it

--- a/tests/data/tokenizer-tests.js
+++ b/tests/data/tokenizer-tests.js
@@ -217,3 +217,69 @@ test('works with multiple tokens given', function (assert) {
     'The two new tags should have been created'
   );
 });
+
+test('works when unknown option used with no tagging', function (assert) {
+  assert.expect(6);
+
+  var SelectData = require('select2/data/select');
+  var Tokenizer = require('select2/data/tokenizer');
+  var Tags = require('select2/data/tags');
+
+  var Options = require('select2/options');
+  var Utils = require('select2/utils');
+
+  var $ = require('jquery');
+
+  var TokenizedSelect = Utils.Decorate(
+    SelectData,
+    Tokenizer
+  );
+  var $select = $('#qunit-fixture .multiple');
+
+  var options = new Options({
+    tags: false,
+    tokenSeparators: [',']
+  });
+
+  var container = new MockContainer();
+  container.dropdown = container.selection = {};
+
+  var $container = $('<div></div>');
+
+  var data = new TokenizedSelect($select, options);
+  data.bind(container, $container);
+
+  var validItemSelected = false;
+
+  data.on('select', function (params) {
+    assert.ok(params.data, 'Data should not be null');
+
+    assert.equal(
+      params.data.id,
+      'One',
+      'Should only receive single valid option'
+    );
+    validItemSelected = true;
+  });
+
+  assert.equal(
+    $select.children('option').length,
+    2,
+    'The two original options should only exist'
+  );
+
+  data.query({
+    term: 'One,Unknown'
+  }, function () {
+    assert.ok(true, 'The callback should have succeeded');
+  });
+
+  assert.ok(validItemSelected, 'The single valid term should have selected');
+
+  assert.equal(
+    $select.children('option').length,
+    2,
+    'The two original options should only exist'
+  );
+
+});


### PR DESCRIPTION
Fix Tokenizer error (`TypeError: g._removeOldTags is not a function`) when an unknown option value is typed in, when `tags` are not enabled.  Unknown options are ignored in this case.

This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Update `Tokenizer` to check if `tags` are enabled before trying to create tags via `Tags` decorator methods.
- Add test to reproduce/validate fix

Resolves https://github.com/select2/select2/issues/4747
