### PR TITLE
Tokenizer bug fixes/enhancements

### DIFF
--- a/tests/data/tags-tests.js
+++ b/tests/data/tags-tests.js
@@ -79,6 +79,31 @@ test('does not create option if text is same but lowercase', function (assert) {
   });
 });
 
+test('uses matcher to find options', function (assert) {
+  var usedMatcher = false;
+  var localOptions = new Options({
+    matcher: function (params, data) {
+      usedMatcher = true;
+      return options.options.matcher(params, data);
+    }
+  });
+
+  var data = new SelectTags($('#qunit-fixture .single'), localOptions);
+
+  data.query({
+    term: 'one'
+  }, function (data) {
+    assert.equal(data.results.length, 1);
+
+    var item = data.results[0];
+
+    assert.equal(item.id, 'One');
+    assert.equal(item.text, 'One');
+  });
+
+  assert.ok(usedMatcher, 'Tags decorator should have called matcher');
+});
+
 test('does not trigger for additional pages', function (assert) {
   var data = new SelectTags($('#qunit-fixture .single'), options);
 

--- a/tests/data/tokenizer-tests.js
+++ b/tests/data/tokenizer-tests.js
@@ -217,3 +217,335 @@ test('works with multiple tokens given', function (assert) {
     'The two new tags should have been created'
   );
 });
+
+test('matches option text, not value (no tags)', function (assert) {
+  assert.expect(7);
+
+  var SelectData = require('select2/data/select');
+  var Tokenizer = require('select2/data/tokenizer');
+
+  var Options = require('select2/options');
+  var Utils = require('select2/utils');
+
+  var $ = require('jquery');
+
+  var TokenizedSelect = Utils.Decorate(
+    SelectData,
+    Tokenizer
+  );
+  var $select = $('#qunit-fixture .single');
+
+  var options = new Options({
+    tags: false,
+    tokenSeparators: [',']
+  });
+
+  var container = new MockContainer();
+  container.dropdown = container.selection = {};
+
+  var $container = $('<div></div>');
+
+  var data = new TokenizedSelect($select, options);
+  data.bind(container, $container);
+
+  var validItemSelected = false;
+
+  data.on('select', function (params) {
+    assert.ok(params.data, 'Data should not be null');
+
+    assert.equal(
+      params.data.id,
+      '1',
+      'The id should have our different value'
+    );
+
+    assert.equal(
+      params.data.text,
+      'One',
+      'The text should match the expected option'
+    );
+
+    validItemSelected = true;
+  });
+
+  assert.equal(
+    $select.children('option').length,
+    1,
+    'The original option should only exist'
+  );
+
+  // Ensure value is different than text
+  $($select.children('option')[0]).val('1');
+
+  data.query({
+    // Try to match by text (One), not value (1)
+    // Use trailing delimiter to force eval by tokenizer
+    term: 'One,Unknown,'
+  }, function () {
+    assert.ok(true, 'The callback should have succeeded');
+  });
+
+  assert.ok(validItemSelected, 'The single valid term should have selected');
+
+  assert.equal(
+    $select.children('option').length,
+    1,
+    'The original option should only exist'
+  );
+
+});
+
+
+test('matches option text (with tags)', function (assert) {
+  assert.expect(10);
+
+  var SelectData = require('select2/data/select');
+  var Tokenizer = require('select2/data/tokenizer');
+  var Tags = require('select2/data/tags');
+
+  var Options = require('select2/options');
+  var Utils = require('select2/utils');
+
+  var $ = require('jquery');
+
+  var TokenizedSelect = Utils.Decorate(
+    Utils.Decorate(SelectData, Tags),
+    Tokenizer
+  );
+  var $select = $('#qunit-fixture .single');
+
+  var options = new Options({
+    tags: true,
+    tokenSeparators: [',']
+  });
+
+  var container = new MockContainer();
+  container.dropdown = container.selection = {};
+
+  var $container = $('<div></div>');
+
+  var data = new TokenizedSelect($select, options);
+  data.bind(container, $container);
+
+  var validItemSelected = false;
+
+  data.on('select', function (params) {
+    assert.ok(params.data, 'Data should not be null');
+
+    assert.ok(
+      params.data.id === '1' || params.data.id === 'Unknown',
+      'The id should match the values of one of our terms: ' + params.data.id
+    );
+
+    assert.ok(
+      params.data.text === 'One' || params.data.text === 'Unknown',
+      'The text should match the text of one of our terms: ' + params.data.text
+    );
+
+    // Mock SelectAdapter selecting option (since all container events
+    // aren't bound/handled in unit test). This keeps Tags from removing
+    // as an "old tag".
+    params.data.element.selected = true;
+
+    validItemSelected = true;
+  });
+
+  assert.equal(
+    $select.children('option').length,
+    1,
+    'The original option should only exist'
+  );
+
+  // Ensure value is different than text (so we ensure match on text, not value)
+  $($select.children('option')[0]).val('1');
+
+  data.query({
+    // Try to match by text (One), not value (1); and add new Unknown
+    // Use trailing delimiter to force eval by tokenizer
+    term: 'One,Unknown,'
+  }, function () {
+    assert.ok(true, 'The callback should have succeeded');
+  });
+
+  assert.ok(validItemSelected, 'The single valid term should have selected');
+
+  assert.equal(
+    $select.children('option').length,
+    2,
+    'The original option and new Unknown should exist'
+  );
+
+});
+
+
+test('select token if exact match found with other partial matches (no tags)',
+function (assert) {
+  var SelectData = require('select2/data/select');
+  var Tokenizer = require('select2/data/tokenizer');
+
+  var Options = require('select2/options');
+  var Utils = require('select2/utils');
+
+  var $ = require('jquery');
+
+  var TokenizedSelect = Utils.Decorate(
+    SelectData,
+    Tokenizer
+  );
+  var $select = $('#qunit-fixture .multiple');
+  $select.append($('<option>Two Thousand</option>'));
+
+  var options = new Options({
+    tags: false,
+    tokenSeparators: [',']
+  });
+
+  var container = new MockContainer();
+  container.dropdown = container.selection = {};
+
+  var $container = $('<div></div>');
+
+  var data = new TokenizedSelect($select, options);
+  data.bind(container, $container);
+
+
+  // Check whether select should be called
+  var selectTriggered = false;
+  data.on('select', function (params) {
+    selectTriggered = true;
+
+    assert.equal(
+      params.data.text,
+      'Two',
+      'The text should match the exact match only'
+    );
+  });
+
+  data.query({
+    // Should have two partial matches ('Two' and 'Two Thousand'), but only
+    // one exact match by text.
+    term: 'Two,'
+  }, function (data) {
+    assert.ok(true, 'The callback should have succeeded');
+  });
+
+  assert.ok(selectTriggered, 'Select with "Two" should have fired');
+
+  assert.equal(
+    $select.children('option').length,
+    3,
+    'The original options should only exist'
+  );
+});
+
+
+test('continue reading token after separator if no exact match (no tags)',
+function (assert) {
+  var SelectData = require('select2/data/select');
+  var Tokenizer = require('select2/data/tokenizer');
+
+  var Options = require('select2/options');
+  var Utils = require('select2/utils');
+
+  var $ = require('jquery');
+
+  var TokenizedSelect = Utils.Decorate(
+    SelectData,
+    Tokenizer
+  );
+  var $select = $('#qunit-fixture .multiple');
+  $select.append($('<option>Two Thousand</option>'));
+
+  var options = new Options({
+    tags: false,
+    tokenSeparators: [',']
+  });
+
+  var container = new MockContainer();
+  container.dropdown = container.selection = {};
+
+  var $container = $('<div></div>');
+
+  var data = new TokenizedSelect($select, options);
+  data.bind(container, $container);
+
+  data.on('select', function (params) {
+    assert.ok(false, 'Select should not have triggered');
+  });
+
+  // Try to query with multiple matches followed by real match, but in our
+  // case, token separator will be kept to let user correct their input.
+  // Select event should not be triggered
+  data.query({
+    // Use trailing delimiter to force eval by tokenizer
+    term: 'Tw,Two Thousand,'
+  }, function (data) {
+    assert.ok(true, 'The callback should have succeeded');
+
+    assert.equal(
+      data.results.length,
+      0,
+      'No results should match "Tw,Two Thousand" essentially'
+    );
+  });
+});
+
+
+test('select first token, but continue reading token after separator ' +
+     'if no exact match found (no tags)',
+function (assert) {
+  var SelectData = require('select2/data/select');
+  var Tokenizer = require('select2/data/tokenizer');
+
+  var Options = require('select2/options');
+  var Utils = require('select2/utils');
+
+  var $ = require('jquery');
+
+  var TokenizedSelect = Utils.Decorate(
+    SelectData,
+    Tokenizer
+  );
+  var $select = $('#qunit-fixture .multiple');
+  $select.append($('<option>Two Thousand</option>'));
+
+  var options = new Options({
+    tags: false,
+    tokenSeparators: [',']
+  });
+
+  var container = new MockContainer();
+  container.dropdown = container.selection = {};
+
+  var $container = $('<div></div>');
+
+  var data = new TokenizedSelect($select, options);
+  data.bind(container, $container);
+
+  var selectTriggered = false;
+  data.on('select', function (params) {
+    assert.equal(
+      params.data.text,
+      'Two Thousand',
+      'Should have received real match only'
+    );
+    selectTriggered = true;
+  });
+
+
+  // Try to query with single match followed by multiple matches
+  // (that shouldn't select 'Tw')
+  data.query({
+    term: 'Two Thousand,Tw,'
+  }, function (data) {
+    assert.ok(true, 'The callback should have succeeded');
+
+    assert.equal(
+      data.results.length,
+      0,
+      'No results should have matched "Tw," essentially'
+    );
+  });
+
+  assert.ok(selectTriggered, 'Select with "Two Thousand" should have fired');
+});


### PR DESCRIPTION
Tokenizer bug fixes/enhancements for https://github.com/select2/select2/issues/6011

- Fix `Tokenizer` to match options by exact text (not id) just like `Tags` and `matcher` already does. This now allows users to type in the text they see, and not a potentially different (hidden) value.
  - For backward compatibility, it will also check an exact id match too. This doesn't apply to the last term in the query (just like before), which is passed down to the decorated bases.
  - Note: Does not do partial text match like `matcher` because we may not have all available data loaded to assume the partial is best.
- Update `Tokenizer` to trim term in createTag just like `Tags` does (so spaces around separators don't affect matching).
- Update `Tokenizer` to keep matching term (including separator) when tokenized term is not handled (when no matches or multiple matches when `tags: false`).  This lets the user potentially correct their input instead of throwing the token away silently.
- Add tokenizer tests to validate changes.
- Add tags test to verify that Tags uses `matcher` from underlying data adapter (Note: Tokenizer does not use matcher because it needs exact matches and runs before decorated data adapter, etc). Just added as a bonus to point out diff between Tags and Tokenizer matching.
- Included fix for https://github.com/select2/select2/issues/4747 with minor changes.

This pull request includes a

- [X] Bug fix
- [X] New feature
- [ ] Translation
