### PR TITLE
Add `SelectionOrder` DataAdapter decorator and related options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 * Selected results in the dropdown should now be properly announced to screen readers (#5841)
 * Significant improvements were made to make the selection area accessible (#5824, #5842, #5916, #5942, #5973)
 * Allow pasting multiple lines into the search field for tokenization (#5806)
+* Added optional `SelectionOrder` DataAdapter decorator to support tracking value ordering for multiple selects (#3106)
+  * Added `keepSelectionOrder` option
+  * Added `trackManualSelectionOrder` option
 
 ### Bug fixes
 

--- a/docs/pages/03.configuration/01.options-api/docs.md
+++ b/docs/pages/03.configuration/01.options-api/docs.md
@@ -22,6 +22,7 @@ This is a list of all the Select2 configuration options.
 | `dropdownCssClass` | string | `''` | Adds additional CSS classes to the dropdown container. The helper `:all:` can be used to add all CSS classes present on the original `<select>` element. |
 | `dropdownParent` | jQuery selector or DOM node | `$(document.body)` | Allows you to [customize placement](/dropdown#dropdown-placement) of the dropdown. |
 | `escapeMarkup` | callback | `Utils.escapeMarkup` | Handles [automatic escaping of content rendered by custom templates](/dropdown#built-in-escaping). |
+| `keepSelectionOrder` | boolean | `false` | When set to `true` and `multiple: true`, the built-in dataAdapter will preserve the order that options are selected and return that order in the control value.
 | `language` | string or object | `EnglishTranslation` | Specify the [language used for Select2 messages](/i18n#message-translations). |
 | `matcher` | A callback taking search `params` and the `data` object. | | Handles custom [search matching](/searching#customizing-how-results-are-matched). |
 | `maximumInputLength` | integer | `0` | [Maximum number of characters](/searching#maximum-search-term-length) that may be provided for a search term. |
@@ -41,5 +42,6 @@ This is a list of all the Select2 configuration options.
 | `theme` | string | `default` | Allows you to set the [theme](/appearance#themes). |
 | `tokenizer` | callback | | A callback that handles [automatic tokenization of free-text entry](/tagging#automatic-tokenization-into-tags). |
 | `tokenSeparators` | array | `null` | The list of characters that should be used as token separators. |
+| `trackManualSelectionOrder` | boolean | `true` | When `keepSelectionOrder: true`, this controls trying to track manual selection changes and ordering. Tracking user selection order made through the control itself is accurate, but selections performed externally via DOM or jQuery has some limitations.  This flag enables additional event handlers to track individual changes, but has some performance overheads.  Setting the control value using `jQuery.val([...])` still cannot preserve the value ordering though.<br />If your application does not manually change selections, you may want to try to use `trackManualSelectionOrder: false`.
 | `width` | string | `resolve` | Supports [customization of the container width](/appearance#container-width). |
 | `scrollAfterSelect` | boolean | `false` | If `true`, resolves issue for multiselects using `closeOnSelect: false` that caused the list of results to scroll to the first selection after each select/unselect (see https://github.com/select2/select2/pull/5150). This behaviour was intentional to deal with infinite scroll UI issues (if you need this behavior, set `false`) but it created an issue with multiselect dropdown boxes of fixed length. This pull request adds a configurable option to toggle between these two desirable behaviours. |

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -274,6 +274,10 @@ define([
       item.text = item.text.toString();
     }
 
+    if (!item.children && item.id == null) {
+      item.id = item.text;
+    }
+
     if (item._resultId == null && item.id && this.container != null) {
       item._resultId = this.generateResultId(this.container, item);
     }

--- a/src/js/select2/data/selectionOrder.js
+++ b/src/js/select2/data/selectionOrder.js
@@ -1,0 +1,371 @@
+define([
+  'jquery',
+  '../utils'
+], function ($, Utils) {
+  
+  var DATA_SELECTION_ORDER_ATTRNAME = 'data-selection-order';
+  var DATA_DISPLAY_ORDER_ATTRNAME = 'data-display-order';
+  
+  /**
+   * Decorator for DataAdapters to maintain selection ordering and
+   * return that order in the control value.
+   *
+   * This class has to keep both display and selection ordering for
+   * all options in order to manage selection order, while maintaining
+   * the default results/query ordering (when `sorter` is not used, etc).
+   *
+   * Options are also physically rearranged in the DOM in order to support
+   * direct DOM `<select>` value retrieval or via `jQuery.val()`.
+   *
+   * @param decorated
+   * @param $element
+   * @param options
+   * @constructor
+   */
+  function SelectionOrder (decorated, $element, options) {
+
+    this.keepSelectionOrder = options.get('keepSelectionOrder');
+
+    // Should we try to track manual selection changes to preserve ordering as
+    // best as possible. It is easy to track user selection order through the
+    // control itself, but externally via DOM or jQuery has some challenges,
+    // and has some performance overheads.
+    this.trackManualSelectionOrder = options.get('trackManualSelectionOrder');
+    if (this.trackManualSelectionOrder == null) {
+      this.trackManualSelectionOrder = true;
+    }
+
+    decorated.call(this, $element, options);
+  }
+
+
+  SelectionOrder.prototype.bind = function (decorated, container, $container) {
+    decorated.call(this, container, $container);
+
+    // Initialize initial set of DOM options
+    if (this.keepSelectionOrder) {
+      this._prepareInitialOptions();
+      if (this.trackManualSelectionOrder) {
+        this._registerChangeHandler();
+      }
+    }
+  };
+
+
+  /**
+   * Prepare initial DOM options with display/selection order attributes
+   * @private
+   */
+  SelectionOrder.prototype._prepareInitialOptions = function() {
+      var self = this;
+      var selectedOpts = [];
+      self.$element.children('option').each(function (i) {
+        var $this = $(this);
+        // Set default display order
+        $this.attr(DATA_DISPLAY_ORDER_ATTRNAME, i);
+
+        if (this.selected) {
+          selectedOpts.push($this);
+        }
+      });
+
+      // Sort selected options last (in order) in DOM
+      if (selectedOpts.length) {
+        selectedOpts = selectedOpts.sort(
+          createJqAttrSorter(DATA_SELECTION_ORDER_ATTRNAME)
+        );
+
+        $.each(selectedOpts, function(i, $opt) {
+          // Ensure data and selection order is set for all selected
+          var data = Utils.GetData($opt[0], 'data');
+          if (data) {
+            data.selectionOrder = i;
+          }
+          $opt.attr(DATA_SELECTION_ORDER_ATTRNAME, i);
+
+          $opt.detach();
+          self.$element.append($opt);
+        });
+      }
+  };
+
+
+  /**
+   * Register change handler on container (select) to monitor for manual
+   * changes made to selections via DOM/jQuery.
+   *
+   * Any options selected before the change event may lose their relative
+   * order unfortunately:
+   * For example, `$select.val(['3','2','1']).trigger('change')` will
+   * not be able to track the value order, but will fallback to DOM option
+   * order essentially.
+   *
+   * jQuery.valHooks could be used to "monitor" for individual changes, however
+   *
+   *
+   * @private
+   */
+  SelectionOrder.prototype._registerChangeHandler = function() {
+    var self = this;
+    self.$element.on('change', function() {
+      var selectedOpts = [];
+      var updatedSelectedOrder = false;
+
+      self.$element.children('option').each(function (i) {
+        var $this = $(this);
+        var selectionOrder = this.getAttribute(DATA_SELECTION_ORDER_ATTRNAME);
+        var data;
+
+        if (this.selected) {
+          selectedOpts.push($this);
+          // Ensure selection order is set
+          if (selectionOrder == null) {
+            var newOrder = (new Date()).getTime();
+            this.setAttribute(DATA_SELECTION_ORDER_ATTRNAME, newOrder);
+            
+            data = self.item($this);
+            data.selectionOrder = newOrder;
+
+            updatedSelectedOrder = true;
+          }
+        }
+        else if (selectionOrder != null) {
+          // Ensure selection order is unset
+          this.removeAttribute(DATA_SELECTION_ORDER_ATTRNAME);
+
+          data = self.item($this);
+          if (data.selectionOrder != null) {
+            delete data.selectionOrder;
+          }
+        }
+      });
+
+
+      if (updatedSelectedOrder) {
+        // Sort selected options last (in order) in DOM
+        if (selectedOpts.length) {
+          selectedOpts = selectedOpts.sort(
+            createJqAttrSorter(DATA_SELECTION_ORDER_ATTRNAME)
+          );
+
+          $.each(selectedOpts, function (i, $opt) {
+            // Ensure data and selection order is set for all selected
+            var data = Utils.GetData($opt[0], 'data');
+            if (data) {
+              data.selectionOrder = i;
+            }
+            $opt.attr(DATA_SELECTION_ORDER_ATTRNAME, i);
+
+            $opt.detach();
+            self.$element.append($opt);
+          });
+        }
+      }
+
+    });
+  };
+
+
+  SelectionOrder.prototype.current = function (decorated, callback) {
+    var self = this;
+
+    function currentDataCallback(data) {
+      if (self.keepSelectionOrder) {
+        // Sort data based on selectionSorter before calling original callback
+        data = self.selectionSorter(data);
+      }
+
+      callback(data);
+    }
+
+    decorated.call(this, currentDataCallback);
+  };
+
+
+  SelectionOrder.prototype.select = function (decorated, data) {
+    if (this.keepSelectionOrder) {
+      var newOrder = (new Date()).getTime();
+
+      var $opt = this.getElementFromData(data);
+      if ($opt && $opt.length) {
+        // In order to support jquery `val` and preserve selection
+        // order, we need to physically move selected option to the end
+        $opt.detach();
+        this.$element.append($opt);
+
+        // Get full data from option
+        data = this.item($opt);
+
+        $opt.attr(DATA_SELECTION_ORDER_ATTRNAME, newOrder);
+      }
+
+      // Use current time as ordering key
+      data.selectionOrder = newOrder;
+    }
+
+    decorated.call(this, data);
+  };
+
+
+  SelectionOrder.prototype.unselect = function (decorated, data) {
+    if (this.keepSelectionOrder) {
+      var $opt = this.getElementFromData(data);
+      if ($opt && $opt.length) {
+        $opt.attr(DATA_SELECTION_ORDER_ATTRNAME, null);
+
+        // Get full data from option
+        data = this.item($opt);
+      }
+
+      if (data.selectionOrder !== undefined) {
+        delete data.selectionOrder;
+      }
+    }
+
+    decorated.call(this, data);
+  };
+
+
+  SelectionOrder.prototype.query = function (decorated, params, callback) {
+    var self = this;
+
+    function queryCallback(data) {
+      if (self.keepSelectionOrder) {
+        // Sort data based on original option order, not adjusted order.
+        // Results/sorter may sort results into more desired order later though.
+        data.results = self.queryResultSorter(data.results);
+      }
+
+      callback(data);
+    }
+
+    decorated.call(this, params, queryCallback);
+  };
+
+
+  SelectionOrder.prototype.addOptions = function (decorated, $options) {
+    decorated.call(this, $options);
+
+    if (this.keepSelectionOrder) {
+      // Add new option at the end
+      var $lastOpt = this.$element.children('option').last();
+      var nextOrder = parseInt(
+        $lastOpt.attr(DATA_DISPLAY_ORDER_ATTRNAME) || '0',
+        10
+      ) + 1;
+      for (var i = 0; i < $options.length; i++) {
+        var $opt = $options[i];
+        $opt.attr(DATA_DISPLAY_ORDER_ATTRNAME, nextOrder + i);
+      }
+    }
+  };
+
+
+  SelectionOrder.prototype.item = function (decorated, $option) {
+    var data = decorated.call(this, $option);
+
+    if (this.keepSelectionOrder) {
+      var attrValue;
+
+      // if `option` item
+      if (data.id != null) {
+        // Default selection order using `data-selection-order` attrib
+        if (data.selectionOrder === undefined) {
+          attrValue = $option.attr(DATA_SELECTION_ORDER_ATTRNAME);
+          if (attrValue != null) {
+            data.selectionOrder = parseInt(attrValue,10);
+          }
+        }
+
+        // Default option/result display order using `data-display-order` attrib
+        if (data.displayOrder === undefined) {
+          attrValue = $option.attr(DATA_DISPLAY_ORDER_ATTRNAME);
+          if (attrValue != null) {
+            data.displayOrder = parseInt(attrValue, 10);
+          }
+        }
+      }
+    }
+
+    return data;
+  };
+
+
+  /**
+   * Get the DOM option given the option data
+   * @param _
+   * @param data Option's data object, which may be incomplete.
+   * @returns {null|*}
+   */
+  SelectionOrder.prototype.getElementFromData = function(_, data) {
+    if (data.element) {
+      return data.element;
+    }
+    else if (data.id) {
+      var idValue = data.id.toString();
+      return this.$element.find('option').filter(function (i, elm) {
+        return elm.value == idValue;
+      });
+    }
+    return null;
+  };
+
+
+  var createPropSorter = function(propName) {
+    /**
+     * Sorter for objects by a given property name like 'selectionOrder'.
+     * Sort ordered items first, then leave all others in same order as original
+     */
+    return function (a, b) {
+      var aVal = a[propName],
+          bVal = b[propName];
+
+      if (aVal != null && bVal != null) {
+        return aVal - bVal;
+      } else if (aVal != null) {
+        return -1;
+      } else if (bVal != null) {
+        return 1;
+      }
+      return 0;
+    };
+  };
+
+  var createJqAttrSorter = function(attrName) {
+    /**
+     * Sorter for JQuery objects by a given attr name
+     * Sort ordered items first, then leave all others in same order as original
+     */
+    return function ($a, $b) {
+      var aVal = $a.attr(attrName),
+          bVal = $b.attr(attrName);
+
+      if (aVal != null && bVal != null) {
+        return aVal - bVal;
+      } else if (aVal != null) {
+        return -1;
+      } else if (bVal != null) {
+        return 1;
+      }
+      return 0;
+    };
+  };
+
+
+  SelectionOrder.prototype.selectionSorter = function (_, data) {
+    return data.sort(createPropSorter('selectionOrder'));
+  };
+
+
+  /**
+   * Sort the query results based on original option display order
+   * @param _
+   * @param data
+   * @returns {*}
+   */
+  SelectionOrder.prototype.queryResultSorter = function(_, data) {
+    return data.sort(createPropSorter('displayOrder'));
+  };
+
+  return SelectionOrder;
+});

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -18,6 +18,7 @@ define([
   './data/select',
   './data/array',
   './data/ajax',
+  './data/selectionOrder',
   './data/tags',
   './data/tokenizer',
   './data/minimumInputLength',
@@ -45,7 +46,7 @@ define([
 
              Utils, Translation, DIACRITICS,
 
-             SelectData, ArrayData, AjaxData, Tags, Tokenizer,
+             SelectData, ArrayData, AjaxData, SelectionOrder, Tags, Tokenizer,
              MinimumInputLength, MaximumInputLength, MaximumSelectionLength,
 
              Dropdown, DropdownSearch, HidePlaceholder, InfiniteScroll,
@@ -67,6 +68,13 @@ define([
         options.dataAdapter = ArrayData;
       } else {
         options.dataAdapter = SelectData;
+      }
+
+      if (options.keepSelectionOrder && options.multiple) {
+          options.dataAdapter = Utils.Decorate(
+            options.dataAdapter,
+            SelectionOrder
+          );
       }
 
       if (options.minimumInputLength > 0) {
@@ -309,6 +317,9 @@ define([
       minimumResultsForSearch: 0,
       selectOnClose: false,
       scrollAfterSelect: false,
+
+      keepSelectionOrder: false,
+
       sorter: function (data) {
         return data;
       },

--- a/tests/data/selectionOrder-tests.js
+++ b/tests/data/selectionOrder-tests.js
@@ -1,0 +1,573 @@
+module('Data adapters - SelectionOrder');
+
+var Select2 = require('select2/core');
+
+var SelectData = require('select2/data/select');
+var SelectionOrder = require('select2/data/selectionOrder');
+var Tags = require('select2/data/tags');
+
+var MultipleSelection = require('select2/selection/multiple');
+
+var $ = require('jquery');
+var Options = require('select2/options');
+var Utils = require('select2/utils');
+
+var options = new Options({});
+
+test('initial dom display order preserved', function (assert) {
+  assert.expect(2);
+
+  var options = new Options({
+    keepSelectionOrder: true
+  });
+
+  var $select = $(
+    '<select multiple>' +
+      '<option selected data-selection-order="2">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3" selected data-selection-order="1">Three</option>' +
+      '<option value="4" selected>Four</option>' +  // No defined order
+    '</select>'
+  );
+
+  var container = new MockContainer();
+  var $container = $('<div></div>');
+
+  var OrderedSelectData = Utils.Decorate(SelectData, SelectionOrder);
+
+  var dataAdapter = new OrderedSelectData($select, options);
+  dataAdapter.bind(container, $container);
+
+  dataAdapter.query({
+    term: ''
+  }, function (data) {
+    assert.equal(data.results.length, 4);
+
+    var itemIds = $.map(data.results, function(item) { return item.id; });
+
+    // Verify display order preserved
+    assert.deepEqual(
+      itemIds,
+      ['One', 'Two', '3', '4'],
+      'The values should be in display order'
+    );
+
+  });
+});
+
+
+test('initial dom selection order preserved', function (assert) {
+  assert.expect(2);
+
+  var options = new Options({
+    keepSelectionOrder: true
+  });
+
+  var $select = $(
+    '<select multiple>' +
+      '<option selected data-selection-order="2">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3" selected data-selection-order="1">Three</option>' +
+      '<option value="4" selected>Four</option>' +  // No defined order
+    '</select>'
+  );
+
+  var container = new MockContainer();
+  var $container = $('<div></div>');
+
+  var OrderedSelectData = Utils.Decorate(SelectData, SelectionOrder);
+
+  var dataAdapter = new OrderedSelectData($select, options);
+  dataAdapter.bind(container, $container);
+
+  dataAdapter.current(function (data) {
+    assert.equal(data.length, 3);
+
+    var itemIds = $.map(data, function(item) { return item.id; });
+
+    // Verify explicit selection order preserved
+    assert.deepEqual(
+      itemIds,
+      ['3', 'One', '4'],
+      'The values should be in selection order'
+    );
+  });
+});
+
+
+
+
+test('selection order after changes preserved', function (assert) {
+  assert.expect(6);
+
+  var options = new Options({
+    keepSelectionOrder: true
+  });
+
+  var $select = $(
+    '<select multiple>' +
+      '<option selected data-selection-order="2">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3" selected data-selection-order="1">Three</option>' +
+      '<option value="4" selected>Four</option>' +  // No defined order
+    '</select>'
+  );
+
+  var container = new MockContainer();
+  var $container = $('<div></div>');
+
+  var OrderedSelectData = Utils.Decorate(SelectData, SelectionOrder);
+
+  var dataAdapter = new OrderedSelectData($select, options);
+  dataAdapter.bind(container, $container);
+
+  dataAdapter.select({
+    id: 'Two',
+    text: 'Two'
+  });
+
+  var expectedIds = ['3', 'One', '4', 'Two'];
+
+  dataAdapter.current(function (data) {
+    assert.equal(data.length, expectedIds.length);
+
+    var itemIds = $.map(data, function(item) { return item.id; });
+
+    // Verify explicit selection order preserved
+    assert.deepEqual(
+      itemIds,
+      expectedIds,
+      'The values should be in selection order'
+    );
+  });
+
+  // jQuery value is same order
+  assert.deepEqual($select.val(), expectedIds);
+
+
+  // ########################################################
+  // Check after unselecting existing and re-selecting
+  dataAdapter.unselect({
+    id: '3',
+    text: 'Three'
+  });
+
+  dataAdapter.select({
+    id: '3',
+    text: 'Three'
+  });
+
+  expectedIds = ['One', '4', 'Two', '3'];
+
+  dataAdapter.current(function (data) {
+    assert.equal(data.length, expectedIds.length);
+
+    var itemIds = $.map(data, function(item) { return item.id; });
+
+    // Verify explicit selection order preserved
+    assert.deepEqual(
+      itemIds,
+      expectedIds,
+      'The values should be in selection order after unselect/select'
+    );
+  });
+
+  // jQuery value is same order
+  assert.deepEqual($select.val(), expectedIds);
+});
+
+
+test('selection order after changes preserved (with tags)', function (assert) {
+  assert.expect(9);
+
+  var options = new Options({
+    keepSelectionOrder: true,
+    tags: true
+  });
+
+  var $select = $(
+    '<select multiple>' +
+      '<option selected data-selection-order="2">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3" selected data-selection-order="1">Three</option>' +
+      '<option value="4" selected>Four</option>' +  // No defined order
+    '</select>'
+  );
+
+  var container = new MockContainer();
+  var $container = $('<div></div>');
+
+  var OrderedSelectData = Utils.Decorate(
+    Utils.Decorate(SelectData, SelectionOrder),
+    Tags);
+
+  var dataAdapter = new OrderedSelectData($select, options);
+  dataAdapter.bind(container, $container);
+
+
+  // Should query and find 'One', plus suggest new tag 'On'
+  // By default, tags are inserted into beginning of results
+  var expectedIdsResultsOrder = ['On', 'One'];
+
+  dataAdapter.query({
+    term: 'On'
+  }, function (data) {
+    assert.equal(data.results.length, expectedIdsResultsOrder.length);
+
+    var itemIds = $.map(data.results, function(item) { return item.id; });
+
+    // Verify tag in results order preserved
+    assert.deepEqual(
+      itemIds,
+      expectedIdsResultsOrder,
+      'The query results values should be in results order'
+    );
+
+    // Select new tag
+    dataAdapter.select(data.results[0]);
+  });
+
+
+  // New tag 'On' should still get returned at end of selections
+  var expectedIdsSelectionOrder = ['3', 'One', '4', 'On'];
+
+  dataAdapter.current(function (data) {
+    assert.equal(data.length, expectedIdsSelectionOrder.length);
+
+    var itemIds = $.map(data, function(item) { return item.id; });
+
+    // Verify explicit selection order preserved
+    assert.deepEqual(
+      itemIds,
+      expectedIdsSelectionOrder,
+      'The values should be in selection order'
+    );
+  });
+
+  // jQuery value is same order
+  assert.deepEqual($select.val(), expectedIdsSelectionOrder);
+
+
+
+  // ########################################################
+  // Check after unselecting existing and re-selecting
+  dataAdapter.unselect({
+    id: 'On',
+    text: 'On'
+  });
+
+  dataAdapter.query({
+    term: 'On'
+  }, function (data) {
+    assert.equal(
+      data.results[0].id,
+      'On',
+      'New tag should be first in results again');
+
+    // Select new tag
+    dataAdapter.select(data.results[0]);
+  });
+
+  dataAdapter.current(function (data) {
+    assert.equal(data.length, expectedIdsSelectionOrder.length);
+
+    var itemIds = $.map(data, function(item) { return item.id; });
+
+    // Verify explicit selection order preserved
+    assert.deepEqual(
+      itemIds,
+      expectedIdsSelectionOrder,
+      'The values should be in selection order after unselect/select tag'
+    );
+  });
+
+  // jQuery value is same order
+  assert.deepEqual($select.val(), expectedIdsSelectionOrder);
+});
+
+
+
+test('query display order after changes preserved', function (assert) {
+  assert.expect(2);
+
+  var options = new Options({
+    keepSelectionOrder: true
+  });
+
+  var $select = $(
+    '<select multiple>' +
+      '<option selected data-selection-order="2">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3" selected data-selection-order="1">Three</option>' +
+      '<option value="4" selected>Four</option>' +  // No defined order
+    '</select>'
+  );
+
+  var container = new MockContainer();
+  var $container = $('<div></div>');
+
+  var OrderedSelectData = Utils.Decorate(SelectData, SelectionOrder);
+
+  var dataAdapter = new OrderedSelectData($select, options);
+  dataAdapter.bind(container, $container);
+
+  // Should return options in original display order
+  var expectedIds = ['One', '3'];
+
+  dataAdapter.query({
+    term: 'e'
+  }, function (data) {
+    assert.equal(data.results.length, expectedIds.length);
+
+    var itemIds = $.map(data.results, function(item) { return item.id; });
+
+    // Verify results order preserved
+    assert.deepEqual(
+      itemIds,
+      expectedIds,
+      'The query results values should be in display order'
+    );
+  });
+
+});
+
+
+test('query display order after changes preserved (with tags)',
+function (assert) {
+  assert.expect(2);
+
+  var options = new Options({
+    keepSelectionOrder: true
+  });
+
+  var $select = $(
+    '<select multiple>' +
+      '<option selected data-selection-order="2">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3" selected data-selection-order="1">Three</option>' +
+      '<option value="4" selected>Four</option>' +  // No defined order
+    '</select>'
+  );
+
+  var container = new MockContainer();
+  var $container = $('<div></div>');
+
+  var OrderedSelectData = Utils.Decorate(
+    Utils.Decorate(SelectData, SelectionOrder),
+    Tags);
+
+  var dataAdapter = new OrderedSelectData($select, options);
+  dataAdapter.bind(container, $container);
+
+  // Should return options in original display order, with new tag at start
+  var expectedIds = ['e', 'One', '3'];
+
+  dataAdapter.query({
+    term: 'e'
+  }, function (data) {
+    assert.equal(data.results.length, expectedIds.length);
+
+    var itemIds = $.map(data.results, function(item) { return item.id; });
+
+    // Verify results order preserved
+    assert.deepEqual(
+      itemIds,
+      expectedIds,
+      'The query results values should be in display order'
+    );
+  });
+
+});
+
+
+
+
+
+module('Data adapters - SelectionOrder - integration');
+
+test('multiple default selections returned in order', function (assert) {
+  var $select = $(
+    '<select multiple>' +
+      '<option selected data-selection-order="2">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3" selected data-selection-order="1">Three</option>' +
+      '<option value="4" selected>Four</option>' +  // No defined order
+    '</select>'
+  );
+  var options = {
+    keepSelectionOrder: true
+  };
+
+  var select = new Select2($select, options);
+
+  var items = select.data();
+  var itemIds = $.map(items, function(item) { return item.id; });
+
+  assert.equal(
+    items.length,
+    3,
+    'The three selected items should be returned'
+  );
+
+  // Verify selection
+  assert.deepEqual(
+    itemIds,
+    ['3', 'One', '4'],
+    'The values should be in selection order'
+  );
+});
+
+
+test('multiple value matches the jquery value', function (assert) {
+  var $select = $(
+    '<select multiple>' +
+      '<option selected data-selection-order="2">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3" selected data-selection-order="1">Three</option>' +
+      '<option value="4" selected>Four</option>' +  // No defined order
+    '</select>'
+  );
+  var options = {
+    keepSelectionOrder: true
+  };
+
+  var select = new Select2($select, options);
+
+  var value = $select.val();
+
+  assert.equal(
+    value.length,
+    3,
+    'Three options should be selected'
+  );
+
+  assert.deepEqual(
+    value,
+    ['3', 'One', '4'],
+    'The values should match the option tag attribute'
+  );
+
+  assert.deepEqual(
+    value,
+    $select.val(),
+    'The values should match the jquery values'
+  );
+});
+
+
+// Really just testing limitation of SelectionOrder because of
+// how jQuery applies val().  If the options were individually selected
+// and a 'change' event fired between, the decorator could track
+test('setting value via jQuery cant preserve selection ordering',
+function (assert) {
+  var $select = $(
+    '<select multiple>' +
+      '<option>One</option>' +
+      '<option>Two</option>' +
+      '<option value="3">Three</option>' +
+      '<option value="4">Four</option>' +
+    '</select>'
+  );
+  var options = {
+    keepSelectionOrder: true
+  };
+
+  var select = new Select2($select, options);
+
+  $select.val(['3','One','4']).trigger('change');
+
+  // In this scenario, the selection order falls back to option DOM order
+  var expectedIds = ['One','3', '4'];
+  var value = $select.val();
+
+  assert.equal(
+    value.length,
+    expectedIds.length,
+    'Expected options should be selected'
+  );
+
+  assert.deepEqual(
+    value,
+    expectedIds,
+    'The value order isn\'t correct'
+  );
+});
+
+
+// Test that manually setting option.selected with a 'change' event
+// inbetween can track selection order propertly still.
+test('setting value via indiv option preserves selection ordering',
+function (assert) {
+  var $select = $(
+    '<select multiple>' +
+      '<option value="One">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3">Three</option>' +
+      '<option value="4">Four</option>' +
+    '</select>'
+  );
+  var options = {
+    keepSelectionOrder: true
+  };
+
+  var select = new Select2($select, options);
+
+  $select.find('option[value=3]').prop('selected', true).trigger('change');
+  $select.find('option[value=One]').prop('selected', true).trigger('change');
+  $select.find('option[value=4]').prop('selected', true).trigger('change');
+
+  var expectedIds = ['3', 'One', '4'];
+  var value = $select.val();
+
+  assert.equal(
+    value.length,
+    expectedIds.length,
+    'Expected options should be selected'
+  );
+
+  assert.deepEqual(
+    value,
+    expectedIds,
+    'The value order isn\'t correct'
+  );
+});
+
+
+// Test that manually setting option.selected with a 'change' event
+// inbetween cant track selection order when trackManualSelectionOrder=false
+test('setting value via indiv option with trackManualSelectionOrder=false',
+function (assert) {
+  var $select = $(
+    '<select multiple>' +
+      '<option value="One">One</option>' +
+      '<option>Two</option>' +
+      '<option value="3">Three</option>' +
+      '<option value="4">Four</option>' +
+    '</select>'
+  );
+  var options = {
+    keepSelectionOrder: true,
+    trackManualSelectionOrder: false
+  };
+
+  var select = new Select2($select, options);
+
+  $select.find('option[value=3]').prop('selected', true).trigger('change');
+  $select.find('option[value=One]').prop('selected', true).trigger('change');
+  $select.find('option[value=4]').prop('selected', true).trigger('change');
+
+  var expectedIds = ['One', '3', '4'];
+  var value = $select.val();
+
+  assert.equal(
+    value.length,
+    expectedIds.length,
+    'Expected options should be selected'
+  );
+
+  assert.deepEqual(
+    value,
+    expectedIds,
+    'The value order isn\'t correct'
+  );
+});

--- a/tests/data/selectionOrder-tests.js
+++ b/tests/data/selectionOrder-tests.js
@@ -3,6 +3,7 @@ module('Data adapters - SelectionOrder');
 var Select2 = require('select2/core');
 
 var SelectData = require('select2/data/select');
+var ArrayData = require('select2/data/array');
 var SelectionOrder = require('select2/data/selectionOrder');
 var Tags = require('select2/data/tags');
 
@@ -94,6 +95,45 @@ test('initial dom selection order preserved', function (assert) {
   });
 });
 
+
+test('initial array selection order preserved', function (assert) {
+  assert.expect(2);
+
+  var options = new Options({
+    keepSelectionOrder: true,
+    data: [
+      { text: 'One', selected: true },
+      { text: 'Two' },
+      { id: 3, text: 'Three', selected: true, selectionOrder: 1 },
+      { id: 4, text: 'Four', selected: true } // No defined order
+    ]
+  });
+
+  var $select = $(
+    '<select multiple></select>'
+  );
+
+  var container = new MockContainer();
+  var $container = $('<div></div>');
+
+  var OrderedArrayData = Utils.Decorate(ArrayData, SelectionOrder);
+
+  var dataAdapter = new OrderedArrayData($select, options);
+  dataAdapter.bind(container, $container);
+
+  dataAdapter.current(function (data) {
+    assert.equal(data.length, 3);
+
+    var itemIds = $.map(data, function(item) { return item.id; });
+
+    // Verify explicit selection order preserved
+    assert.deepEqual(
+      itemIds,
+      ['3', 'One', '4'],
+      'The values should be in selection order'
+    );
+  });
+});
 
 
 

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -61,6 +61,7 @@
     <script src="data/array-tests.js" type="text/javascript"></script>
     <script src="data/base-tests.js" type="text/javascript"></script>
     <script src="data/select-tests.js" type="text/javascript"></script>
+    <script src="data/selectionOrder-tests.js" type="text/javascript"></script>
     <script src="data/tags-tests.js" type="text/javascript"></script>
     <script src="data/tokenizer-tests.js" type="text/javascript"></script>
 

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -61,6 +61,7 @@
     <script src="data/array-tests.js" type="text/javascript"></script>
     <script src="data/base-tests.js" type="text/javascript"></script>
     <script src="data/select-tests.js" type="text/javascript"></script>
+    <script src="data/selectionOrder-tests.js" type="text/javascript"></script>
     <script src="data/tags-tests.js" type="text/javascript"></script>
     <script src="data/tokenizer-tests.js" type="text/javascript"></script>
 

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -61,6 +61,7 @@
     <script src="data/array-tests.js" type="text/javascript"></script>
     <script src="data/base-tests.js" type="text/javascript"></script>
     <script src="data/select-tests.js" type="text/javascript"></script>
+    <script src="data/selectionOrder-tests.js" type="text/javascript"></script>
     <script src="data/tags-tests.js" type="text/javascript"></script>
     <script src="data/tokenizer-tests.js" type="text/javascript"></script>
 


### PR DESCRIPTION
Add `SelectionOrder` DataAdapter decorator and related options as a proposal to resolve https://github.com/select2/select2/issues/3106 with some limitations for manual selection changes (as noted).

- This class has to keep both display and selection ordering for all options in order to manage selection order, while maintaining the default results/query ordering (when `sorter` is not used, etc).
- Notable but unfortunate limitation: Setting the control value using `jQuery.val([...])` with multiple items or manually toggling option `selected` (without a `change` event) still cannot preserve the value ordering.
  - The partial workaround for this is to manually set your selected options with the `data-selection-order` attribute before setting val() if possible.
  - It may also be possible to enhance the decorator to watch for manual changes via MutationObserver. TBD.

New options:
- `keepSelectionOrder`
- `trackManualSelectionOrder`

Update docs.
Add tests.

This pull request includes a

- [X] Bug fix
- [X] New feature
- [ ] Translation
