### PR TITLE
Prevent fields from toggling open when cleared

### DIFF
--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -21,7 +21,7 @@ define([
 
     this.$selection.on('mousedown', '.select2-selection__clear',
       function (evt) {
-        self._handleClear(evt);
+        self._handleClear(evt, container);
     });
 
     container.on('keypress', function (evt) {
@@ -29,7 +29,7 @@ define([
     });
   };
 
-  AllowClear.prototype._handleClear = function (_, evt) {
+  AllowClear.prototype._handleClear = function (_, evt, container) {
     // Ignore the event if it is disabled
     if (this.isDisabled()) {
       return;
@@ -76,7 +76,9 @@ define([
 
     this.$element.trigger('input').trigger('change');
 
-    this.trigger('toggle', {});
+    if (container.isOpen()) {
+      this.trigger('toggle', {});
+    }
   };
 
   AllowClear.prototype._handleKeyboardClear = function (_, evt, container) {


### PR DESCRIPTION
Currently when the `_handleClear` event fires the field will be closed if it was opened (👍) and opened if it was previously closed (👎). I can think of no reason why anyone would want both of those to be the case, and in most cases I expect it would be undesirable to have fields automatically opening when they’re cleared.

Anyone that wants to select a different option can already click in any other part of the field to open it up and select a new value – someone that clicks the clear button is explicitly choosing not to do that.

This is discussed in #3320 and clearly a lot of people feel the same way. I appreciate the request was denied before, but I thought I’d submit a very clean/simple PR before resorting to a nasty local hack in my project.

This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- The mouse clear event will no longer open a closed field.
