### PR TITLE
fixed auto focus for search box for jquery 3.6.0

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -55,8 +55,6 @@ define([
       self.$search.attr('tabindex', 0);
       self.$search.attr('aria-controls', resultsId);
 
-      self.$search.trigger('focus');
-
       window.setTimeout(function () {
         self.$search.trigger('focus');
       }, 0);

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -69,12 +69,6 @@ define([
       self.$search.trigger('blur');
     });
 
-    container.on('focus', function () {
-      if (!container.isOpen()) {
-        self.$search.trigger('focus');
-      }
-    });
-
     container.on('results:all', function (params) {
       if (params.query.term == null || params.query.term === '') {
         var showSearch = self.showSearch(params);


### PR DESCRIPTION
This pull request includes a fix for the search box not focusing immediately after the select is opened for clients using latest jquery v3.6.0

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Removed unnecessary jquery that conflicts with the same code called the line after which actually works.
- Tested with jquery 3.6.0, 3.5.1, 3.3.1, 3.2.1, 3.1.1, 1.12.1 and worked.

tickets:
https://github.com/select2/select2/issues/5996
https://github.com/select2/select2/issues/6005