### PR TITLE
Update docs.md

### DIFF
--- a/docs/pages/06.data-sources/02.ajax/docs.md
+++ b/docs/pages/06.data-sources/02.ajax/docs.md
@@ -16,7 +16,7 @@ Select2 comes with AJAX support built in, using jQuery's AJAX methods. In this e
 **In your HTML:**
 
 ```
-<select class="js-data-example-ajax"></select>
+<input class="js-data-example-ajax"></input>
 ```
 
 **In your Javascript:**


### PR DESCRIPTION
Using select for an ajax call just doesn't work, looks like it needs to be an input element to work.
Many users are getting this error: Option 'ajax' is not allowed for Select2 when attached to a select element

This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

-
-
-

If this is related to an existing ticket, include a link to it as well.
