### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.github export-ignore
+/docs export-ignore
+/src export-ignore
+/tests export-ignore


### PR DESCRIPTION
This pull request includes a .gitattributes file to exclude tests, src, and other directories from the archive files available under tags.

I'm following the advice at https://stackoverflow.com/questions/32475266/how-to-remove-all-tests-in-composer-php:

> It's worth noting that the Composer maintainers stopped promoting .gitattributes as a way to exclude stuff from packages. That option still exists due to the way Composer usually fetches distribution packages from Git repos, but it has been labeled to be "out of scope" for Composer itself. – Sven Jul 6 '16 at 19:43

The reason for this change is that the docs directory includes PHP files. So when this package is installed in a PHP site, there are unwanted PHP files in the web root.
