### PR TITLE
Add feature that allows reuse of options

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -27,6 +27,21 @@ define([
 
   SelectAdapter.prototype.select = function (data) {
     var self = this;
+    var current = this.$element.val();
+    var options = self.options;
+
+    // If the selected data was already selected, clone the option and select it
+    // as well.
+    if (options && options.get('reuse') && current.includes(data.id)) {
+      // Clone the option removing the id such that a new one is generated.
+      var $option = this.option(data);
+      $option[0].removeAttribute('data-select2-id');
+      this.addOptions($option);
+
+      current.push(data.id);
+      this.$element.val(current);
+      this.$element.trigger('input').trigger('change');
+    }
 
     data.selected = true;
 
@@ -69,9 +84,19 @@ define([
 
   SelectAdapter.prototype.unselect = function (data) {
     var self = this;
+    var val = this.$element.val();
+    var options = self.options;
 
     if (!this.$element.prop('multiple')) {
       return;
+    }
+
+    // Remove the option, unless it is the last occurrence remaining.
+    if (
+        options && options.get('reuse') &&
+        val.indexOf(data.id) != val.lastIndexOf(data.id)
+    ) {
+      this.removeOption(data);
     }
 
     data.selected = false;
@@ -158,6 +183,15 @@ define([
 
   SelectAdapter.prototype.addOptions = function ($options) {
     this.$element.append($options);
+  };
+
+  SelectAdapter.prototype.removeOption = function ($option) {
+    var id = $option.element.getAttribute('data-select2-id');
+    for (var d = 0; d < this.$element[0].length; d++) {
+      if (this.$element[0][d].getAttribute('data-select2-id') == id) {
+        this.$element[0].remove(d);
+      }
+    }
   };
 
   SelectAdapter.prototype.option = function (data) {

--- a/src/js/select2/options.js
+++ b/src/js/select2/options.js
@@ -24,6 +24,10 @@ define([
       this.options.multiple = $e.prop('multiple');
     }
 
+    if (this.options.reuse == null) {
+      this.options.reuse = $e.prop('reuse');
+    }
+
     if (this.options.disabled == null) {
       this.options.disabled = $e.prop('disabled');
     }

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -455,7 +455,13 @@ define([
       var data = Utils.GetData(this, 'data');
 
       if ($this.hasClass('select2-results__option--selected')) {
-        if (self.options.get('multiple')) {
+        if (self.options.get('reuse')) {
+          data.selected = false;
+          self.trigger('select', {
+            originalEvent: evt,
+            data: data
+          });
+        } else if (self.options.get('multiple')) {
           self.trigger('unselect', {
             originalEvent: evt,
             data: data


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Add the possibility to reuse existing tags for select widgets that allow multiple tags. When clicking on a tag from the selection container that is already selected, instead of deselecting it (as is the current behavior) the option is cloned and selected as well. Deselecting tags can now only be done by directly clicking on the cross mark of the tag which will also remove the corresponding option from the selection container.

If this is related to an existing ticket, include a link to it as well.
Fixes #4472 

This is my first contribution to `select2` and I am not a javascript programmer in general. It is quite possible that this implementation is therefore far from ideal. I haven't added unit tests yet because I am not sure how, but testing this manually seems to accomplish what I needed for this feature. Happy to add tests once I know how and add documentation if the feature is approved and finalized.
