### PR TITLE
Force dropdown position

### DIFF
--- a/docs/pages/07.dropdown/docs.md
+++ b/docs/pages/07.dropdown/docs.md
@@ -130,6 +130,6 @@ $('#mySelect2').select2({
 
 //Forces the Select2 dropdown to open ABOVE the <select> element
 $('#mySelect2').select2({
-    forceDropdownPosition: 'above'
+  forceDropdownPosition: 'above'
 });
 ```

--- a/docs/pages/07.dropdown/docs.md
+++ b/docs/pages/07.dropdown/docs.md
@@ -116,3 +116,20 @@ If you run into positioning issues while using the default `body` attachment, yo
 See [this issue](https://github.com/select2/select2/issues/3970#issuecomment-160496724).
 
 >>>> `dropdownParent` will cause DOM events to be raised outside of the standard Select2 DOM container. This can cause issues with third-party components such as modals.
+
+## Dropdown position
+
+By default, Select2 will try to select the optimal position for the dropdown, either below or above the `<select>` element.
+If you want to force the dropdown to open either above or below the `<select>` element, you can specify this with a constructor option `forceDropdownPosition`:
+```
+//Forces the Select2 dropdown to open BELOW the <select> element
+$('#mySelect2').select2({
+    forceDropdownPosition: 'below'
+});
+
+
+//Forces the Select2 dropdown to open ABOVE the <select> element
+$('#mySelect2').select2({
+    forceDropdownPosition: 'above'
+});
+```

--- a/docs/pages/07.dropdown/docs.md
+++ b/docs/pages/07.dropdown/docs.md
@@ -122,7 +122,7 @@ See [this issue](https://github.com/select2/select2/issues/3970#issuecomment-160
 By default, Select2 will try to select the optimal position for the dropdown, either below or above the `<select>` element.
 If you want to force the dropdown to open either above or below the `<select>` element, you can specify this with a constructor option `forceDropdownPosition`:
 ```
-//Forces the Select2 dropdown to open BELOW the <select> element
+// Forces the Select2 dropdown to open BELOW the <select> element
 $('#mySelect2').select2({
   forceDropdownPosition: 'below'
 });

--- a/docs/pages/07.dropdown/docs.md
+++ b/docs/pages/07.dropdown/docs.md
@@ -124,7 +124,7 @@ If you want to force the dropdown to open either above or below the `<select>` e
 ```
 //Forces the Select2 dropdown to open BELOW the <select> element
 $('#mySelect2').select2({
-    forceDropdownPosition: 'below'
+  forceDropdownPosition: 'below'
 });
 
 

--- a/docs/pages/07.dropdown/docs.md
+++ b/docs/pages/07.dropdown/docs.md
@@ -128,7 +128,7 @@ $('#mySelect2').select2({
 });
 
 
-//Forces the Select2 dropdown to open ABOVE the <select> element
+// Forces the Select2 dropdown to open ABOVE the <select> element
 $('#mySelect2').select2({
   forceDropdownPosition: 'above'
 });

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -299,6 +299,7 @@ define([
       autocomplete: 'off',
       closeOnSelect: true,
       debug: false,
+      forceDropdownPosition: 'auto',
       dropdownAutoWidth: false,
       escapeMarkup: Utils.escapeMarkup,
       language: {},

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -207,7 +207,7 @@ define([
     css.top -= parentOffset.top;
     css.left -= parentOffset.left;
     
-    if(this.options.get('forceDropdownPosition')==='below' || this.options.get('forceDropdownPosition')==='above') {
+    if (this.options.get('forceDropdownPosition') === 'below' || this.options.get('forceDropdownPosition') === 'above') {
       newDirection = this.options.get('forceDropdownPosition');
     }else {
       if (!isCurrentlyAbove && !isCurrentlyBelow) {

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -206,20 +206,19 @@ define([
 
     css.top -= parentOffset.top;
     css.left -= parentOffset.left;
+    
+    if(this.options.get('forceDropdownPosition')==='below' || this.options.get('forceDropdownPosition')==='above') {
+      newDirection = this.options.get('forceDropdownPosition');
+    }else {
+      if (!isCurrentlyAbove && !isCurrentlyBelow) {
+        newDirection = 'below';
+      }
 
-    if (!isCurrentlyAbove && !isCurrentlyBelow) {
-      newDirection = 'below';
-    }
-
-    if (!enoughRoomBelow && enoughRoomAbove && !isCurrentlyAbove) {
-      newDirection = 'above';
-    } else if (!enoughRoomAbove && enoughRoomBelow && isCurrentlyAbove) {
-      newDirection = 'below';
-    }
-
-    if(this.options.get('forcePosition') && 
-        (this.options.get('forcePosition')==='below' || this.options.get('forcePosition')==='above')) {
-        newDirection = this.options.get('forcePosition');
+      if (!enoughRoomBelow && enoughRoomAbove && !isCurrentlyAbove) {
+        newDirection = 'above';
+      } else if (!enoughRoomAbove && enoughRoomBelow && isCurrentlyAbove) {
+        newDirection = 'below';
+      }
     }
     
     if (newDirection == 'above' ||

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -209,7 +209,7 @@ define([
     
     if (this.options.get('forceDropdownPosition') === 'below' || this.options.get('forceDropdownPosition') === 'above') {
       newDirection = this.options.get('forceDropdownPosition');
-    }else {
+    } else {
       if (!isCurrentlyAbove && !isCurrentlyBelow) {
         newDirection = 'below';
       }

--- a/src/js/select2/dropdown/attachBody.js
+++ b/src/js/select2/dropdown/attachBody.js
@@ -217,6 +217,11 @@ define([
       newDirection = 'below';
     }
 
+    if(this.options.get('forcePosition') && 
+        (this.options.get('forcePosition')==='below' || this.options.get('forcePosition')==='above')) {
+        newDirection = this.options.get('forcePosition');
+    }
+    
     if (newDirection == 'above' ||
       (isCurrentlyAbove && newDirection !== 'below')) {
       css.top = container.top - parentOffset.top - dropdown.height;


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Added functionality to enable forcing dropdown position to either below or above \<select> element 
- Expanded the documentation (7. Dropdown) to include usage example of this new functionality

If this is related to an existing ticket, include a link to it as well.
This functionality was discussed in issue https://github.com/select2/select2/issues/3121
It was previously proposed in PR https://github.com/select2/select2/pull/4618

This PR improves upon the above linked PR https://github.com/select2/select2/pull/4618, so that it:
- provides documentation changes compatible with the new .md documentation
- provides (imo) a clearer configuration option name `forceDropdownPosition`, as it is more descriptive of what it does
- uses a more standard `auto` default value for the proposed configuration option

Feedback is welcome, as well as pointers if anything else needs to be done to make this change ready for merge to `master` branch.