### PR TITLE
Unselect events: cache lookup key fix

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -110,9 +110,7 @@ define([
     this.container = container;
 
     container.on('select', function (params) {
-      var option = container.$element.find('option')[0];
-      var data = Utils.GetData(option, 'data');
-      self.select(data);
+      self.select(params.data);
     });
 
     container.on('unselect', function (params) {

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -114,7 +114,8 @@ define([
     });
 
     container.on('unselect', function (params) {
-      container.$element.find('option[value=' + params.data.id + ']').each(function () {
+      var unselected = 'option[value=' + params.data.id + ']';
+      container.$element.find(unselected).each(function () {
         var data = Utils.GetData(this, 'data');
         self.unselect(data);
       });

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -110,11 +110,15 @@ define([
     this.container = container;
 
     container.on('select', function (params) {
-      self.select(params.data);
+      var option = container.$element.find('option')[0];
+      var data = Utils.GetData(option, 'data');
+      self.select(data);
     });
 
     container.on('unselect', function (params) {
-      self.unselect(params.data);
+      var option = container.$element.find('option')[0];
+      var data = Utils.GetData(option, 'data');
+      self.unselect(data);
     });
   };
 

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -114,7 +114,7 @@ define([
     });
 
     container.on('unselect', function (params) {
-      var option = container.$element.find('option')[0];
+      var option = container.$element.find('option[value=' + params.data.id + ']')[0];
       var data = Utils.GetData(option, 'data');
       self.unselect(data);
     });

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -114,10 +114,11 @@ define([
     });
 
     container.on('unselect', function (params) {
-      var unselected = 'option[value=' + params.data.id + ']';
-      container.$element.find(unselected).each(function () {
-        var data = Utils.GetData(this, 'data');
-        self.unselect(data);
+      container.$element.find('option').each(function () {
+        if ($(this).val() == params.data.id) {
+          var data = Utils.GetData(this, 'data');
+          self.unselect(data);
+        }
       });
     });
   };

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -114,9 +114,10 @@ define([
     });
 
     container.on('unselect', function (params) {
-      var option = container.$element.find('option[value=' + params.data.id + ']')[0];
-      var data = Utils.GetData(option, 'data');
-      self.unselect(data);
+      container.$element.find('option[value=' + params.data.id + ']').each(function () {
+        var data = Utils.GetData(this, 'data');
+        self.unselect(data);
+      });
     });
   };
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- During `unselect` events, retrieve the HTML `option` element related to the unselection and use that as a cache key to retrieve item data

If this is related to an existing ticket, include a link to it as well.

Resolves #6128.