### PR TITLE
Fix snippet for select2 ajax

### DIFF
--- a/docs/pages/06.data-sources/02.ajax/docs.md
+++ b/docs/pages/06.data-sources/02.ajax/docs.md
@@ -16,13 +16,13 @@ Select2 comes with AJAX support built in, using jQuery's AJAX methods. In this e
 **In your HTML:**
 
 ```
-<select class="js-data-example-ajax"></select>
+<select class="js-example-data-ajax"></select>
 ```
 
 **In your Javascript:**
 
 ```
-$('.js-data-example-ajax').select2({
+$('.js-example-data-ajax').select2({
   ajax: {
     url: 'https://api.github.com/search/repositories',
     dataType: 'json'


### PR DESCRIPTION
Modify snippet to have the same class as the one declared.

This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation
- [x] Doc fix

The following changes were made

- Modified the class in two first snippets

Why the changes were made

- If you use the first snippet to declare your select and use the last one which is the full working example, it will not work since the class aren't the same so I fixed the two first snippets to use the same class as the one declared.

I hope it's the right place to do my pull request (since it's the first one in this repo) because if I follow the CONTRIBUTING.md (https://github.com/select2/select2/blob/develop/.github/CONTRIBUTING.md) I should had contribute to select2/docs but when I go to this repo. seems to be archived with the note "DEPRECATED - Now located in docs directory of main repository".