### PR TITLE
Change results mouseup to click event to avoid accidental selection after clear

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -328,7 +328,7 @@ define([
         return;
       }
 
-      $highlighted.trigger('mouseup');
+      $highlighted.trigger('click');
     });
 
     container.on('results:select', function () {
@@ -448,7 +448,7 @@ define([
       });
     }
 
-    this.$results.on('mouseup', '.select2-results__option--selectable',
+    this.$results.on('click', '.select2-results__option--selectable',
       function (evt) {
       var $this = $(this);
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix / UX improvement
- [ ] New feature
- [ ] Translation

The following changes were made

The event for selecting results was changed from mouseup to click.  
This prevents the undesirable behavior that options can be clicked by accident after clearing the select.  
This is only relevant when clearing triggers a layout shift but I think since this is quite a commen use case this issue should be adressed somehow.

Resolves #6187