### PR TITLE
Fix Typo - word 'item' Brazilian Portuguese

### DIFF
--- a/src/js/select2/i18n/pt-BR.js
+++ b/src/js/select2/i18n/pt-BR.js
@@ -46,7 +46,7 @@ define(function () {
       return 'Remover todos os itens';
     },
     removeItem: function () {
-      return 'Remover iten';
+      return 'Remover item';
     },
     search: function() {
       return 'Buscar';


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [X ] Translation

The following changes were made

- Word "iten" changed to "item" in pt-BR.js file

