### PR TITLE
Revert "Unselect events: cache lookup key fix (#6179)"

### DIFF
--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -114,12 +114,7 @@ define([
     });
 
     container.on('unselect', function (params) {
-      container.$element.find('option').each(function () {
-        if ($(this).val() == params.data.id) {
-          var data = Utils.GetData(this, 'data');
-          self.unselect(data);
-        }
-      });
+      self.unselect(params.data);
     });
   };
 


### PR DESCRIPTION
This reverts commit d961613058cec3e7b1ee184643b483dc92170e54 (#6179).

Re-opens #6128.