### PR TITLE
Replace `removeAttr` with `removeAttribute`.

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -64,8 +64,8 @@ define([
 
     container.on('close', function () {
       self.$search.attr('tabindex', -1);
-      self.$search.removeAttr('aria-controls');
-      self.$search.removeAttr('aria-activedescendant');
+      self.$search[0].removeAttribute('aria-controls');
+      self.$search[0].removeAttribute('aria-activedescendant');
 
       self.$search.val('');
       self.$search.trigger('blur');
@@ -93,7 +93,7 @@ define([
       if (params.data._resultId) {
         self.$search.attr('aria-activedescendant', params.data._resultId);
       } else {
-        self.$search.removeAttr('aria-activedescendant');
+        self.$search[0].removeAttribute('aria-activedescendant');
       }
     });
   };

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -318,7 +318,7 @@ define([
       // When the dropdown is closed, aria-expended="false"
       self.$results.attr('aria-expanded', 'false');
       self.$results.attr('aria-hidden', 'true');
-      self.$results.removeAttr('aria-activedescendant');
+      self.$results[0].removeAttribute('aria-activedescendant');
     });
 
     container.on('results:toggle', function () {

--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -78,8 +78,8 @@ define([
     container.on('close', function () {
       // When the dropdown is closed, aria-expanded="false"
       self.$selection.attr('aria-expanded', 'false');
-      self.$selection.removeAttr('aria-activedescendant');
-      self.$selection.removeAttr('aria-owns');
+      self.$selection[0].removeAttribute('aria-activedescendant');
+      self.$selection[0].removeAttribute('aria-owns');
 
       self.$selection.trigger('focus');
 

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -51,8 +51,8 @@ define([
     container.on('close', function () {
       self.$search.val('');
       self.resizeSearch();
-      self.$search.removeAttr('aria-controls');
-      self.$search.removeAttr('aria-activedescendant');
+      self.$search[0].removeAttribute('aria-controls');
+      self.$search[0].removeAttribute('aria-activedescendant');
       self.$search.trigger('focus');
     });
 
@@ -74,7 +74,7 @@ define([
       if (params.data._resultId) {
         self.$search.attr('aria-activedescendant', params.data._resultId);
       } else {
-        self.$search.removeAttr('aria-activedescendant');
+        self.$search[0].removeAttribute('aria-activedescendant');
       }
     });
 

--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -68,7 +68,7 @@ define([
   SingleSelection.prototype.clear = function () {
     var $rendered = this.$selection.find('.select2-selection__rendered');
     $rendered.empty();
-    $rendered.removeAttr('title'); // clear tooltip on empty
+    $rendered[0].removeAttribute('title'); // clear tooltip on empty
   };
 
   SingleSelection.prototype.display = function (data, container) {
@@ -100,7 +100,7 @@ define([
     if (title) {
       $rendered.attr('title', title);
     } else {
-      $rendered.removeAttr('title');
+      $rendered[0].removeAttribute('title');
     }
   };
 


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- This replaces jQuery's `removeAttr` function with the vanilla JavaScript `removeAttribute`.

This is related to: https://github.com/select2/select2/issues/6196