### PR TITLE
Replace `addClass` with `classList.add`

### DIFF
--- a/src/js/select2/dropdown/dropdownCss.js
+++ b/src/js/select2/dropdown/dropdownCss.js
@@ -14,7 +14,11 @@ define([
       Utils.copyNonInternalCssClasses($dropdown[0], this.$element[0]);
     }
 
-    $dropdown.addClass(dropdownCssClass);
+    dropdownCssClass.trim().split(' ').forEach(function(cssClass) {
+      if(cssClass.length > 0) {
+        $dropdown[0].classList.add(cssClass);
+      }
+    });
 
     return $dropdown;
   };

--- a/src/js/select2/selection/selectionCss.js
+++ b/src/js/select2/selection/selectionCss.js
@@ -14,7 +14,11 @@ define([
       Utils.copyNonInternalCssClasses($selection[0], this.$element[0]);
     }
 
-    $selection.addClass(selectionCssClass);
+    selectionCssClass.trim().split(' ').forEach(function(cssClass) {
+      if(cssClass.length > 0) {
+        $selection[0].classList.add(cssClass);
+      }
+    });
 
     return $selection;
   };


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- This replaces jQuery's `addClass` function with the vanilla JavaScript `classList.add`.

This is related to: https://github.com/select2/select2/issues/6196
