### PR TITLE
Update testing dependencies to support Python3 as an interpreter for node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "grunt-contrib-requirejs": "^1.0.0",
     "grunt-contrib-uglify": "~4.0.1",
     "grunt-contrib-watch": "~1.1.0",
-    "grunt-sass": "^2.1.0",
+    "grunt-sass": "^3.1.0",
     "jquery-mousewheel": "~3.1.13",
-    "node-sass": "^4.12.0"
+    "node-sass": "^7.0.3"
   }
 }


### PR DESCRIPTION
This pull request includes a

- [x] Dependency update

The following changes were made

- Update `node-sass` to the maximum current version >= v5.x that supports NodeJS v12
- Update `grunt-sass` the maximum current version that depends on `node-sass` >= v5.x and supports NodeJS v12