### PR TITLE
Prevent returnning previous results when ajax is running #4854

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -161,7 +161,7 @@ define([
     var $loading = this.option(loading);
     $loading.className += ' loading-results';
 
-    this.$results.prepend($loading);
+    this.$results.html($loading);
   };
 
   Results.prototype.hideLoading = function () {


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

This patch was proposed by @atsawin in 2017 (see post [here](https://github.com/select2/select2/issues/4854#issuecomment-354089039)). The ticket is currently closed but the fix works and IMHO should be incorporated to the trunk.

If this is related to an existing ticket, include a link to it as well.

#4854 