### PR TITLE
Update django-select2 URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Support this project with your organization. Your logo will show up here with a 
 [django]: https://www.djangoproject.com/
 [django-autocomplete-light]: https://github.com/yourlabs/django-autocomplete-light
 [django-easy-select2]: https://github.com/asyncee/django-easy-select2
-[django-select2]: https://github.com/applegrew/django-select2
+[django-select2]: https://github.com/codingjoe/django-select2
 [drupal]: https://www.drupal.org/
 [drupal-select2]: https://www.drupal.org/project/select2
 [flat-ui]: http://designmodo.github.io/Flat-UI/


### PR DESCRIPTION
The repo has been moved to a new owner, as can be seen in the README in the old repo: https://github.com/applegrew/django-select2