### PR TITLE
Resolve bug with Korean input handling

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -48,8 +48,18 @@ define([
     });
 
     this.$search.on('keyup input', function (evt) {
-      self.handleSearch(evt);
-    });
+    // Set the current input value to an empty string if the previous value is undefined.
+    self.preTargetValue = self.preTargetValue === undefined ? "" : self.preTargetValue;
+
+    // In the case of Korean characters, the 'input' event can occur even when
+    // arrow keys or enter keys are pressed. Therefore, prevent additional actions
+    // and avoid duplicate searches if the value has not changed.
+    if (self.preTargetValue === evt.target.value) {
+        evt.preventDefault();
+    } else {
+        self.preTargetValue = evt.target.value;
+        self.handleSearch(evt);
+    }
 
     container.on('open', function () {
       self.$search.attr('tabindex', 0);

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -48,19 +48,20 @@ define([
     });
 
     this.$search.on('keyup input', function (evt) {
-    // Set the current input value to an empty string if the previous value is undefined.
-    self.preTargetValue = self.preTargetValue === undefined ? "" : self.preTargetValue;
+      // Set the current input value to an empty string if the previous value is undefined.
+      self.preTargetValue = self.preTargetValue === undefined ? "" : self.preTargetValue;
 
-    // In the case of Korean characters, the 'input' event can occur even when
-    // arrow keys or enter keys are pressed. Therefore, prevent additional actions
-    // and avoid duplicate searches if the value has not changed.
-    if (self.preTargetValue === evt.target.value) {
+      // In the case of Korean characters, the 'input' event can occur even when
+      // arrow keys or enter keys are pressed. Therefore, prevent additional actions
+      // and avoid duplicate searches if the value has not changed.
+      if (self.preTargetValue === evt.target.value) {
         evt.preventDefault();
-    } else {
+      } else {
         self.preTargetValue = evt.target.value;
         self.handleSearch(evt);
-    }
-
+      }
+    });
+    
     container.on('open', function () {
       self.$search.attr('tabindex', 0);
       self.$search.attr('aria-controls', resultsId);


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Fix a bug related to Korean input handling
- Improve the handling of Korean input events, addressing an issue where the same search query is duplicated when arrow keys or Enter key are pressed after entering Korean characters.
- Introduce an update to the preTargetValue variable for better handling.