### PR TITLE
Bugfix / Support data-placeholder values which consist solely of digits

### DIFF
--- a/src/js/select2/dropdown/hidePlaceholder.js
+++ b/src/js/select2/dropdown/hidePlaceholder.js
@@ -14,7 +14,7 @@ define([
   };
 
   HidePlaceholder.prototype.normalizePlaceholder = function (_, placeholder) {
-    if (typeof placeholder === 'string') {
+    if (typeof placeholder !== 'object') {
       placeholder = {
         id: '',
         text: placeholder

--- a/src/js/select2/selection/placeholder.js
+++ b/src/js/select2/selection/placeholder.js
@@ -8,7 +8,7 @@ define([
   }
 
   Placeholder.prototype.normalizePlaceholder = function (_, placeholder) {
-    if (typeof placeholder === 'string') {
+    if (typeof placeholder !== 'object') {
       placeholder = {
         id: '',
         text: placeholder


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix

The following changes were made

Validate placeholder type as an `object` instead of checking if it is a `string`. This fixes a bug where placeholder is defined as an inline attribute `data-placeholder` which consists solely of digits. In this case the value type becomes a `number` which breaks the test `typeof placeholder === 'string'` and causes the placeholder to get ignored.
