### PR TITLE
Fix bug which causes tags to not work if dataAdapter is set

### DIFF
--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -68,38 +68,38 @@ define([
       } else {
         options.dataAdapter = SelectData;
       }
+    }
 
-      if (options.minimumInputLength > 0) {
-        options.dataAdapter = Utils.Decorate(
-          options.dataAdapter,
-          MinimumInputLength
-        );
-      }
+    if (options.minimumInputLength > 0) {
+      options.dataAdapter = Utils.Decorate(
+        options.dataAdapter,
+        MinimumInputLength
+      );
+    }
 
-      if (options.maximumInputLength > 0) {
-        options.dataAdapter = Utils.Decorate(
-          options.dataAdapter,
-          MaximumInputLength
-        );
-      }
+    if (options.maximumInputLength > 0) {
+      options.dataAdapter = Utils.Decorate(
+        options.dataAdapter,
+        MaximumInputLength
+      );
+    }
 
-      if (options.maximumSelectionLength > 0) {
-        options.dataAdapter = Utils.Decorate(
-          options.dataAdapter,
-          MaximumSelectionLength
-        );
-      }
+    if (options.maximumSelectionLength > 0) {
+      options.dataAdapter = Utils.Decorate(
+        options.dataAdapter,
+        MaximumSelectionLength
+      );
+    }
 
-      if (options.tags) {
-        options.dataAdapter = Utils.Decorate(options.dataAdapter, Tags);
-      }
+    if (options.tags) {
+      options.dataAdapter = Utils.Decorate(options.dataAdapter, Tags);
+    }
 
-      if (options.tokenSeparators != null || options.tokenizer != null) {
-        options.dataAdapter = Utils.Decorate(
-          options.dataAdapter,
-          Tokenizer
-        );
-      }
+    if (options.tokenSeparators != null || options.tokenizer != null) {
+      options.dataAdapter = Utils.Decorate(
+        options.dataAdapter,
+        Tokenizer
+      );
     }
 
     if (options.resultsAdapter == null) {


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- I moved a closing bracket to the right place
- This makes it possible to set a dataAdapter while still being able to use `tags` and other options that were affected by this bug