### PR TITLE
Fixing ArrayAdapter optgroup children data binding

### DIFF
--- a/src/js/select2/data/array.js
+++ b/src/js/select2/data/array.js
@@ -18,14 +18,8 @@ define([
   };
 
   ArrayAdapter.prototype.select = function (data) {
-    var $option = this.$element.find('option').filter(function (i, elm) {
-      return elm.value == data.id.toString();
-    });
-
-    if ($option.length === 0) {
-      $option = this.option(data);
-
-      this.addOptions($option);
+    if (!data.element) {
+      this.addOptions(this.option(data));
     }
 
     ArrayAdapter.__super__.select.call(this, data);
@@ -68,9 +62,11 @@ define([
       var $option = this.option(item);
 
       if (item.children) {
-        var $children = this.convertToOptions(item.children);
-
-        $option.append($children);
+        item.children.forEach(function(child, index, children) {
+          var $child = self.convertToOptions([child]);
+          children[index] = self.item($child[0]);
+          $option.append($child);
+        })
       }
 
       $options.push($option);


### PR DESCRIPTION
ArrayAdapter.convertToOptions fails to create item data for optgroup children, not binding it to the select options.   
This results in a bug, where the passed data element to `select(data)` is not initialized and normalized, thus element is null and id is an integer. Therefore the select function can't find the corresponding &lt;option&gt; while comparing an integer id with string &lt;option&gt;[value] and creates duplicate options when selecting optgroup child options, which was meant for adding search tags:
```js
ArrayAdapter.prototype.select = function (data) {
  var $option = this.$element.find('option').filter(function (i, elm) {
    return elm.value == data.id.toString();
  });

  if ($option.length === 0) {
    $option = this.option(data);

    this.addOptions($option);
  }
```

### Here's a polyfill for the bugfix
```js
$.fn.select2.amd.require(['select2/data/array'],
  function (ArrayAdapter) {
    let __super__convertToOptions = ArrayAdapter.prototype.convertToOptions;
    ArrayAdapter.prototype.convertToOptions = function (data) {
      var self = this;

      const $options = __super__convertToOptions.call(this, data);
      for(const $option of $options) {
        (function applyChildData(option) {
          if (option.children) {
            option.children.forEach(function(child, index, children) {
              var $child = $($(option.element).children()[index]);
              children[index] = self.item($child);
              applyChildData(children[index]);
            });
          }
        })(self.item($option));
      }
      return $options;
    }

    ArrayAdapter.prototype.select = function (data) {
      if (!data.element) {
        this.addOptions(this.option(data));
      }
  
      ArrayAdapter.__super__.select.call(this, data);
    };
  }, null, true);
```

This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made
- Creating a data cache for each optgroup child (recursively for nested optgroups) and binding it correctly to its corresponding select option
- simplifying the search if there exists an option corresponding to the data passed to select, also making it available for optgroups and not only options.