### PR TITLE
Allow html content in selection template

### DIFF
--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -535,7 +535,7 @@ define([
 
     if (content == null) {
       container.style.display = 'none';
-    } else if (typeof content === 'string') {
+    } else if (typeof content === 'string' || content instanceof String) {
       container.innerHTML = escapeMarkup(content);
     } else {
       $(container).append(content);

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -80,7 +80,10 @@ define([
     var template = this.options.get('templateSelection');
     var escapeMarkup = this.options.get('escapeMarkup');
 
-    return escapeMarkup(template(data, container));
+    var content = template(data, container);
+    if (typeof content === 'string' || content instanceof String)
+      content = escapeMarkup(content);
+    return content;
   };
 
   MultipleSelection.prototype.selectionContainer = function () {

--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -75,7 +75,10 @@ define([
     var template = this.options.get('templateSelection');
     var escapeMarkup = this.options.get('escapeMarkup');
 
-    return escapeMarkup(template(data, container));
+    var content = template(data, container);
+    if (typeof content === 'string' || content instanceof String)
+      content = escapeMarkup(content);
+    return content;
   };
 
   SingleSelection.prototype.selectionContainer = function () {


### PR DESCRIPTION
Applying the same logic, which was already implemented for the result template, where only strings are HTML escaped. Now the user does not have to overwrite `escapeMarkup` when passing html content from templateSelection. Also fixed the typecheck of strings, because `typeof new String("")` is `'object'` and not `'string'`.

This pull request includes a

- [x] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made
- Fixing a bug, where String objects are not escaped because `typeof new String("")` is `'object'`, not `'string'`
- Only escape template strings for selection aswell