### PR TITLE
Fixups: post-merge updates related to PR #6241

### DIFF
--- a/dist/js/select2.full.js
+++ b/dist/js/select2.full.js
@@ -3744,9 +3744,13 @@ S2.define('select2/data/ajax',[
       var $request = options.transport(options, function (data) {
         var results = self.processResults(data, params);
 
-        if (self.options.get('debug') && window.console && console.error) {
-          // Check to make sure that the response included a `results` key.
-          if (!results || !results.results || !Array.isArray(results.results)) {
+        if (results && results.results && Array.isArray(results.results)) {
+          results.results = results.results.map(
+            AjaxAdapter.prototype._normalizeItem
+          );
+        } else {
+          if (self.options.get('debug') && window.console && console.error) {
+            // Check to make sure that the response included a `results` key.
             console.error(
               'Select2: The AJAX results did not return an array in the ' +
               '`results` key of the response.'

--- a/dist/js/select2.js
+++ b/dist/js/select2.js
@@ -3744,9 +3744,13 @@ S2.define('select2/data/ajax',[
       var $request = options.transport(options, function (data) {
         var results = self.processResults(data, params);
 
-        if (self.options.get('debug') && window.console && console.error) {
-          // Check to make sure that the response included a `results` key.
-          if (!results || !results.results || !Array.isArray(results.results)) {
+        if (results && results.results && Array.isArray(results.results)) {
+          results.results = results.results.map(
+            AjaxAdapter.prototype._normalizeItem
+          );
+        } else {
+          if (self.options.get('debug') && window.console && console.error) {
+            // Check to make sure that the response included a `results` key.
             console.error(
               'Select2: The AJAX results did not return an array in the ' +
               '`results` key of the response.'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "select2",
       "version": "4.1.0-rc.0",
       "license": "MIT",
-      "dependencies": {
-        "sass": "^1.77.8"
-      },
       "devDependencies": {
         "almond": "~0.3.1",
         "grunt": "^1.6.1",

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -279,9 +279,13 @@ QUnit.test('searching tags does not loose focus', function (assert) {
   var inputEl = select.selection.$search[0];
   inputEl.focus();
 
+  var done = false;
   select.on('selection:update', function() {
-    assert.equal(document.activeElement, inputEl);
-    asyncDone();
+    if (!done) {
+      assert.equal(document.activeElement, inputEl);
+      done = true;
+      asyncDone();
+    }
   });
 
   select.selection.trigger('query', {term: 'f'});

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -257,7 +257,6 @@ QUnit.test('removing a selected option changes the value', function (assert) {
   syncDone();
 });
 
-/*
 QUnit.test('searching tags does not loose focus', function (assert) {
   assert.expect(1);
 
@@ -288,7 +287,6 @@ QUnit.test('searching tags does not loose focus', function (assert) {
   select.selection.trigger('query', {term: 'f'});
   select.selection.trigger('query', {term: 'ff'});
 });
-*/
 
 
 QUnit.test('adding multiple options calls selection:update once', function (assert) {

--- a/tests/integration/dom-changes.js
+++ b/tests/integration/dom-changes.js
@@ -257,6 +257,7 @@ QUnit.test('removing a selected option changes the value', function (assert) {
   syncDone();
 });
 
+/*
 QUnit.test('searching tags does not loose focus', function (assert) {
   assert.expect(1);
 
@@ -287,6 +288,7 @@ QUnit.test('searching tags does not loose focus', function (assert) {
   select.selection.trigger('query', {term: 'f'});
   select.selection.trigger('query', {term: 'ff'});
 });
+*/
 
 
 QUnit.test('adding multiple options calls selection:update once', function (assert) {

--- a/tests/integration/select2-methods.js
+++ b/tests/integration/select2-methods.js
@@ -138,7 +138,7 @@ QUnit.test('multiple value matches the jquery value', function (assert) {
   );
 });
 
-test('selection and clearing of data from ajax source', function (assert) {
+QUnit.test('selection and clearing of data from ajax source', function (assert) {
   var asyncDone = assert.async();
 
   var dataURL = 'http://127.0.0.1/test';

--- a/tests/integration/select2-methods.js
+++ b/tests/integration/select2-methods.js
@@ -190,6 +190,7 @@ QUnit.test('selection and clearing of data from ajax source', function (assert) 
         'The previously-selected item should have been unselected'
       );
 
+      selectionStatus = false;
       asyncDone();
     }
   });


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Instead of referring to (QUnit) `test` in an integration test added by #6241, use the fully-qualified reference `QUnit.test` instead, as becomes standard after #6334.
- Add some guard conditions to `selection:update` event handlers in the integration tests, because these are not isolated from each other at test runtime, and otherwise may delay/timeout unrelated test cases.
- Regenerate distributable content.
- Regenerate NPM lockfile.

If this is related to an existing ticket, include a link to it as well.

Relates-to / merge-resolution-for #6241 and #6334.

Edit: add additional fixup descriptions.