### PR TITLE
Tests: add `defer` attribute to all `<script>` elements so that they load in page order

### DIFF
--- a/tests/integration-jq1.html
+++ b/tests/integration-jq1.html
@@ -8,15 +8,15 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
 
-    <script src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
-    <script src="vendor/jquery-1.12.4.js" type="text/javascript"></script>
-    <script src="vendor/jquery.mockjax-2.6.1.js" type="text/javascript"></script>
-    <script src="../dist/js/select2.full.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/jquery-1.12.4.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/jquery.mockjax-2.6.1.js" type="text/javascript"></script>
+    <script defer="defer" src="../dist/js/select2.full.js" type="text/javascript"></script>
 
-    <script src="helpers.js" type="text/javascript"></script>
+    <script defer="defer" src="helpers.js" type="text/javascript"></script>
 
-    <script src="integration/dom-changes.js" type="text/javascript"></script>
-    <script src="integration/jquery-calls.js" type="text/javascript"></script>
-    <script src="integration/select2-methods.js" type="text/javascript"></script>
+    <script defer="defer" src="integration/dom-changes.js" type="text/javascript"></script>
+    <script defer="defer" src="integration/jquery-calls.js" type="text/javascript"></script>
+    <script defer="defer" src="integration/select2-methods.js" type="text/javascript"></script>
   </body>
 </html>

--- a/tests/integration-jq2.html
+++ b/tests/integration-jq2.html
@@ -8,15 +8,15 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
 
-    <script src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
-    <script src="vendor/jquery-2.2.4.js" type="text/javascript"></script>
-    <script src="vendor/jquery.mockjax-2.6.1.js" type="text/javascript"></script>
-    <script src="../dist/js/select2.full.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/jquery-2.2.4.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/jquery.mockjax-2.6.1.js" type="text/javascript"></script>
+    <script defer="defer" src="../dist/js/select2.full.js" type="text/javascript"></script>
 
-    <script src="helpers.js" type="text/javascript"></script>
+    <script defer="defer" src="helpers.js" type="text/javascript"></script>
 
-    <script src="integration/dom-changes.js" type="text/javascript"></script>
-    <script src="integration/jquery-calls.js" type="text/javascript"></script>
-    <script src="integration/select2-methods.js" type="text/javascript"></script>
+    <script defer="defer" src="integration/dom-changes.js" type="text/javascript"></script>
+    <script defer="defer" src="integration/jquery-calls.js" type="text/javascript"></script>
+    <script defer="defer" src="integration/select2-methods.js" type="text/javascript"></script>
   </body>
 </html>

--- a/tests/integration-jq3.html
+++ b/tests/integration-jq3.html
@@ -8,15 +8,15 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
 
-    <script src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
-    <script src="vendor/jquery-3.4.1.js" type="text/javascript"></script>
-    <script src="vendor/jquery.mockjax-2.6.1.js" type="text/javascript"></script>
-    <script src="../dist/js/select2.full.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/jquery-3.4.1.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/jquery.mockjax-2.6.1.js" type="text/javascript"></script>
+    <script defer="defer" src="../dist/js/select2.full.js" type="text/javascript"></script>
 
-    <script src="helpers.js" type="text/javascript"></script>
+    <script defer="defer" src="helpers.js" type="text/javascript"></script>
 
-    <script src="integration/dom-changes.js" type="text/javascript"></script>
-    <script src="integration/jquery-calls.js" type="text/javascript"></script>
-    <script src="integration/select2-methods.js" type="text/javascript"></script>
+    <script defer="defer" src="integration/dom-changes.js" type="text/javascript"></script>
+    <script defer="defer" src="integration/jquery-calls.js" type="text/javascript"></script>
+    <script defer="defer" src="integration/select2-methods.js" type="text/javascript"></script>
   </body>
 </html>

--- a/tests/unit-jq1.html
+++ b/tests/unit-jq1.html
@@ -50,57 +50,57 @@
       <select class="user-defined"></select>
     </div>
 
-    <script src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
-    <script src="vendor/jquery-1.12.4.js" type="text/javascript"></script>
-    <script src="../dist/js/select2.full.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/jquery-1.12.4.js" type="text/javascript"></script>
+    <script defer="defer" src="../dist/js/select2.full.js" type="text/javascript"></script>
 
-    <script src="helpers.js" type="text/javascript"></script>
+    <script defer="defer" src="helpers.js" type="text/javascript"></script>
 
-    <script src="a11y/selection-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="a11y/selection-tests.js" type="text/javascript"></script>
 
-    <script src="data/array-tests.js" type="text/javascript"></script>
-    <script src="data/base-tests.js" type="text/javascript"></script>
-    <script src="data/select-tests.js" type="text/javascript"></script>
-    <script src="data/tags-tests.js" type="text/javascript"></script>
-    <script src="data/tokenizer-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/array-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/base-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/select-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/tags-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/tokenizer-tests.js" type="text/javascript"></script>
 
-    <script src="data/maximumInputLength-tests.js" type="text/javascript"></script>
-    <script src="data/maximumSelectionLength-tests.js" type="text/javascript"></script>
-    <script src="data/minimumInputLength-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/maximumInputLength-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/maximumSelectionLength-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/minimumInputLength-tests.js" type="text/javascript"></script>
 
-    <script src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
-    <script src="dropdown/dropdownParent-tests.js" type="text/javascript"></script>
-    <script src="dropdown/positioning-tests.js" type="text/javascript"></script>
-    <script src="dropdown/search-tests.js" type="text/javascript"></script>
-    <script src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
-    <script src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
-    <script src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/dropdownParent-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/positioning-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/search-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>
 
-    <script src="options/ajax-tests.js" type="text/javascript"></script>
-    <script src="options/data-tests.js" type="text/javascript"></script>
-    <script src="options/element-tests.js" type="text/javascript"></script>
-    <script src="options/translation-tests.js" type="text/javascript"></script>
-    <script src="options/width-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/ajax-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/data-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/element-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/translation-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/width-tests.js" type="text/javascript"></script>
 
-    <script src="results/a11y-tests.js" type="text/javascript"></script>
-    <script src="results/focusing-tests.js" type="text/javascript"></script>
-    <script src="results/infiniteScroll-tests.js" type="text/javascript"></script>
-    <script src="results/option-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/a11y-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/focusing-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/infiniteScroll-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/option-tests.js" type="text/javascript"></script>
 
-    <script src="selection/allowClear-tests.js" type="text/javascript"></script>
-    <script src="selection/focusing-tests.js" type="text/javascript"></script>
-    <script src="selection/multiple-tests.js" type="text/javascript"></script>
-    <script src="selection/placeholder-tests.js" type="text/javascript"></script>
-    <script src="selection/search-tests.js" type="text/javascript"></script>
-    <script src="selection/search-a11y-tests.js" type="text/javascript"></script>
-    <script src="selection/search-placeholder-tests.js" type="text/javascript"></script>
-    <script src="selection/selectionCss-tests.js" type="text/javascript"></script>
-    <script src="selection/single-tests.js" type="text/javascript"></script>
-    <script src="selection/stopPropagation-tests.js" type="text/javascript"></script>
-    <script src="selection/openOnKeyDown-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/allowClear-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/focusing-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/multiple-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/placeholder-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/search-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/search-a11y-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/search-placeholder-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/selectionCss-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/single-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/stopPropagation-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/openOnKeyDown-tests.js" type="text/javascript"></script>
 
-    <script src="utils/data-tests.js" type="text/javascript"></script>
-    <script src="utils/decorator-tests.js" type="text/javascript"></script>
-    <script src="utils/escapeMarkup-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="utils/data-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="utils/decorator-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="utils/escapeMarkup-tests.js" type="text/javascript"></script>
   </body>
 </html>

--- a/tests/unit-jq2.html
+++ b/tests/unit-jq2.html
@@ -50,57 +50,57 @@
       <select class="user-defined"></select>
     </div>
 
-    <script src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
-    <script src="vendor/jquery-2.2.4.js" type="text/javascript"></script>
-    <script src="../dist/js/select2.full.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/jquery-2.2.4.js" type="text/javascript"></script>
+    <script defer="defer" src="../dist/js/select2.full.js" type="text/javascript"></script>
 
-    <script src="helpers.js" type="text/javascript"></script>
+    <script defer="defer" src="helpers.js" type="text/javascript"></script>
 
-    <script src="a11y/selection-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="a11y/selection-tests.js" type="text/javascript"></script>
 
-    <script src="data/array-tests.js" type="text/javascript"></script>
-    <script src="data/base-tests.js" type="text/javascript"></script>
-    <script src="data/select-tests.js" type="text/javascript"></script>
-    <script src="data/tags-tests.js" type="text/javascript"></script>
-    <script src="data/tokenizer-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/array-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/base-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/select-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/tags-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/tokenizer-tests.js" type="text/javascript"></script>
 
-    <script src="data/maximumInputLength-tests.js" type="text/javascript"></script>
-    <script src="data/maximumSelectionLength-tests.js" type="text/javascript"></script>
-    <script src="data/minimumInputLength-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/maximumInputLength-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/maximumSelectionLength-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/minimumInputLength-tests.js" type="text/javascript"></script>
 
-    <script src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
-    <script src="dropdown/dropdownParent-tests.js" type="text/javascript"></script>
-    <script src="dropdown/positioning-tests.js" type="text/javascript"></script>
-    <script src="dropdown/search-tests.js" type="text/javascript"></script>
-    <script src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
-    <script src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
-    <script src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/dropdownParent-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/positioning-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/search-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>
 
-    <script src="options/ajax-tests.js" type="text/javascript"></script>
-    <script src="options/data-tests.js" type="text/javascript"></script>
-    <script src="options/element-tests.js" type="text/javascript"></script>
-    <script src="options/translation-tests.js" type="text/javascript"></script>
-    <script src="options/width-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/ajax-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/data-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/element-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/translation-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/width-tests.js" type="text/javascript"></script>
 
-    <script src="results/a11y-tests.js" type="text/javascript"></script>
-    <script src="results/focusing-tests.js" type="text/javascript"></script>
-    <script src="results/infiniteScroll-tests.js" type="text/javascript"></script>
-    <script src="results/option-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/a11y-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/focusing-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/infiniteScroll-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/option-tests.js" type="text/javascript"></script>
 
-    <script src="selection/allowClear-tests.js" type="text/javascript"></script>
-    <script src="selection/focusing-tests.js" type="text/javascript"></script>
-    <script src="selection/multiple-tests.js" type="text/javascript"></script>
-    <script src="selection/placeholder-tests.js" type="text/javascript"></script>
-    <script src="selection/search-tests.js" type="text/javascript"></script>
-    <script src="selection/search-a11y-tests.js" type="text/javascript"></script>
-    <script src="selection/search-placeholder-tests.js" type="text/javascript"></script>
-    <script src="selection/selectionCss-tests.js" type="text/javascript"></script>
-    <script src="selection/single-tests.js" type="text/javascript"></script>
-    <script src="selection/stopPropagation-tests.js" type="text/javascript"></script>
-    <script src="selection/openOnKeyDown-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/allowClear-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/focusing-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/multiple-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/placeholder-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/search-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/search-a11y-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/search-placeholder-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/selectionCss-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/single-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/stopPropagation-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/openOnKeyDown-tests.js" type="text/javascript"></script>
 
-    <script src="utils/data-tests.js" type="text/javascript"></script>
-    <script src="utils/decorator-tests.js" type="text/javascript"></script>
-    <script src="utils/escapeMarkup-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="utils/data-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="utils/decorator-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="utils/escapeMarkup-tests.js" type="text/javascript"></script>
   </body>
 </html>

--- a/tests/unit-jq3.html
+++ b/tests/unit-jq3.html
@@ -50,57 +50,57 @@
       <select class="user-defined"></select>
     </div>
 
-    <script src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
-    <script src="vendor/jquery-3.4.1.js" type="text/javascript"></script>
-    <script src="../dist/js/select2.full.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/qunit-2.22.0.js" type="text/javascript"></script>
+    <script defer="defer" src="vendor/jquery-3.4.1.js" type="text/javascript"></script>
+    <script defer="defer" src="../dist/js/select2.full.js" type="text/javascript"></script>
 
-    <script src="helpers.js" type="text/javascript"></script>
+    <script defer="defer" src="helpers.js" type="text/javascript"></script>
 
-    <script src="a11y/selection-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="a11y/selection-tests.js" type="text/javascript"></script>
 
-    <script src="data/array-tests.js" type="text/javascript"></script>
-    <script src="data/base-tests.js" type="text/javascript"></script>
-    <script src="data/select-tests.js" type="text/javascript"></script>
-    <script src="data/tags-tests.js" type="text/javascript"></script>
-    <script src="data/tokenizer-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/array-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/base-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/select-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/tags-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/tokenizer-tests.js" type="text/javascript"></script>
 
-    <script src="data/maximumInputLength-tests.js" type="text/javascript"></script>
-    <script src="data/maximumSelectionLength-tests.js" type="text/javascript"></script>
-    <script src="data/minimumInputLength-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/maximumInputLength-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/maximumSelectionLength-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="data/minimumInputLength-tests.js" type="text/javascript"></script>
 
-    <script src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
-    <script src="dropdown/dropdownParent-tests.js" type="text/javascript"></script>
-    <script src="dropdown/positioning-tests.js" type="text/javascript"></script>
-    <script src="dropdown/search-tests.js" type="text/javascript"></script>
-    <script src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
-    <script src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
-    <script src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/dropdownCss-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/dropdownParent-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/positioning-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/search-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/search-a11y-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/selectOnClose-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="dropdown/stopPropagation-tests.js" type="text/javascript"></script>
 
-    <script src="options/ajax-tests.js" type="text/javascript"></script>
-    <script src="options/data-tests.js" type="text/javascript"></script>
-    <script src="options/element-tests.js" type="text/javascript"></script>
-    <script src="options/translation-tests.js" type="text/javascript"></script>
-    <script src="options/width-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/ajax-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/data-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/element-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/translation-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="options/width-tests.js" type="text/javascript"></script>
 
-    <script src="results/a11y-tests.js" type="text/javascript"></script>
-    <script src="results/focusing-tests.js" type="text/javascript"></script>
-    <script src="results/infiniteScroll-tests.js" type="text/javascript"></script>
-    <script src="results/option-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/a11y-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/focusing-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/infiniteScroll-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="results/option-tests.js" type="text/javascript"></script>
 
-    <script src="selection/allowClear-tests.js" type="text/javascript"></script>
-    <script src="selection/focusing-tests.js" type="text/javascript"></script>
-    <script src="selection/multiple-tests.js" type="text/javascript"></script>
-    <script src="selection/placeholder-tests.js" type="text/javascript"></script>
-    <script src="selection/search-tests.js" type="text/javascript"></script>
-    <script src="selection/search-a11y-tests.js" type="text/javascript"></script>
-    <script src="selection/search-placeholder-tests.js" type="text/javascript"></script>
-    <script src="selection/selectionCss-tests.js" type="text/javascript"></script>
-    <script src="selection/single-tests.js" type="text/javascript"></script>
-    <script src="selection/stopPropagation-tests.js" type="text/javascript"></script>
-    <script src="selection/openOnKeyDown-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/allowClear-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/focusing-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/multiple-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/placeholder-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/search-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/search-a11y-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/search-placeholder-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/selectionCss-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/single-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/stopPropagation-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="selection/openOnKeyDown-tests.js" type="text/javascript"></script>
 
-    <script src="utils/data-tests.js" type="text/javascript"></script>
-    <script src="utils/decorator-tests.js" type="text/javascript"></script>
-    <script src="utils/escapeMarkup-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="utils/data-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="utils/decorator-tests.js" type="text/javascript"></script>
+    <script defer="defer" src="utils/escapeMarkup-tests.js" type="text/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Set the `defer="defer"` attribute on all `<script>` elements in the test HTML harnesses, so that scripts are loaded in the same order that they are written in the HTML.

If this is related to an existing ticket, include a link to it as well.

Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script

>  Scripts loaded with the `defer` attribute will load in the order they appear on the page. They won't run until the page content has all loaded, which is useful if your scripts depend on the DOM being in place (e.g. they modify one or more elements on the page).