### PR TITLE
feat: add selectedData support to AjaxAdapter

### DIFF
--- a/docs/pages/03.configuration/01.options-api/docs.md
+++ b/docs/pages/03.configuration/01.options-api/docs.md
@@ -43,3 +43,4 @@ This is a list of all the Select2 configuration options.
 | `tokenSeparators` | array | `null` | The list of characters that should be used as token separators. |
 | `width` | string | `resolve` | Supports [customization of the container width](/appearance#container-width). |
 | `scrollAfterSelect` | boolean | `false` | If `true`, resolves issue for multiselects using `closeOnSelect: false` that caused the list of results to scroll to the first selection after each select/unselect (see https://github.com/select2/select2/pull/5150). This behaviour was intentional to deal with infinite scroll UI issues (if you need this behavior, set `false`) but it created an issue with multiselect dropdown boxes of fixed length. |
+| `selectedData` | array of objects | `false` | Used to pre-select value when needed (works with ajax/remote). |

--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -6,14 +6,30 @@ define([
   function AjaxAdapter ($element, options) {
     this.ajaxOptions = this._applyDefaults(options.get('ajax'));
 
+    this.selectedData = options.get('selectedData') || []; // Store selected data
+
     if (this.ajaxOptions.processResults != null) {
       this.processResults = this.ajaxOptions.processResults;
     }
 
     AjaxAdapter.__super__.constructor.call(this, $element, options);
+
+    // Automatically select any data sent via selectedData
+    if (Array.isArray(this.selectedData) && this.selectedData.length > 0) {
+      this._selectInitialData($element, this.selectedData);
+    }
   }
 
   Utils.Extend(AjaxAdapter, ArrayAdapter);
+
+  // Helper function to programmatically select the data
+  AjaxAdapter.prototype._selectInitialData = function ($element, selectedData) {
+    for (var i = 0; i < selectedData.length; i++) {
+      var item = selectedData[i];
+      var newOption = new Option(item.text, item.id, true, true);
+      $element.append(newOption).trigger('change'); // Programmatically set the value
+    }
+  };
 
   AjaxAdapter.prototype._applyDefaults = function (options) {
     var defaults = {
@@ -87,7 +103,7 @@ define([
         // Attempt to detect if a request was aborted
         // Only works if the transport exposes a status property
         if ($request && 'status' in $request &&
-            ($request.status === 0 || $request.status === '0')) {
+          ($request.status === 0 || $request.status === '0')) {
           return;
         }
 

--- a/tests/options/ajax-tests.js
+++ b/tests/options/ajax-tests.js
@@ -48,3 +48,34 @@ QUnit.test('more than one default option can be changed via set()', function(ass
     'Both ajax.delay and ajax.dataType present in defaults');
   defaults.reset();
 });
+
+QUnit.test('selectedData option is merged and applied', function (assert) {
+  var defaults = require('select2/defaults');
+
+  var selectedData = [
+    { id: 1, text: 'Option 1' },
+    { id: 2, text: 'Option 2' }
+  ];
+
+  // Apply the selectedData to defaults
+  defaults.set('selectedData', selectedData);
+
+  var mergedOptions = defaults.apply({
+    selectedData: selectedData
+  });
+
+  assert.deepEqual(
+    mergedOptions.selectedData,
+    selectedData,
+    'selectedData is correctly set and applied in merged options'
+  );
+
+  // Ensure the selectedData is applied when passed as an option
+  assert.equal(
+    mergedOptions.selectedData.length,
+    2,
+    'The selectedData array contains two items'
+  );
+
+  defaults.reset();
+});


### PR DESCRIPTION


This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Introduced `selectedData` option in AjaxAdapter to allow pre-selected options to be programmatically appended and selected during initialization.
- Automatically selects and appends options from `selectedData` if provided.
- Maintains standard AJAX behavior for fetching options while ensuring that selectedData can be pre-loaded and displayed without additional input.
- Added safety checks to ensure selectedData is correctly processed even if not present or in an unexpected format.

### Example Use Case:
```javascript
$('#select').select2({
	ajax: {
		url: '/your-api-endpoint',
		dataType: 'json',
		processResults: function (data) {
			return { results: data.items };
		}
	},
	selectedData: [
		{ id: 1, text: 'val 1' }
	]
});
```

Multiple options can be selected:
```javascript
$('#select').select2({
	ajax: {
		url: '/your-api-endpoint',
		dataType: 'json',
		processResults: function (data) {
			return { results: data.items };
		}
	},
	multiple: true,
	selectedData: [
		{ id: 1, text: 'val 1' },
		{ id: 2, text: 'val 2' },
	]
});
```
