### PR TITLE
Add option to disable title rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Selected results in the dropdown should now be properly announced to screen readers (#5841)
 * Significant improvements were made to make the selection area accessible (#5824, #5842, #5916, #5942, #5973)
 * Allow pasting multiple lines into the search field for tokenization (#5806)
+* Added `renderTitle` option to control whether titles are rendered (#3158)
 
 ### Bug fixes
 

--- a/docs/pages/03.configuration/01.options-api/docs.md
+++ b/docs/pages/03.configuration/01.options-api/docs.md
@@ -30,6 +30,7 @@ This is a list of all the Select2 configuration options.
 | `minimumResultsForSearch` | integer | `0` | The minimum number of results required to [display the search box](/searching#limiting-display-of-the-search-box-to-large-result-sets). |
 | `multiple` | boolean | `false` | This option enables multi-select (pillbox) mode. Select2 will automatically map the value of the `multiple` HTML attribute to this option during initialization. |
 | `placeholder` | string or object | `null` | Specifies the [placeholder](/placeholders) for the control. |
+| `renderTitle` | boolean | `true` | Controls whether the HTML title attribute is rendered on the selected item. |
 | `resultsAdapter` | | `ResultsAdapter` | Used to override the built-in [ResultsAdapter](/advanced/default-adapters/results). |
 | `selectionAdapter` | | `SingleSelection` or `MultipleSelection`, depending on the value of `multiple`. | Used to override the built-in [SelectionAdapter](/advanced/default-adapters/selection). |
 | `selectionCssClass` | string | `''` | Adds additional CSS classes to the selection container. The helper `:all:` can be used to add all CSS classes present on the original `<select>` element. |

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -307,6 +307,7 @@ define([
       maximumInputLength: 0,
       maximumSelectionLength: 0,
       minimumResultsForSearch: 0,
+      renderTitle: true,
       selectOnClose: false,
       scrollAfterSelect: false,
       sorter: function (data) {

--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -97,7 +97,7 @@ define([
 
     var title = selection.title || selection.text;
 
-    if (title) {
+    if (title && this.options.get('renderTitle')) {
       $rendered.attr('title', title);
     } else {
       $rendered[0].removeAttribute('title');

--- a/tests/selection/single-tests.js
+++ b/tests/selection/single-tests.js
@@ -225,3 +225,35 @@ QUnit.test('escapeMarkup is being used', function (assert) {
     'The text should be escaped by default to prevent injection'
   );
 });
+
+QUnit.test('renderTitle renders title', function(assert) {
+  var selection = new SingleSelection(
+    $('#qunit-fixture .single'),
+    options
+  );
+
+  var $selection = selection.render();
+  var $rendered = $selection.find('.select2-selection__rendered');
+
+  selection.update([{
+    text: 'test'
+  }]);
+
+  assert.equal($rendered.attr('title'), 'test');
+});
+
+QUnit.test('no renderTitle does not render any title', function(assert) {
+  var selection = new SingleSelection(
+    $('#qunit-fixture .single'),
+    new Options({ renderTitle: false })
+  );
+
+  var $selection = selection.render();
+  var $rendered = $selection.find('.select2-selection__rendered');
+
+  selection.update([{
+    text: 'test'
+  }]);
+
+  assert.equal($rendered.attr('title'), undefined);
+});


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Added an option to disable title rendering in the selection element
- Added related documentation, changelog entry and tests

Related issue:
[#3158](https://github.com/select2/select2/issues/3158)
