### PR TITLE
Update docs with sorter callback

### DIFF
--- a/docs/pages/03.configuration/01.options-api/docs.md
+++ b/docs/pages/03.configuration/01.options-api/docs.md
@@ -34,7 +34,7 @@ This is a list of all the Select2 configuration options.
 | `selectionAdapter` | | `SingleSelection` or `MultipleSelection`, depending on the value of `multiple`. | Used to override the built-in [SelectionAdapter](/advanced/default-adapters/selection). |
 | `selectionCssClass` | string | `''` | Adds additional CSS classes to the selection container. The helper `:all:` can be used to add all CSS classes present on the original `<select>` element. |
 | `selectOnClose` | boolean | `false` | Implements [automatic selection](/dropdown#automatic-selection) when the dropdown is closed. |
-| `sorter` | callback | | |
+| `sorter` | callback | | Handles custom sorting of matched results. Accepts one argument: an array of data objects. If search parameters are set, the array will contain only matched objects. Must return an array of data objects in the desired order. |
 | `tags` | boolean / array of objects | `false` | Used to enable [free text responses](/tagging). |
 | `templateResult` | callback | | Customizes the way that [search results are rendered](/dropdown#templating). |
 | `templateSelection` | callback | | Customizes the way that [selections are rendered](/selections#templating). |


### PR DESCRIPTION
This pull request includes a

- [x] Document update

This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

Options API has no description for ```sorter``` callback option. Added description.

If this is related to an existing ticket, include a link to it as well.
