### PR TITLE
scrollTop is called on the scroll content and always returns 0, should be on its parent

### DIFF
--- a/src/js/select2/dropdown/infiniteScroll.js
+++ b/src/js/select2/dropdown/infiniteScroll.js
@@ -37,7 +37,7 @@ define([
       self.loading = true;
     });
 
-    this.$results.on('scroll', this.loadMoreIfNeeded.bind(this));
+    this.$results.parent().on('scroll', this.loadMoreIfNeeded.bind(this));
   };
 
   InfiniteScroll.prototype.loadMoreIfNeeded = function () {
@@ -50,7 +50,7 @@ define([
       return;
     }
 
-    var currentOffset = this.$results.offset().top +
+    var currentOffset = this.$results.parent().offset().top +
       this.$results.outerHeight(false);
     var loadingMoreOffset = this.$loadingMore.offset().top +
       this.$loadingMore.outerHeight(false);

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -375,7 +375,7 @@ define([
 
       var currentOffset = self.$results.offset().top;
       var nextTop = $next.offset().top;
-      var nextOffset = self.$results..parent().scrollTop() + (nextTop - currentOffset);
+      var nextOffset = self.$results.parent().scrollTop() + (nextTop - currentOffset);
 
       if (nextIndex === 0) {
         self.$results.scrollTop(0);

--- a/src/js/select2/results.js
+++ b/src/js/select2/results.js
@@ -375,7 +375,7 @@ define([
 
       var currentOffset = self.$results.offset().top;
       var nextTop = $next.offset().top;
-      var nextOffset = self.$results.scrollTop() + (nextTop - currentOffset);
+      var nextOffset = self.$results..parent().scrollTop() + (nextTop - currentOffset);
 
       if (nextIndex === 0) {
         self.$results.scrollTop(0);
@@ -425,7 +425,7 @@ define([
 
     if ($.fn.mousewheel) {
       this.$results.on('mousewheel', function (e) {
-        var top = self.$results.scrollTop();
+        var top = self.$results.parent().scrollTop();
 
         var bottom = self.$results.get(0).scrollHeight - top + e.deltaY;
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- installing the scroll event on the parent of the scroll content
- getting the offset from the scroll content parent
- calling the scrollTop from the scroll content parent

Issues at the moment:
- You sometimes cannot scroll up when you have scrolled down.
- When there are more then 50 results the load more message stays and no more results are appended.
- When you reach the end of the list you scroll the page instead of stopping the propagation.
