### PR TITLE
Update select2.full.js

### DIFF
--- a/dist/js/select2.full.js
+++ b/dist/js/select2.full.js
@@ -1574,7 +1574,7 @@ S2.define('select2/selection/base',[
   };
 
   BaseSelection.prototype.update = function (data) {
-    throw new Error('The `update` method must be defined in child classes.');
+    throw new Error('The "update" method must be defined in child classes.');
   };
 
   /**


### PR DESCRIPTION
fixed backtick instead of quotation mark inside a string. crapsh out on chrome, maybe other browsers too

This pull request includes a

- [this] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

-
-
-

If this is related to an existing ticket, include a link to it as well.

(i dont know what im doing)
