### PR TITLE
Optional trimTitle in options.

### DIFF
--- a/docs/pages/03.configuration/01.options-api/docs.md
+++ b/docs/pages/03.configuration/01.options-api/docs.md
@@ -41,5 +41,6 @@ This is a list of all the Select2 configuration options.
 | `theme` | string | `default` | Allows you to set the [theme](/appearance#themes). |
 | `tokenizer` | callback | | A callback that handles [automatic tokenization of free-text entry](/tagging#automatic-tokenization-into-tags). |
 | `tokenSeparators` | array | `null` | The list of characters that should be used as token separators. |
+| `trimTitle` | boolean | `false` | Trims whitespaces around text displayed as tooltip. |
 | `width` | string | `resolve` | Supports [customization of the container width](/appearance#container-width). |
 | `scrollAfterSelect` | boolean | `false` | If `true`, resolves issue for multiselects using `closeOnSelect: false` that caused the list of results to scroll to the first selection after each select/unselect (see https://github.com/select2/select2/pull/5150). This behaviour was intentional to deal with infinite scroll UI issues (if you need this behavior, set `false`) but it created an issue with multiselect dropdown boxes of fixed length. |

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -319,6 +319,7 @@ define([
         return selection.text;
       },
       theme: 'default',
+      trimTitle: false,
       width: 'resolve'
     };
   };

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -130,7 +130,7 @@ define([
       var title = selection.title || selection.text;
 
       if (title) {
-        $selection.attr('title', title);
+        $selection.attr('title', this.options.get('trimTitle') ? title.trim() : title);
       }
 
       var removeItem = this.options.get('translations').get('removeItem');

--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -98,7 +98,7 @@ define([
     var title = selection.title || selection.text;
 
     if (title) {
-      $rendered.attr('title', title);
+      $rendered.attr('title', this.options.get('trimTitle') ? title.trim() : title);
     } else {
       $rendered[0].removeAttribute('title');
     }


### PR DESCRIPTION
Introduce optional trimTitle in options in order to avoid leading and trailing whitespaces in tooltip.

This pull request includes a

- [X] New feature


The following changes were made

- Added trimTitle top options (defaults to false)
- Trims title on update() in order to compact tooltip when options set to true

Before:
```TWIG
    <select class="select2">
        {{ foreach option in options }}
        <option value="{{ option.value }}">
            {{ option.text }}
        </option>
        {{ endforeach }}
    </select>
```
![afbeelding](https://github.com/user-attachments/assets/c33552ba-6b49-4fbf-a002-9ad0c2320903)

After

```JavaScript
    $('.select2').select2({
        trimTitle: true
    });
```

<img width="223" alt="afbeelding" src="https://github.com/user-attachments/assets/29e71c2e-37ff-49ac-b62d-d16fe3d2685d" />



Aiming to fix / contribute to #6373 
