### PR TITLE
Fix: Trim input value in handleSearch to prevent duplicate tags with trailing spaces

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -100,7 +100,7 @@ define([
 
   Search.prototype.handleSearch = function (evt) {
     if (!this._keyUpPrevented) {
-      var input = this.$search.val();
+      var input = $.trim(this.$search.val());
 
       this.trigger('query', {
         term: input

--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -100,7 +100,7 @@ define([
 
   Search.prototype.handleSearch = function (evt) {
     if (!this._keyUpPrevented) {
-      var input = $.trim(this.$search.val());
+      var input = this.$search.val().trim();
 
       this.trigger('query', {
         term: input

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -205,7 +205,7 @@ define([
     this.resizeSearch();
 
     if (!this._keyUpPrevented) {
-      var input = this.$search.val();
+      var input = $.trim(this.$search.val());
 
       this.trigger('query', {
         term: input

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -205,7 +205,7 @@ define([
     this.resizeSearch();
 
     if (!this._keyUpPrevented) {
-      var input = $.trim(this.$search.val());
+      var input = this.$search.val().trim();
 
       this.trigger('query', {
         term: input


### PR DESCRIPTION
This pull request fixes an issue where duplicate tags are created due to leading or trailing spaces in the input.

- Trimmed input value in `handleSearch` method in both `dropdown/search.js` and `selection/search.js`
- Prevents duplicate tags caused by whitespace around user input
- Keeps consistent behavior across dropdown and selection components

This pull request includes a:

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made:

- Added `$.trim()` around the search input value in `handleSearch`
- Updated two files to keep behavior consistent (`dropdown/search.js`, `selection/search.js`)

If this is related to an existing ticket, include a link to it as well:

- No existing ticket, this is a small bugfix discovered during use
