### PR TITLE
Improving label announcement for screen readers.

### DIFF
--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -36,8 +36,15 @@ define([
       .attr('id', id)
       .attr('role', 'textbox')
       .attr('aria-readonly', 'true');
-    this.$selection.attr('aria-labelledby', id);
     this.$selection.attr('aria-controls', id);
+
+    // Set aria-label or aria-labelledby for accessibility.
+    const ariaLabel = this.$element.attr('aria-label') ? this.$element.attr('aria-label') : $('label[for="' + this.$element.attr('id') + '"]').text();
+    if (ariaLabel) {
+      this.$selection.attr('aria-label', ariaLabel)
+    } else {
+      this.$selection.attr('aria-labelledby', id);
+    }
 
     this.$selection.on('mousedown', function (evt) {
       // Only respond to left clicks


### PR DESCRIPTION
This pull request includes an accessibility improvement.

Labelling the field by its fist value causes confusion to screen readers about the combo box purpose.

The following changes were made:
- Use aria-label instead of aria-labelledby for single selection components.

Related to #3744 
