### PR TITLE
Document placeholders and clearable selection for Select2

### DIFF
--- a/docs/pages/04.appearance/docs.md
+++ b/docs/pages/04.appearance/docs.md
@@ -213,4 +213,32 @@ $(".js-example-theme-multiple").select2({
 
 </script>
 
+
+## Placeholders and Clearable Selection
+
+You can easily add a placeholder text to your Select2 control. By setting the `allowClear` option to `true`, you can also give users the ability to clear their selection. 
+
+> **Note:** For the `allowClear` option to work properly on a single select, you must include an empty `<option></option>` at the very top of your `<select>` element.
+
+<div class="s2-example">
+  <p>
+    <select class="js-example-placeholder-single js-states form-control">
+      <option></option> <!-- Empty option required for allowClear -->
+      <option value="AL">Alabama</option>
+      <option value="WY">Wyoming</option>
+      <option value="NY">New York</option>
+    </select>
+  </p>
+</div>
+
+<pre data-fill-from=".js-code-placeholder"></pre>
+
+<script type="text/javascript" class="js-code-placeholder">
+
+$(".js-example-placeholder-single").select2({
+  placeholder: "Select a state",
+  allowClear: true
+});
+
+</script>
 Various display options of the Select2 component can be changed.  You can access the `<option>` element (or `<optgroup>`) and any attributes on those elements using `.element`.


### PR DESCRIPTION
Added section on placeholders and clearable selection for Select2 control, including usage instructions and example code.

**This pull request includes a:**
- [ ] Bug fix
- [x] New feature (Documentation update)
- [ ] Translation

**The following changes were made:**
- Added a new section for "Placeholders and Clearable Selection" in the Appearance documentation.
- Included an `s2-example` demonstrating `placeholder` and `allowClear: true`.
- Added a note about the requirement of an empty `<option>` tag for single selects.

**If this is related to an existing ticket, include a link to it as well:**
N/A