### PR TITLE
Switch NPM publishing to trusted publishing with provenance

### DIFF
--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -40,6 +40,9 @@ jobs:
     name: NPM
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 24
@@ -52,6 +55,4 @@ jobs:
       - name: Run linting, tests, minify
         run: grunt
       - name: Deploy (release)
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation
- [x] Maintenance

The following changes were made

- Add id-token: write permission so the job can obtain an OIDC token from GitHub, which NPM uses to authenticate the publish request
- Add contents: read as explicit least-privilege for the checkout step
- Pass --provenance to npm publish to attach a signed provenance attestation linking the published package to this workflow run
- Pass --access public to ensure the package is published as public
