### PR TITLE
Fix disabled state for data optgroup children

### DIFF
--- a/src/js/select2/data/array.js
+++ b/src/js/select2/data/array.js
@@ -46,6 +46,10 @@ define(['./select', '../utils', 'jquery'], function (SelectAdapter, Utils, $) {
       };
     }
 
+    function itemFromOption($option) {
+      return self.item($option);
+    }
+
     for (var d = 0; d < data.length; d++) {
       var item = this._normalizeItem(data[d]);
 
@@ -69,6 +73,12 @@ define(['./select', '../utils', 'jquery'], function (SelectAdapter, Utils, $) {
         var $children = this.convertToOptions(item.children);
 
         $option.append($children);
+
+        var optionData = this.item($option);
+
+        optionData.children = $children.map(itemFromOption);
+
+        Utils.StoreData($option[0], 'data', optionData);
       }
 
       $options.push($option);

--- a/tests/data/array-tests.js
+++ b/tests/data/array-tests.js
@@ -338,48 +338,51 @@ QUnit.test('optgroup tags have the right properties', function (assert) {
   );
 });
 
-QUnit.test('optgroup child data uses generated option state', function (assert) {
-  var $select = $('#qunit-fixture .single-empty');
-  var options = new Options({
-    data: [
-      {
-        text: 'Group',
-        children: [
-          {
-            id: 'child',
-            text: 'Child'
-          }
-        ]
-      }
-    ]
-  });
+QUnit.test(
+  'optgroup child data uses generated option state',
+  function (assert) {
+    var $select = $('#qunit-fixture .single-empty');
+    var options = new Options({
+      data: [
+        {
+          text: 'Group',
+          children: [
+            {
+              id: 'child',
+              text: 'Child'
+            }
+          ]
+        }
+      ]
+    });
 
-  var data = new ArrayData($select, options);
+    var data = new ArrayData($select, options);
 
-  var container = new MockContainer();
-  data.bind(container, $('<div></div>'));
+    var container = new MockContainer();
+    data.bind(container, $('<div></div>'));
 
-  var child = $select.find('optgroup option')[0];
-  child.disabled = true;
+    var child = $select.find('optgroup option')[0];
+    child.disabled = true;
 
-  data.query({}, function (data) {
-    var childData = data.results[0].children[0];
-    var results = new Results($select, new Options({}));
-    var resultOption = results.option(childData);
+    data.query({}, function (data) {
+      var childData = data.results[0].children[0];
+      var results = new Results($select, new Options({}));
+      var resultOption = results.option(childData);
 
-    assert.equal(
-      childData.element,
-      child,
-      'The child data should reference the generated <option>'
-    );
+      assert.equal(
+        childData.element,
+        child,
+        'The child data should reference the generated <option>'
+      );
 
-    assert.equal(
-      resultOption.getAttribute('aria-disabled'),
-      'true',
-      'The child result should reflect the generated <option> disabled state'
-    );
-  });
-});
+      assert.equal(
+        resultOption.getAttribute('aria-disabled'),
+        'true',
+        'The child result should reflect the generated <option> disabled state'
+      );
+    });
+  }
+);
 
 QUnit.test(
   'existing selections are respected on initialization',

--- a/tests/data/array-tests.js
+++ b/tests/data/array-tests.js
@@ -3,6 +3,7 @@ QUnit.module('Data adapters - Array');
 var ArrayData = require('select2/data/array');
 var $ = require('jquery');
 var Options = require('select2/options');
+var Results = require('select2/results');
 var Utils = require('select2/utils');
 
 var UserDefinedType = function (id, text) {
@@ -335,6 +336,49 @@ QUnit.test('optgroup tags have the right properties', function (assert) {
     1,
     'The <optgroup> should have one child under it'
   );
+});
+
+QUnit.test('optgroup child data uses generated option state', function (assert) {
+  var $select = $('#qunit-fixture .single-empty');
+  var options = new Options({
+    data: [
+      {
+        text: 'Group',
+        children: [
+          {
+            id: 'child',
+            text: 'Child'
+          }
+        ]
+      }
+    ]
+  });
+
+  var data = new ArrayData($select, options);
+
+  var container = new MockContainer();
+  data.bind(container, $('<div></div>'));
+
+  var child = $select.find('optgroup option')[0];
+  child.disabled = true;
+
+  data.query({}, function (data) {
+    var childData = data.results[0].children[0];
+    var results = new Results($select, new Options({}));
+    var resultOption = results.option(childData);
+
+    assert.equal(
+      childData.element,
+      child,
+      'The child data should reference the generated <option>'
+    );
+
+    assert.equal(
+      resultOption.getAttribute('aria-disabled'),
+      'true',
+      'The child result should reflect the generated <option> disabled state'
+    );
+  });
 });
 
 QUnit.test(


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Keep generated optgroup data synchronized with the generated child `<option>` data when Select2 is initialized from a data array.
- Add QUnit coverage for disabling a generated optgroup child option after initialization and rendering it as disabled in results.

Fixes #6392.

Verified with:

- Red before fix: `npx grunt connect:tests qunit:all`
- `npx grunt compile`
- `npx grunt connect:tests qunit:all`
- `npx grunt lint`
- `git diff --check`
