### PR TITLE
Add Norwegian Nynorsk (nn) translation

### DIFF
--- a/src/js/select2/i18n/nn.js
+++ b/src/js/select2/i18n/nn.js
@@ -1,0 +1,33 @@
+define(function () {
+  // Norwegian (Nynorsk)
+  return {
+    errorLoading: function () {
+      return 'Kunne ikkje hente resultat.';
+    },
+    inputTooLong: function (args) {
+      var overChars = args.input.length - args.maximum;
+
+      return 'Fjern ' + overChars + ' teikn';
+    },
+    inputTooShort: function (args) {
+      var remainingChars = args.minimum - args.input.length;
+
+      return 'Skriv inn ' + remainingChars + ' teikn til';
+    },
+    loadingMore: function () {
+      return 'Lastar fleire resultat …';
+    },
+    maximumSelected: function (args) {
+      return 'Du kan velje maks ' + args.maximum + ' element';
+    },
+    noResults: function () {
+      return 'Ingen treff';
+    },
+    searching: function () {
+      return 'Søkjer …';
+    },
+    removeAllItems: function () {
+      return 'Fjern alle element';
+    }
+  };
+});


### PR DESCRIPTION
Adds a Norwegian **Nynorsk** (`nn`) translation. Select2 already ships Bokmål (`nb`); this adds Norway's other official written standard, same message set.

Disclosure: prepared with AI assistance and reviewed by me as a native Norwegian speaker.