### PR TITLE
Add missing ja (Japanese) translations for removeItem and search

### DIFF
--- a/src/js/select2/i18n/ja.js
+++ b/src/js/select2/i18n/ja.js
@@ -34,6 +34,12 @@ define(function () {
     },
     removeAllItems: function () {
       return 'すべてのアイテムを削除';
+    },
+    removeItem: function () {
+      return 'アイテムを削除';
+    },
+    search: function () {
+      return '検索';
     }
   };
 });


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [x] Translation

The following changes were made

- Added the `removeItem` key to the Japanese (`ja`) locale: アイテムを削除
- Added the `search` key to the Japanese (`ja`) locale: 検索

`ja.js` was missing these two keys, so Japanese users got the English fallback for two ARIA labels: the per-item remove button (`removeItem`, used in `selection/multiple.js`) and the search field (`search`, used in `selection/search.js` and `dropdown/search.js`). Both are part of the canonical set in `en.js` and are asserted by the translations test. They were recently added to other locales, for example Estonian in #6305, so this brings `ja` in line. The wording follows the existing `removeAllItems` (すべてのアイテムを削除); I am a native Japanese speaker.
