### PR TITLE
Fix unbound _normalizeItem crash for AJAX data in strict-mode builds

### DIFF
--- a/src/js/select2/data/ajax.js
+++ b/src/js/select2/data/ajax.js
@@ -71,7 +71,7 @@ define(['./array', '../utils', 'jquery'], function (ArrayAdapter, Utils, $) {
 
           if (results && results.results && Array.isArray(results.results)) {
             results.results = results.results.map(
-              AjaxAdapter.prototype._normalizeItem
+              AjaxAdapter.prototype._normalizeItem.bind(self)
             );
           } else {
             if (self.options.get('debug') && window.console && console.error) {

--- a/src/js/select2/data/select.js
+++ b/src/js/select2/data/select.js
@@ -280,7 +280,9 @@ define(['./base', '../utils', 'jquery'], function (BaseAdapter, Utils, $) {
     }
 
     if (item.children) {
-      item.children = item.children.map(SelectAdapter.prototype._normalizeItem);
+      item.children = item.children.map(
+        SelectAdapter.prototype._normalizeItem.bind(this)
+      );
     }
 
     return $.extend({}, defaults, item);

--- a/tests/options/ajax-tests.js
+++ b/tests/options/ajax-tests.js
@@ -56,3 +56,49 @@ QUnit.test(
     defaults.reset();
   }
 );
+
+QUnit.module('Data adapter - Ajax');
+
+QUnit.test(
+  'query normalizes results with the adapter bound as `this`',
+  function (assert) {
+    var AjaxData = require('select2/data/ajax');
+    var Options = require('select2/options');
+    var $ = require('jquery');
+
+    var $select = $('#qunit-fixture .single-empty');
+
+    var options = new Options({
+      ajax: {
+        transport: function (params, success) {
+          success({
+            results: [
+              { id: 'a', text: 'First' },
+              {
+                text: 'Group',
+                children: [{ id: 'b', text: 'Child' }]
+              }
+            ]
+          });
+        }
+      }
+    });
+
+    var data = new AjaxData($select, options);
+
+    var container = new MockContainer();
+    data.bind(container, $('<div></div>'));
+
+    data.query({}, function (results) {
+      assert.ok(
+        results.results[0]._resultId,
+        'A top-level AJAX result should receive a generated result ID'
+      );
+
+      assert.ok(
+        results.results[1].children[0]._resultId,
+        'A nested optgroup child should receive a generated result ID'
+      );
+    });
+  }
+);


### PR DESCRIPTION
Fixes #6423

## Problem

Every AJAX-backed Select2 dropdown throws when the library is consumed as an
ESM / npm import bundled with Vite, Webpack or Rollup (as opposed to a classic
`<script>` tag). The dropdown stays stuck on "Searching..." and the console
shows:

```
TypeError: Cannot read properties of undefined (reading 'container')
```

## Root cause

`_normalizeItem` (defined at `src/js/select2/data/select.js:249`) reads
`this.container` and `this.generateResultId` (lines 278-279). It was being
passed **unbound** as the callback to `Array#map` in two places:

- `src/js/select2/data/ajax.js:74` — `results.results.map(AjaxAdapter.prototype._normalizeItem)`
  (introduced by #6241, which resolved #6128)
- `src/js/select2/data/select.js:283` — `item.children.map(SelectAdapter.prototype._normalizeItem)`
  for optgroup children (introduced by #6239)

`Array#map` invokes the callback with no `this`. In a bundled ESM build the
module body runs in strict mode, so `this` is `undefined` inside the callback
and `this.container` throws immediately — breaking the whole query. In the
classic non-strict `<script>` build the same code silently falls back to the
global object, so `this.container` is `undefined`, the `_resultId` branch is
skipped, and items never receive a `_resultId` (the value `#6241` relies on for
unselecting non-string identifiers). Same bug, two symptoms.

## Fix

Bind `_normalizeItem` to the adapter instance before handing it to `map`,
matching the existing `.bind(this)` style already used in the codebase
(e.g. `src/js/select2/dropdown/infiniteScroll.js:38`):

- `ajax.js` — `AjaxAdapter.prototype._normalizeItem.bind(self)`
- `select.js` — `SelectAdapter.prototype._normalizeItem.bind(this)`

Every other caller already invokes `_normalizeItem` as a bound method, so the
recursive optgroup-children call now propagates the adapter as `this` correctly
in all paths.

## Tests

Added a regression test in `tests/options/ajax-tests.js` that drives
`AjaxAdapter.query()` through a synchronous transport whose response contains a
top-level item with an `id` and an optgroup with a child that has an `id`, then
asserts both the top-level result and the nested child receive a `_resultId`.
The single test covers both fixed call sites (the AJAX map and the recursive
optgroup-children map).

## Verification (exact)

Toolchain: `npm ci`; tests run with `grunt compile test` (CI parity —
`.github/workflows/main.yml`).

Before the fix (buggy `develop`), the new test fails on all four jQuery
matrices:

```
>> Data adapter - Ajax > query normalizes results with the adapter bound as `this`
>> Message: A top-level AJAX result should receive a generated result ID
>> Message: A nested optgroup child should receive a generated result ID
Warning: 1088 tests completed in 4872ms, with 4 failed, 8 skipped, and 0 todo.
```

After the fix:

```
>> 1088 tests completed in 4906ms, with 0 failed, 8 skipped, and 0 todo.
```

Lint is clean: `grunt lint` → `107 files lint free` (src) and `42 files lint
free` (tests).

## Compatibility

No API or behaviour change for the working (non-strict) case beyond restoring
the intended `_resultId` assignment. Purely fixes the strict-mode/ESM crash and
the silently-missing `_resultId`. Per `CONTRIBUTING.md`, only `src/` and test
files are changed; `dist/` is regenerated by the maintainers' build.
