### PR TITLE
Fix #6428 -- Remove the Node engines constraint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,6 @@
         "grunt-sass": "^4.1.0",
         "jquery-mousewheel": "~3.2.2",
         "sass": "^1.100.0"
-      },
-      "engines": {
-        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
       "lib": "dist"
     }
   },
-  "engines": {
-    "node": ">=24"
-  },
   "scripts": {
     "docs:serve": "uv run mkdocs serve",
     "docs:build": "uv run mkdocs build --strict"


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation
- [x] Package maintenance

The following changes were made

- Remove the `engines` field from `package.json`
- Remove the matching root entry from `package-lock.json`

Related to #6428, per your note there:

> Feel free to submit a PR removing or lowering it. You're correct that it's a dev requirement only.

## Why this PR

We use select2 in an internal project and bumping from 4.1.0-rc.0 to 4.1.0 broke our build. I prefer to not be stuck on RC-versions, because of what is essentially a development requirement.

## Why remove rather than lower

`engines` is a constraint on everyone *installing* the package, but the Node 24 requirement applies only to this repository's own build tooling. Nothing in the published artifact is executed by Node:

- `files` is `["src", "dist"]` — browser JS, CSS and Sass
- there is no `bin`
- there are no `install`/`postinstall` lifecycle scripts, and the two `scripts` entries shell out to `uv`/mkdocs

So no value of `engines` is meaningful to consumers, and lowering it would just move the arbitrary cutoff rather than remove it.

The field arrived in #6404, described as "Upgrade internal build tooling to Node 24", alongside `.nvmrc` and the CI workflow changes — it looks like it followed along with that tooling bump rather than being an intentional consumer requirement.

The development requirement is unaffected by this change. It stays enforced where it already is, and more reliably: `.nvmrc` pins `24`, and every job in `main.yml` and `package-deploy.yml` pins `node-version: 24` via `setup-node`.

## Verification

Packed this branch with `npm pack` and installed the tarball with Yarn on Node 20.12.1, alongside a control installing the published `select2@4.1.0` on the same Node version:

```
--- this branch ---
success Saved 1 new dependency.
Done in 0.23s.

--- control: published select2@4.1.0 ---
error select2@4.1.0: The engine "node" is incompatible with this module. Expected version ">=24". Got "20.12.1"
error Found incompatible module.
```

The installed package is intact — `dist/js/select2.full.js` and `dist/css/select2.css` both present, `main` unchanged.

`npm install --package-lock-only` reproduces the `package-lock.json` edit exactly, so the lockfile will not come back dirty in CI.

No `dist` rebuild is included, since this only touches package metadata.

If you would prefer to keep the requirement expressed in `package.json`, `devEngines` is the non-consumer-facing equivalent and I am happy to switch to that instead.

🤖 (mostly/partially) Generated by robots