### PR TITLE
Don't toggle the dropdown when clearing or unselecting

### DIFF
--- a/src/js/select2/selection/allowClear.js
+++ b/src/js/select2/selection/allowClear.js
@@ -74,8 +74,6 @@ define(['jquery', '../keys', '../utils'], function ($, KEYS, Utils) {
     }
 
     this.$element.trigger('input').trigger('change');
-
-    this.trigger('toggle', {});
   };
 
   AllowClear.prototype._handleKeyboardClear = function (_, evt, container) {

--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -51,6 +51,8 @@ define(['jquery', './base', '../utils'], function ($, BaseSelection, Utils) {
           originalEvent: evt,
           data: data
         });
+
+        evt.stopPropagation();
       }
     );
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- `MultipleSelection`: the delegated click handler for `.select2-selection__choice__remove` now calls `evt.stopPropagation()`, so removing a choice doesn't bubble up to the selection's toggle handler and open the dropdown. The `keydown` handler for the same selector already does this.
- `AllowClear._handleClear`: removed the trailing `this.trigger('toggle', {})`, so clearing a selection no longer opens the dropdown (and no longer triggers an unwanted ajax query via `open()`, see #6116).

In both cases the user is just removing a selection, but the dropdown opens as a side effect. This has been reported a few times over the years (#3632, #4281, #3320) and is usually worked around with the `select2:unselecting` + `select2:opening` preventDefault trick.

No new options or API changes. Test suite passes (1088 tests, 0 failed, all four jQuery matrices). Note this does change behavior for anyone relying on the clear button also opening the dropdown.

Fixes #6389, fixes #6116