### PR TITLE
Fix #5995 -- language option now takes precedence over the element lang attr

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -32,10 +32,10 @@ The language does not have to be defined when Select2 is being initialized, but 
 Select2 builds a fallback chain from every language source it can find and uses the first one that provides each message. The order, from highest priority to lowest, is:
 
 1. the `language` option passed to `select2()` (a string, an object, or an array of either)
-2. the `[lang]` attribute on the `<select>` element itself
-3. the default set via `$.fn.select2.defaults.set('language', ...)`
-4. the `[lang]` attribute inherited from the closest ancestor element
-5. `en`, which is always appended so every message has a value
+1. the `[lang]` attribute on the `<select>` element itself
+1. the default set via `$.fn.select2.defaults.set('language', ...)`
+1. the `[lang]` attribute inherited from the closest ancestor element
+1. `en`, which is always appended so every message has a value
 
 ### Translation objects
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -27,6 +27,16 @@ $(".js-example-language").select2({
 
 The language does not have to be defined when Select2 is being initialized, but instead can be defined in the `[lang]` attribute of any parent elements as `[lang="es"]`.
 
+### Precedence
+
+Select2 builds a fallback chain from every language source it can find and uses the first one that provides each message. The order, from highest priority to lowest, is:
+
+1. the `language` option passed to `select2()` (a string, an object, or an array of either)
+2. the `[lang]` attribute on the `<select>` element itself
+3. the default set via `$.fn.select2.defaults.set('language', ...)`
+4. the `[lang]` attribute inherited from the closest ancestor element
+5. `en`, which is always appended so every message has a value
+
 ### Translation objects
 
 You may alternatively provide your own custom messages to be displayed by providing an object similar to the one below:

--- a/src/js/select2/defaults.js
+++ b/src/js/select2/defaults.js
@@ -349,9 +349,11 @@ define([
     var elementClosest = $element.closest('[lang]');
     var parentLanguage = elementClosest[0] ? elementClosest[0].lang : null;
 
+    // An explicit `language` option is the most intentional signal, so it
+    // takes precedence over the element's own `lang` attribute. See #5995.
     var languages = Array.prototype.concat.call(
-      this._resolveLanguage(elementLanguage),
       this._resolveLanguage(optionLanguage),
+      this._resolveLanguage(elementLanguage),
       this._resolveLanguage(defaultLanguage),
       this._resolveLanguage(parentLanguage)
     );

--- a/tests/options/translation-tests.js
+++ b/tests/options/translation-tests.js
@@ -284,3 +284,27 @@ QUnit.test('default language overrides inherited lang attr', function (assert) {
 
   assert.deepEqual(options.get('language'), ['es', 'it', 'en']);
 });
+
+QUnit.test(
+  'partial dictionary overrides element lang attr (#5995)',
+  function (assert) {
+    var $element = $('<select lang="en"></select>');
+
+    var options = new Options(
+      {
+        language: {
+          noResults: function () {
+            return 'override works';
+          }
+        }
+      },
+      $element
+    );
+
+    assert.equal(
+      options.get('translations').get('noResults')(),
+      'override works',
+      'The explicit partial override wins over the element lang="en" file'
+    );
+  }
+);


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- `src/js/select2/defaults.js`: in `applyFromElement`, the language fallback chain now puts the explicit `language` option **before** the element's `lang` attribute. Previously the element's own `lang` file was resolved first, and because `Translation.extend` keeps the first value seen, it shadowed any message provided through the `language` option.
- `tests/options/translation-tests.js`: added a regression test asserting that a partial dictionary override (`language: { noResults: ... }`) wins over `lang="en"` on the element.
- `docs/i18n.md`: added a "Precedence" section listing the five levels of the fallback chain (option, element `lang`, `defaults.set`, inherited `lang`, `en`).

Fixes #5995.

### What happened

A message override such as

```js
$('.x').select2({ language: { noResults: () => 'no matches' } });
```

was silently ignored when the `<select>` carried `lang="en"`. The element's `lang` file was given higher priority than the explicit option, so for any key that file defines (`en` defines all of them) the override never applied. It appeared to work with other `lang` values only because those language files are not in the default build and fail to load silently, leaving the override as the highest-priority source by default.

An explicit `language` option is the most intentional signal a developer can give, so it should outrank a markup `lang` hint. The rest of the chain is unchanged: the element `lang` still beats `$.fn.select2.defaults.set('language', ...)`, an inherited/parent `lang` stays lowest, and `en` is still appended as the final fallback.

### Potential backward compatibility issue

`select2({ language: 'de' })` on an element with `lang="fr"` now resolves to `de` first instead of `fr`. This is the intended effect of the fix (explicit config over markup hint), but it is a change for anyone who currently relies on the element `lang` winning over a `language` string option.

### Testing

`grunt test` passes (`1092 tests, 0 failed`).  
The new test fails against `develop` and passes with this change. 
`grunt lint` is clean. 
No `dist/` files were modified.