### PR TITLE
docs: clarify closeOnSelect applies to single selects

### DIFF
--- a/docs/dropdown.md
+++ b/docs/dropdown.md
@@ -72,7 +72,7 @@ $('#mySelect2').select2({
 });
 ```
 
-Note that this option is only applicable to multi-select controls.
+This option applies to both single-select and multi-select controls.
 
 > [!NOTE]
 > If the [`CloseOnSelect` decorator](advanced/default-adapters/dropdown.md#closeonselect) is not used (or `closeOnSelect` is set to <code>false</code>), the dropdown will not automatically close when a result is selected. The dropdown will also never close if the <kbd>ctrl</kbd> key is held down when the result is selected.


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix (documentation)
- [ ] New feature
- [ ] Translation

The documentation currently says `closeOnSelect` only applies to multi-select controls. Setting it to `false` also keeps a single-select dropdown open after selecting a result. Clarify that the option applies to both types.

Fixes #6455.

Validation:
- `python -m mkdocs build --strict` passed using the documentation dependencies from `pyproject.toml` in an isolated Python 3.14 environment. The generated dropdown page contains the corrected sentence. CI-only Git metadata plugins were disabled by the repository's default configuration.
- Checked `defaults.js`: the CloseOnSelect decorator is applied outside the single/multiple branch.
- Exercised the checked-in Select2 4.1.0 bundle with jQuery 3.5.1 in jsdom: selecting Beta in single and multiple controls leaves the dropdown open with `closeOnSelect: false` and closes it with `true` (four passing cases). This was a local behavior check, not a real-browser or full QUnit run.
- `git diff --check` passed. Only documentation changed.

AI assistance: OpenAI Codex helped investigate, validate, and prepare this change.
